### PR TITLE
fix(frontend): bump dompurify to 3.4.13 to fix GHSA-55q2-fjhq-7xh7

### DIFF
--- a/frontend/bun.lock
+++ b/frontend/bun.lock
@@ -28,7 +28,7 @@
         "clsx": "^2.1.1",
         "docx": "^9.6.1",
         "docx-preview": "^0.3.7",
-        "dompurify": "^3.4.8",
+        "dompurify": "^3.4.13",
         "exceljs": "^4.4.0",
         "katex": "^0.16.27",
         "lucide-react": "^0.553.0",
@@ -1166,7 +1166,7 @@
 
     "docx-preview": ["docx-preview@0.3.7", "", { "dependencies": { "jszip": ">=3.0.0" } }, "sha512-Lav69CTA/IYZPJTsKH7oYeoZjyg96N0wEJMNslGJnZJ+dMUZK85Lt5ASC79yUlD48ecWjuv+rkcmFt6EVPV0Xg=="],
 
-    "dompurify": ["dompurify@3.4.8", "", { "optionalDependencies": { "@types/trusted-types": "^2.0.7" } }, "sha512-yb1cEmaOum7wFvOCSQxyfgVlv5D47Rc30iZWoMpbDIWTnJ6grDDQyu2KFJzB2k7u0pMuJcQ1zphH//fFnw2tjQ=="],
+    "dompurify": ["dompurify@3.4.13", "", { "optionalDependencies": { "@types/trusted-types": "^2.0.7" } }, "sha512-2vmYIoqjze2d+kakP8S/nS5shfsl587kzwEjcGlTdiksUVgFHnFCsLYDVj/JNqJVOQZGSYBTmuycv0PodwmnMQ=="],
 
     "dotenv": ["dotenv@16.6.1", "", {}, "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow=="],
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -32,7 +32,7 @@
                 "clsx": "^2.1.1",
                 "docx": "^9.6.1",
                 "docx-preview": "^0.3.7",
-                "dompurify": "^3.4.8",
+                "dompurify": "^3.4.13",
                 "exceljs": "^4.4.0",
                 "katex": "^0.16.27",
                 "lucide-react": "^0.553.0",
@@ -1722,13 +1722,13 @@
             }
         },
         "node_modules/@babel/parser": {
-            "version": "7.29.7",
-            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
-            "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
+            "version": "7.29.8",
+            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.8.tgz",
+            "integrity": "sha512-E8lTAYNB1KW+FH+VGJuZM1ioAx2E6oVlvQFRrf5P8ZZmsiJXYAD9vTFV7yyEURNzgh1dFqMZuO6tUwcARbqFCA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/types": "^7.29.7"
+                "@babel/types": "^7.29.8"
             },
             "bin": {
                 "parser": "bin/babel-parser.js"
@@ -1813,9 +1813,9 @@
             }
         },
         "node_modules/@babel/types": {
-            "version": "7.29.7",
-            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
-            "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
+            "version": "7.29.8",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.8.tgz",
+            "integrity": "sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg==",
             "devOptional": true,
             "license": "MIT",
             "dependencies": {
@@ -10322,9 +10322,9 @@
             "peer": true
         },
         "node_modules/dompurify": {
-            "version": "3.4.8",
-            "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.8.tgz",
-            "integrity": "sha512-yb1cEmaOum7wFvOCSQxyfgVlv5D47Rc30iZWoMpbDIWTnJ6grDDQyu2KFJzB2k7u0pMuJcQ1zphH//fFnw2tjQ==",
+            "version": "3.4.13",
+            "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.13.tgz",
+            "integrity": "sha512-2vmYIoqjze2d+kakP8S/nS5shfsl587kzwEjcGlTdiksUVgFHnFCsLYDVj/JNqJVOQZGSYBTmuycv0PodwmnMQ==",
             "license": "(MPL-2.0 OR Apache-2.0)",
             "optionalDependencies": {
                 "@types/trusted-types": "^2.0.7"
@@ -14185,14 +14185,14 @@
             }
         },
         "node_modules/magicast": {
-            "version": "0.5.3",
-            "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.3.tgz",
-            "integrity": "sha512-pVKE4UdSQ7DvHzivsCIFx2BJn1mHG6KsyrFcaxFx6tONdneEuThrDx0Cj3AMg58KyN4pzYT+LHOotxDQDjNvkw==",
+            "version": "0.5.4",
+            "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.4.tgz",
+            "integrity": "sha512-llBEhWm1SacoRwgHUoQJYtwp4PBLF4faQi5TCpIGyGs9n4y5+juI0tDgyKIfpqxckRHaHzouUEph3THklWh03w==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/parser": "^7.29.3",
-                "@babel/types": "^7.29.0",
+                "@babel/parser": "^7.29.7",
+                "@babel/types": "^7.29.7",
                 "source-map-js": "^1.2.1"
             }
         },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -38,7 +38,7 @@
         "clsx": "^2.1.1",
         "docx": "^9.6.1",
         "docx-preview": "^0.3.7",
-        "dompurify": "^3.4.8",
+        "dompurify": "^3.4.13",
         "exceljs": "^4.4.0",
         "katex": "^0.16.27",
         "lucide-react": "^0.553.0",


### PR DESCRIPTION
## Summary

Bumps `dompurify` from `^3.4.8` to `^3.4.13` in the frontend to pick up the fix for [GHSA-55q2-fjhq-7xh7](https://github.com/advisories/GHSA-55q2-fjhq-7xh7) (moderate severity): *IN_PLACE hook removal leaves a detached subtree executable, causing XSS*. All versions `<=3.4.12` are affected; the fix landed in `3.4.13`.

## Changes

- `frontend/package.json`: `dompurify` `^3.4.8` → `^3.4.13`
- `frontend/package-lock.json`: regenerated accordingly

No code changes required — this is a drop-in patch update.

## Verification

- `npm audit` no longer reports the dompurify advisory after the bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)