### PR TITLE
feat(mcp): DingDuff connector support — OAuth redirect discovery and chat case retrieval

### DIFF
--- a/backend/src/lib/chat/streaming.ts
+++ b/backend/src/lib/chat/streaming.ts
@@ -45,6 +45,21 @@ import {
 } from "./tools/documentOps";
 import { verifyCitations } from "./verifyCitations";
 
+function isDingDuffMcpTool(tool: OpenAIToolSchema): boolean {
+  const haystack = [
+    tool.function.name,
+    tool.function.description,
+    JSON.stringify(tool.function.parameters),
+  ]
+    .join(" ")
+    .toLowerCase();
+  return (
+    haystack.includes("dingduff") ||
+    haystack.includes("ding-duff") ||
+    haystack.includes("ding duff")
+  );
+}
+
 export type AssistantEvent =
   | { type: "reasoning"; text: string }
   | AskInputsEvent
@@ -202,8 +217,10 @@ export async function runLLMStream(params: {
     projectId,
     nonce,
   } = params;
-  const researchTools = includeResearchTools ? COURTLISTENER_TOOLS : [];
   const mcpTools = await buildUserMcpTools(userId, db);
+  const hasDingDuffMcpTools = mcpTools.some(isDingDuffMcpTool);
+  const researchTools =
+    includeResearchTools && !hasDingDuffMcpTools ? COURTLISTENER_TOOLS : [];
   const conversationTools = includeAskInputs
     ? TOOLS
     : TOOLS.filter((tool) => tool.function.name !== "ask_inputs");
@@ -215,8 +232,14 @@ export async function runLLMStream(params: {
   // Extract system prompt; pass remaining turns to the adapter as
   // plain user/assistant messages.
   const rawMsgs = apiMessages as { role: string; content: string | null }[];
-  const systemPrompt =
+  let systemPrompt =
     rawMsgs[0]?.role === "system" ? (rawMsgs[0].content ?? "") : "";
+  if (hasDingDuffMcpTools) {
+    systemPrompt = `${systemPrompt}
+
+DINGDUFF MCP CASE RETRIEVAL:
+Use the available DingDuff MCP tool(s) for case retrieval, case reading, and case-specific document lookup. Do not use CourtListener for case retrieval in this turn; the built-in CourtListener tools are intentionally unavailable when DingDuff MCP tools are present.`;
+  }
   const chatMessages: LlmMessage[] = rawMsgs
     .filter((m) => m.role !== "system")
     .map((m) => ({

--- a/backend/src/lib/mcp/__tests__/client.ssrf.test.ts
+++ b/backend/src/lib/mcp/__tests__/client.ssrf.test.ts
@@ -142,4 +142,85 @@ describe("guardedFetch", () => {
         };
         expect(nextInit.dispatcher).toBe(init.dispatcher);
     });
+
+    it("follows redirects hop by hop, re-validating each target", async () => {
+        resolvesTo("93.184.216.34");
+        const fetchSpy = vi
+            .spyOn(globalThis, "fetch")
+            .mockResolvedValueOnce(
+                new Response(null, {
+                    status: 302,
+                    headers: { location: "/metadata/.well-known/oauth-protected-resource" },
+                }),
+            )
+            .mockResolvedValueOnce(new Response("{}", { status: 200 }));
+
+        const res = await guardedFetch(
+            "https://public.example.com/.well-known/oauth-protected-resource",
+        );
+        expect(res.status).toBe(200);
+        expect(fetchSpy).toHaveBeenCalledTimes(2);
+        expect(String(fetchSpy.mock.calls[1][0])).toBe(
+            "https://public.example.com/metadata/.well-known/oauth-protected-resource",
+        );
+    });
+
+    it("refuses to follow a redirect to a blocked address", async () => {
+        lookupMock
+            .mockResolvedValueOnce([{ address: "93.184.216.34", family: 4 }])
+            .mockResolvedValueOnce([{ address: "10.0.0.5", family: 4 }]);
+        const fetchSpy = vi
+            .spyOn(globalThis, "fetch")
+            .mockResolvedValueOnce(
+                new Response(null, {
+                    status: 302,
+                    headers: { location: "https://evil.example.com/" },
+                }),
+            );
+
+        await expect(
+            guardedFetch("https://public.example.com/"),
+        ).rejects.toThrow(/blocked network address/);
+        expect(fetchSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it("strips credentials when a redirect crosses origins", async () => {
+        resolvesTo("93.184.216.34");
+        const fetchSpy = vi
+            .spyOn(globalThis, "fetch")
+            .mockResolvedValueOnce(
+                new Response(null, {
+                    status: 302,
+                    headers: { location: "https://other.example.com/meta" },
+                }),
+            )
+            .mockResolvedValueOnce(new Response("{}", { status: 200 }));
+
+        await guardedFetch("https://public.example.com/", {
+            headers: { authorization: "Bearer secret" },
+        });
+        const secondInit = fetchSpy.mock.calls[1][1] as RequestInit;
+        expect(new Headers(secondInit.headers).get("authorization")).toBeNull();
+    });
+
+    it("converts a redirected POST to GET and drops the body", async () => {
+        resolvesTo("93.184.216.34");
+        const fetchSpy = vi
+            .spyOn(globalThis, "fetch")
+            .mockResolvedValueOnce(
+                new Response(null, {
+                    status: 303,
+                    headers: { location: "/done" },
+                }),
+            )
+            .mockResolvedValueOnce(new Response("{}", { status: 200 }));
+
+        await guardedFetch("https://public.example.com/register", {
+            method: "POST",
+            body: "{}",
+        });
+        const secondInit = fetchSpy.mock.calls[1][1] as RequestInit;
+        expect(secondInit.method).toBe("GET");
+        expect(secondInit.body).toBeUndefined();
+    });
 });

--- a/backend/src/lib/mcp/client.ts
+++ b/backend/src/lib/mcp/client.ts
@@ -228,7 +228,13 @@ export function toConnectorSummary(
 // Private/reserved IP classification lives in lib/privateIp.ts so every
 // guarded egress check reuses the exact same ranges.
 
-export async function validateRemoteMcpUrl(rawUrl: string): Promise<string> {
+type ValidatedTarget = {
+    url: string;
+    hostname: string;
+    addresses: { address: string; family: number }[];
+};
+
+async function resolveValidatedTarget(rawUrl: string): Promise<ValidatedTarget> {
     let url: URL;
     try {
         url = new URL(rawUrl);
@@ -260,14 +266,19 @@ export async function validateRemoteMcpUrl(rawUrl: string): Promise<string> {
             ? hostname.slice(1, -1)
             : hostname;
     const literalFamily = net.isIP(literalHost);
-    const addresses = literalFamily
-        ? [{ address: literalHost }]
+    const addresses: { address: string; family: number }[] = literalFamily
+        ? [{ address: literalHost, family: literalFamily }]
         : await dns.lookup(hostname, { all: true, verbatim: true });
     if (!addresses.length || addresses.some(({ address }) => isBlockedIp(address))) {
         throw new Error("MCP server URL resolves to a blocked network address.");
     }
 
-    return url.toString();
+    return { url: url.toString(), hostname, addresses };
+}
+
+export async function validateRemoteMcpUrl(rawUrl: string): Promise<string> {
+    const target = await resolveValidatedTarget(rawUrl);
+    return target.url;
 }
 
 export function headersForAuth(config: McpConnectorAuthConfig) {
@@ -329,64 +340,101 @@ export function authConfigPatch(config: McpConnectorAuthConfig): Record<string, 
     });
 }
 
-// A shared undici dispatcher whose DNS lookup runs the private-IP guard at the
-// moment a socket is opened and returns ONLY validated addresses. Because
-// undici connects to exactly what this lookup yields, the address we validate is
-// the address we connect to — there is no second, unguarded resolution for an
-// attacker to race (DNS-rebinding / TOCTOU). Reusing the dispatcher also lets
-// undici pool validated HTTPS connections instead of leaving a new Agent and
-// keep-alive socket behind for every MCP request.
-const guardedAgent = new Agent({
-    connect: {
-        lookup: (hostname, _options, callback) => {
-            dns.lookup(hostname, { all: true, verbatim: true })
-                .then((addresses) => {
-                    if (
-                        !addresses.length ||
-                        addresses.some(({ address }) => isBlockedIp(address))
-                    ) {
-                        callback(
-                            new Error(
-                                "MCP server URL resolves to a blocked network address.",
-                            ),
-                            [],
-                        );
-                        return;
-                    }
-                    callback(null, addresses);
-                })
-                .catch((err: unknown) =>
+// Cache one dispatcher per validated hostname+address set. Pinning the
+// pre-validated DNS answers closes the DNS-rebinding window between
+// validateRemoteMcpUrl and the actual connection (which would otherwise
+// re-resolve the hostname).
+const dispatcherCache = new Map<string, Agent>();
+
+function pinnedDispatcher(target: ValidatedTarget): Agent {
+    const key = `${target.hostname}|${target.addresses
+        .map((entry) => `${entry.address}:${entry.family}`)
+        .sort()
+        .join(",")}`;
+    const cached = dispatcherCache.get(key);
+    if (cached) return cached;
+    const agent = new Agent({
+        connect: {
+            lookup: (_hostname, options, callback) => {
+                if (options?.all) {
                     callback(
-                        err instanceof Error ? err : new Error(String(err)),
-                        [],
-                    ),
-                );
+                        null,
+                        target.addresses.map((entry) => ({
+                            address: entry.address,
+                            family: entry.family,
+                        })),
+                    );
+                } else {
+                    const first = target.addresses[0];
+                    callback(null, first.address, first.family);
+                }
+            },
         },
-    },
-});
+    });
+    dispatcherCache.set(key, agent);
+    return agent;
+}
 
 // The single guarded egress helper for every outbound MCP request (connector
 // transport, OAuth discovery/registration/refresh). It rejects non-HTTPS,
 // credentialed, metadata-host and private-IP-literal URLs up front, pins the
-// connection to a connect-time-validated address, and refuses to auto-follow
-// redirects (`redirect: "manual"`) so a 3xx to an internal host cannot smuggle
-// egress past the guard.
+// connection to the addresses that were just validated (so there is no second,
+// unguarded resolution for an attacker to race — DNS rebinding / TOCTOU), and
+// never lets undici auto-follow redirects (`redirect: "manual"`): each 3xx hop
+// is re-validated by this loop before it is followed. Caching the dispatcher
+// also lets undici pool validated HTTPS connections instead of leaving a new
+// Agent and keep-alive socket behind for every MCP request.
 export async function guardedFetch(
     input: Parameters<typeof fetch>[0],
     init?: Parameters<typeof fetch>[1],
 ) {
-    const url =
-        typeof input === "string"
-            ? input
-            : input instanceof URL
-              ? input.toString()
-              : input.url;
-    await validateRemoteMcpUrl(url);
-    return fetch(input, {
-        ...init,
-        redirect: "manual",
-        dispatcher: guardedAgent,
-    } as RequestInit);
+    let currentInput = input;
+    let currentInit = init;
+
+    for (let redirectCount = 0; ; redirectCount++) {
+        const url =
+            typeof currentInput === "string"
+                ? currentInput
+                : currentInput instanceof URL
+                  ? currentInput.toString()
+                  : currentInput.url;
+        const target = await resolveValidatedTarget(url);
+        const dispatcher = pinnedDispatcher(target);
+        const response = await fetch(currentInput, {
+            ...currentInit,
+            redirect: "manual",
+            dispatcher,
+        } as Parameters<typeof fetch>[1]);
+
+        const isRedirect = [301, 302, 303, 307, 308].includes(response.status);
+        if (!isRedirect || redirectCount >= 5) return response;
+
+        const location = response.headers.get("location");
+        if (!location) return response;
+        const nextUrl = new URL(location, url).toString();
+
+        // Mirror the fetch spec: credentials must not follow the request to
+        // a different origin, or a redirecting server could exfiltrate the
+        // caller's Authorization header to a host of its choosing.
+        if (new URL(nextUrl).origin !== new URL(url).origin && currentInit?.headers) {
+            const headers = new Headers(currentInit.headers as HeadersInit);
+            headers.delete("authorization");
+            headers.delete("proxy-authorization");
+            headers.delete("cookie");
+            currentInit = { ...currentInit, headers };
+        }
+
+        const method = currentInit?.method?.toUpperCase() ?? "GET";
+        if (
+            response.status === 303 ||
+            ((response.status === 301 || response.status === 302) &&
+                method === "POST")
+        ) {
+            const { body: _body, ...rest } = currentInit ?? {};
+            currentInit = { ...rest, method: "GET" };
+        }
+        currentInput = nextUrl;
+    }
 }
 
 export function base64Url(buffer: Buffer) {

--- a/backend/src/lib/mcp/oauth.ts
+++ b/backend/src/lib/mcp/oauth.ts
@@ -4,8 +4,10 @@ import {
     type OAuthClientProvider,
 } from "@modelcontextprotocol/sdk/client/auth.js";
 import type {
+    AuthorizationServerMetadata,
     OAuthClientInformationMixed,
     OAuthClientMetadata,
+    OAuthProtectedResourceMetadata,
     OAuthTokens,
 } from "@modelcontextprotocol/sdk/shared/auth.js";
 import { createServerSupabase } from "../supabase";
@@ -46,8 +48,9 @@ function parseWwwAuthenticate(value: string | null): string | null {
 
 async function fetchJson(url: string, init?: RequestInit) {
     // Route through the shared guarded egress helper so this call gets the same
-    // HTTPS-only / private-IP / connect-time-pinned / no-redirect protections as
-    // the connector transport (closes the raw-fetch SSRF gap in OAuth discovery).
+    // HTTPS-only / private-IP / pinned-address / revalidated-redirect protections
+    // as the connector transport (closes the raw-fetch SSRF gap in OAuth
+    // discovery).
     const response = await guardedFetch(url, init);
     if (!response.ok) {
         throw new Error(`Failed to fetch OAuth metadata (${response.status}).`);
@@ -167,6 +170,37 @@ export async function discoverOAuthMetadata(serverUrl: string): Promise<OAuthMet
                   (scope): scope is string => typeof scope === "string",
               )
             : undefined,
+    };
+}
+
+// Full discovery state for the MCP SDK's OAuthClientProvider.discoveryState
+// hook. The SDK's own discovery does not follow redirects, which breaks
+// servers (like DingDuff) that 302 their well-known metadata to a path-scoped
+// issuer; Mike's fetch follows redirects, so we hand the SDK the results.
+export async function discoverOAuthServerState(serverUrl: string): Promise<{
+    authorizationServerUrl: string;
+    authorizationServerMetadata: AuthorizationServerMetadata;
+    resourceMetadata: OAuthProtectedResourceMetadata;
+    resourceMetadataUrl: string;
+}> {
+    const metadataUrl = await discoverProtectedResourceMetadataUrl(serverUrl);
+    const resourceMetadata = await fetchJson(metadataUrl);
+    const authServers = resourceMetadata.authorization_servers;
+    const authorizationServer =
+        Array.isArray(authServers) && typeof authServers[0] === "string"
+            ? authServers[0]
+            : null;
+    if (!authorizationServer) {
+        throw new Error("MCP server did not advertise an OAuth authorization server.");
+    }
+    const authMetadata = await fetchAuthorizationServerMetadata(authorizationServer);
+    return {
+        authorizationServerUrl: authorizationServer,
+        authorizationServerMetadata:
+            authMetadata as unknown as AuthorizationServerMetadata,
+        resourceMetadata:
+            resourceMetadata as unknown as OAuthProtectedResourceMetadata,
+        resourceMetadataUrl: metadataUrl,
     };
 }
 
@@ -411,6 +445,27 @@ export class DbMcpOAuthProvider implements OAuthClientProvider {
 
     state() {
         return this.stateToken;
+    }
+
+    private discoveryStateCache?: {
+        authorizationServerUrl: string;
+        authorizationServerMetadata: AuthorizationServerMetadata;
+        resourceMetadata: OAuthProtectedResourceMetadata;
+        resourceMetadataUrl: string;
+    } | null;
+
+    async discoveryState() {
+        if (this.discoveryStateCache !== undefined) {
+            return this.discoveryStateCache ?? undefined;
+        }
+        try {
+            this.discoveryStateCache = await discoverOAuthServerState(
+                this.connector.server_url,
+            );
+        } catch {
+            this.discoveryStateCache = null;
+        }
+        return this.discoveryStateCache ?? undefined;
     }
 
     async clientInformation(): Promise<OAuthClientInformationMixed | undefined> {


### PR DESCRIPTION
## Summary

Adds support for DingDuff as a user MCP connector, so the assistant can use DingDuff tools for case retrieval, case reading, and case-specific document lookup directly from chat.

Two changes make this work:

**1. OAuth discovery behind redirects** (`backend/src/lib/mcp/client.ts`, `oauth.ts`)

DingDuff's server 302s its well-known OAuth metadata to a path-scoped issuer, and the MCP SDK's own discovery does not follow redirects, so the OAuth flow could not complete.

- `guardedFetch` now follows redirects hop by hop instead of refusing them outright: every 3xx target is re-validated against the existing SSRF guard (HTTPS-only, private-IP/metadata-host blocks, DNS-pinned dispatcher), credentials are stripped on cross-origin hops (per the fetch spec), and redirected POSTs are converted to GET with the body dropped. Undici still never auto-follows (`redirect: "manual"` on every hop), so no redirect can smuggle egress past the guard.
- New `discoverOAuthServerState` plus the SDK's `OAuthClientProvider.discoveryState` hook hand the SDK pre-discovered metadata, so connectors whose well-known documents live behind a redirect complete the flow.

**2. Chat integration** (`backend/src/lib/chat/streaming.ts`)

When DingDuff MCP tools are present on a turn, the built-in CourtListener tools are withheld and the system prompt directs case retrieval at the DingDuff tools, so the two case-law sources are never mixed within a single turn.

## Tests

- New cases in `client.ssrf.test.ts`: redirect following with per-hop re-validation, refusal to follow a redirect to a blocked address, credential stripping on cross-origin redirects, and POST→GET conversion.
- Full backend suite passes (**711 passed, 24 skipped**); `tsc --noEmit` clean.

## Rebased onto current main

Re-verified that all three pieces are still needed — none has landed upstream in the meantime: `guardedFetch` still sets `redirect: "manual"` with no hop-following, `oauth.ts` has no `discoveryState`/`discoverOAuthServerState`, and `streaming.ts` has no DingDuff handling.

One conflict needed resolving beyond the textual merge. `main` has since introduced `includeAskInputs`/`conversationTools`, which declares its own `baseTools`; this branch declared a second one. The DingDuff contribution here is really the `researchTools` gate, and main's line already consumes that, so the duplicate declaration is dropped and the gate feeds main's `conversationTools` list.

## Notes

- No schema changes; no new dependencies.
- The legal-monitors DingDuff connector source is intentionally **not** part of this PR (that feature set isn't upstream).
