### PR TITLE
Extend `/docx` downloads to `/file` for arbitrary file types

### DIFF
--- a/backend/src/routes/documents.ts
+++ b/backend/src/routes/documents.ts
@@ -174,6 +174,45 @@ documentsRouter.get("/:documentId/display", requireAuth, async (req, res) => {
   }
 });
 
+// GET /single-documents/:documentId/file
+// Streams active-version source bytes for browser editors. Unlike /display,
+// this never substitutes a generated PDF rendition for an Office document.
+documentsRouter.get("/:documentId/file", requireAuth, async (req, res) => {
+  const userId = res.locals.userId as string;
+  const userEmail = res.locals.userEmail as string | undefined;
+  const { documentId } = req.params;
+  const versionIdParam =
+    typeof req.query.version_id === "string" ? req.query.version_id : null;
+  const db = createServerSupabase();
+
+  const { data: doc } = await db
+    .from("documents")
+    .select("id, user_id, project_id")
+    .eq("id", documentId)
+    .single();
+  if (!doc)
+    return void res.status(404).json({ detail: "Document not found" });
+  const access = await ensureDocAccess(doc, userId, userEmail, db);
+  if (!access.ok)
+    return void res.status(404).json({ detail: "Document not found" });
+
+  const active = await loadActiveVersion(documentId, db, versionIdParam);
+  if (!active)
+    return void res.status(404).json({ detail: "No file available" });
+  const raw = await downloadFile(active.storage_path);
+  if (!raw)
+    return void res.status(404).json({ detail: "Document bytes not available" });
+
+  const filename = downloadFilenameForVersion(
+    active.filename,
+    active.version_number,
+    active.source === "assistant_edit",
+  );
+  res.setHeader("Content-Type", contentTypeForDocumentType(active.file_type));
+  res.setHeader("Content-Disposition", buildContentDisposition("inline", filename));
+  res.send(Buffer.from(raw));
+});
+
 // POST /single-documents/download-zip
 documentsRouter.post("/download-zip", requireAuth, async (req, res) => {
   const userId = res.locals.userId as string;

--- a/backend/src/routes/documents.ts
+++ b/backend/src/routes/documents.ts
@@ -175,7 +175,9 @@ documentsRouter.get("/:documentId/display", requireAuth, async (req, res) => {
 });
 
 // GET /single-documents/:documentId/file
-// Streams active-version source bytes for browser editors. Unlike /display,
+// Downloads active-version or `?version_id` source bytes for browser editors. 
+// this bypasses R2 (avoids the browser CORS problem on signed URLs) so the frontend
+// docx-preview viewer can load tracked-change documents directly. Unlike /display,
 // this never substitutes a generated PDF rendition for an Office document.
 documentsRouter.get("/:documentId/file", requireAuth, async (req, res) => {
   const userId = res.locals.userId as string;
@@ -323,52 +325,15 @@ documentsRouter.get("/:documentId/url", requireAuth, async (req, res) => {
 });
 
 // GET /single-documents/:documentId/docx
-// Streams the raw .docx bytes for the given document, optionally at a
-// specific tracked-changes version. Unlike /url, this bypasses R2 (avoids
-// the browser CORS problem on signed URLs) so the frontend docx-preview
-// viewer can load tracked-change documents directly.
-documentsRouter.get("/:documentId/docx", requireAuth, async (req, res) => {
-  const userId = res.locals.userId as string;
-  const userEmail = res.locals.userEmail as string | undefined;
-  const { documentId } = req.params;
-  const versionIdParam = typeof req.query.version_id === "string" ? req.query.version_id : null;
-  const db = createServerSupabase();
-
-  const { data: doc, error } = await db
-    .from("documents")
-    .select("id, user_id, project_id")
-    .eq("id", documentId)
-    .single();
-  if (error || !doc)
-    return void res.status(404).json({ detail: "Document not found" });
-  const access = await ensureDocAccess(doc, userId, userEmail, db);
-  if (!access.ok)
-    return void res.status(404).json({ detail: "Document not found" });
-
-  const active = await loadActiveVersion(documentId, db, versionIdParam);
-  if (!active)
-    return void res.status(404).json({ detail: "No file available" });
-
-  const raw = await downloadFile(active.storage_path);
-  if (!raw)
-    return void res.status(404).json({ detail: "Document bytes not available" });
-
-  res.setHeader(
-    "Content-Type",
-    "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+// Permanent compatibility redirect for old docx-preview callers. /file owns
+// source-byte downloads and query parameters, including ?version_id=.
+documentsRouter.get("/:documentId/docx", (req, res) => {
+  const queryIndex = req.originalUrl.indexOf("?");
+  const query = queryIndex >= 0 ? req.originalUrl.slice(queryIndex) : "";
+  res.redirect(
+    301,
+    `${req.baseUrl}/${encodeURIComponent(req.params.documentId)}/file${query}`,
   );
-  res.setHeader(
-    "Content-Disposition",
-    buildContentDisposition(
-      "inline",
-      downloadFilenameForVersion(
-        active.filename,
-        active.version_number,
-        active.source === "assistant_edit",
-      ),
-    ),
-  );
-  res.send(Buffer.from(raw));
 });
 
 // Produce the filename a download should present to the user. Version

--- a/frontend/src/app/lib/mikeApi.ts
+++ b/frontend/src/app/lib/mikeApi.ts
@@ -840,6 +840,14 @@ export async function getDocumentUrl(
     return apiRequest(`/single-documents/${documentId}/url${qs}`);
 }
 
+export async function getDocumentFile(
+    documentId: string,
+    versionId?: string | null,
+): Promise<{ blob: Blob; filename: string | null }> {
+    const qs = versionId ? `?version_id=${encodeURIComponent(versionId)}` : "";
+    return apiBlobRequest(`/single-documents/${documentId}/file${qs}`);
+}
+
 export async function downloadDocumentsZip(
     documentIds: string[],
 ): Promise<Blob> {


### PR DESCRIPTION
## Summary

This extends the existing `/docx` endpoint to allow for download of arbitrary files, not just DOCX. It consolidates the old `/docx` endpoint with a new `/file` endpoint and redirects the former there.

It's just a suggestion to allow other folks to extend it as we have.

## Why / Motivation

Folks implementing in-browser editors and document viewers for the miscellaneous supported formats will want access to the raw file bytes as opposed to the results supplied by `/display`.

## Changes

As above.

## Tradeoffs & risks

The very minor trade-off is that folks who want to avoid the imperceptible redirect from `/docx` to `/file` will need to migrate. Then the `/docx` endpoint could be deprecated in favor of the more general `/file`.

## How verified

We ran the test suite, which was unaffected by the changes.

## Checklist

- [x] Ran the relevant build/test command for the area changed.
- [x] Reviewed `git diff` and removed unrelated changes.
- [x] Updated docs / env examples if setup, config, or behavior changed.
- [x] No secrets, API keys, real documents, or `.env` files committed.
