### PR TITLE
fix(docx): disable numeric coercion of Word text runs

### DIFF
--- a/backend/src/lib/__tests__/docxTrackedChanges.test.ts
+++ b/backend/src/lib/__tests__/docxTrackedChanges.test.ts
@@ -42,6 +42,30 @@ describe("extractDocxBodyText", () => {
         );
     });
 
+    it("preserves numeric-looking text through an unrelated edit", async () => {
+        const bytes = await makeDocx(
+            `<w:p>` +
+                `<w:r><w:t>12.10</w:t></w:r>` +
+                `<w:r><w:t> applies.</w:t></w:r>` +
+                `</w:p>`,
+        );
+        const result = await applyTrackedEdits(bytes, [
+            {
+                find: "applies",
+                replace: "governs",
+                context_before: " ",
+                context_after: ".",
+            },
+        ]);
+
+        expect(result.errors).toEqual([]);
+        expect(await readDocumentXml(result.bytes)).toContain("<w:t>12.10</w:t>");
+        await expect(extractDocxBodyText(result.bytes)).resolves.toBe(
+            "12.10 governs.",
+        );
+        await expect(extractDocxBodyText(bytes)).resolves.toBe("12.10 applies.");
+    });
+
     it("uses the accepted view: w:ins text included, w:del text excluded", async () => {
         const bytes = await makeDocx(
             `<w:p>` +

--- a/backend/src/lib/docxTrackedChanges.ts
+++ b/backend/src/lib/docxTrackedChanges.ts
@@ -650,6 +650,7 @@ function createParser() {
         attributeNamePrefix: "@_",
         preserveOrder: true,
         trimValues: false,
+        parseTagValue: false,
         parseAttributeValue: false,
         processEntities: true,
     });


### PR DESCRIPTION
## Summary

Prevent numeric-looking Word text runs from being altered when Mike parses or rewrites DOCX files.

## Why / Motivation

`fast-xml-parser` converts element text to JavaScript numbers and booleans by
default. Word stores visible document text in `w:t`, so a run containing
`12.10` becomes `12.1`.

This affects text returned by `read_document` and can rewrite an untouched run
when Mike saves an unrelated tracked edit.

## Changes

- Disable tag-value coercion in the shared DOCX parser.
- Add regression coverage for extracted text and the rewritten
  `word/document.xml`.

## Tradeoffs & risks

Element text in `word/document.xml` is now retained as strings, matching how
the DOCX helper consumes it. Attribute parsing, tracked-change IDs, entity
handling, and whitespace behavior are unchanged.

## How verified

- Confirmed the regression test fails on current `main`, where the rewritten
  `w:t` contains `12.1`.
- Confirmed the patched output retains `12.10` through an unrelated tracked
  edit.
- `npm test --prefix backend` — 551 passed, 23 skipped.
- `npm run build --prefix backend`.

## Checklist

- [x] Ran the relevant build and tests.
- [x] Reviewed the diff and removed unrelated changes.
- [x] Docs and environment examples are not applicable.
- [x] No secrets, API keys, real documents, or `.env` files committed.