### PR TITLE
feat: user-defined LLM committees

### DIFF
--- a/backend/migrations/20260823_02_user_model_committees.sql
+++ b/backend/migrations/20260823_02_user_model_committees.sql
@@ -1,0 +1,5 @@
+-- Migration date: 2026-08-23
+-- Per-user model committees, managed from Settings > Models.
+
+alter table public.user_profiles
+  add column if not exists model_committees jsonb not null default '[]'::jsonb;

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -28,6 +28,7 @@
         "fast-xml-parser": "^5.7.1",
         "helmet": "^8.1.0",
         "html-to-text": "9.0.5",
+        "jsonrepair": "^3.15.0",
         "jszip": "^3.10.1",
         "libreoffice-convert": "^1.6.0",
         "mammoth": "^1.9.0",
@@ -6640,6 +6641,15 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/jsonrepair": {
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/jsonrepair/-/jsonrepair-3.15.0.tgz",
+      "integrity": "sha512-wy8OTjwsJwQRnQJkKnMJJ9vcytRdBPAgIF/Hy6+s1dAj42BHMKiyL8JzEieIl3JY7idt8eyHwBWTO8mh/+mtwA==",
+      "license": "ISC",
+      "bin": {
+        "jsonrepair": "bin/cli.js"
       }
     },
     "node_modules/jszip": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -32,6 +32,7 @@
     "fast-xml-parser": "^5.7.1",
     "helmet": "^8.1.0",
     "html-to-text": "9.0.5",
+    "jsonrepair": "^3.15.0",
     "jszip": "^3.10.1",
     "libreoffice-convert": "^1.6.0",
     "mammoth": "^1.9.0",

--- a/backend/schema.sql
+++ b/backend/schema.sql
@@ -46,6 +46,7 @@ create table if not exists public.user_profiles (
   title_model text,
   tabular_model text not null default 'gemini-3-flash-preview',
   quote_model text,
+  model_committees jsonb not null default '[]'::jsonb,
   mfa_on_login boolean not null default false,
   legal_research_us boolean not null default true,
   quick_actions_visible boolean not null default true,

--- a/backend/src/lib/__tests__/committee.test.ts
+++ b/backend/src/lib/__tests__/committee.test.ts
@@ -1,0 +1,207 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { completeWithProvider, streamWithProvider } = vi.hoisted(() => ({
+    completeWithProvider: vi.fn(),
+    streamWithProvider: vi.fn(),
+}));
+
+vi.mock("../llm/providers", () => ({
+    completeWithProvider: (...args: unknown[]) => completeWithProvider(...args),
+    streamWithProvider: (...args: unknown[]) => streamWithProvider(...args),
+}));
+
+import { completeText, streamChatWithTools } from "../llm";
+import type { CommitteeModel } from "../llm/types";
+
+const COMMITTEE: CommitteeModel = {
+    id: "user-committee/panel",
+    label: "Panel",
+    members: ["claude-opus-5", "gemini-3.5-flash"],
+    chair: "gpt-5.5",
+    strategy: "synthesize",
+};
+
+const committees = [COMMITTEE];
+
+beforeEach(() => {
+    vi.clearAllMocks();
+    completeWithProvider.mockImplementation(
+        async ({ model }: { model: string }) => `answer from ${model}`,
+    );
+});
+
+describe("committee completion", () => {
+    it("asks every member, then hands their answers to the chair", async () => {
+        const text = await completeText({
+            model: COMMITTEE.id,
+            systemPrompt: "Be precise.",
+            user: "Is this mark registrable?",
+            committeeModels: committees,
+        });
+
+        const models = completeWithProvider.mock.calls.map(
+            ([params]) => params.model,
+        );
+        expect(models).toEqual([
+            "claude-opus-5",
+            "gemini-3.5-flash",
+            "gpt-5.5",
+        ]);
+        expect(text).toBe("answer from gpt-5.5");
+
+        const chairCall = completeWithProvider.mock.calls.at(-1)![0];
+        expect(chairCall.user).toContain("answer from claude-opus-5");
+        expect(chairCall.user).toContain("answer from gemini-3.5-flash");
+        expect(chairCall.user).toContain("Is this mark registrable?");
+        expect(chairCall.systemPrompt).toContain("Be precise.");
+    });
+
+    it("runs the members concurrently rather than one after another", async () => {
+        let running = 0;
+        let peak = 0;
+        completeWithProvider.mockImplementation(async () => {
+            running += 1;
+            peak = Math.max(peak, running);
+            await new Promise((resolve) => setTimeout(resolve, 5));
+            running -= 1;
+            return "ok";
+        });
+
+        await completeText({
+            model: COMMITTEE.id,
+            user: "question",
+            committeeModels: committees,
+        });
+
+        expect(peak).toBe(COMMITTEE.members.length);
+    });
+
+    it("passes each member its own extra system prompt", async () => {
+        await completeText({
+            model: "user-committee/mixed",
+            systemPrompt: "Base.",
+            user: "question",
+            committeeModels: [
+                {
+                    id: "user-committee/mixed",
+                    label: "Mixed",
+                    members: [
+                        { model: "claude-opus-5", systemPrompt: "Be sceptical." },
+                        "gemini-3.5-flash",
+                    ],
+                    chair: "gpt-5.5",
+                },
+            ],
+        });
+
+        const first = completeWithProvider.mock.calls[0][0];
+        expect(first.systemPrompt).toBe("Base.\n\nBe sceptical.");
+        const second = completeWithProvider.mock.calls[1][0];
+        expect(second.systemPrompt).toBe("Base.");
+    });
+
+    it("refuses a committee that chairs itself", async () => {
+        await expect(
+            completeText({
+                model: "user-committee/self",
+                user: "question",
+                committeeModels: [
+                    {
+                        id: "user-committee/self",
+                        members: ["claude-opus-5", "gpt-5.5"],
+                        chair: "user-committee/self",
+                    },
+                ],
+            }),
+        ).rejects.toThrow(/cannot use itself as the chair/);
+    });
+
+    it("refuses a committee that lists itself as a member", async () => {
+        await expect(
+            completeText({
+                model: "user-committee/self-member",
+                user: "question",
+                committeeModels: [
+                    {
+                        id: "user-committee/self-member",
+                        members: ["user-committee/self-member", "gpt-5.5"],
+                        chair: "claude-opus-5",
+                    },
+                ],
+            }),
+        ).rejects.toThrow(/cannot include itself as member/);
+    });
+
+    it("breaks a cycle between two committees", async () => {
+        const cyclic: CommitteeModel[] = [
+            {
+                id: "user-committee/a",
+                members: ["user-committee/b", "gpt-5.5"],
+                chair: "claude-opus-5",
+            },
+            {
+                id: "user-committee/b",
+                members: ["user-committee/a", "gpt-5.5"],
+                chair: "claude-opus-5",
+            },
+        ];
+        await expect(
+            completeText({
+                model: "user-committee/a",
+                user: "question",
+                committeeModels: cyclic,
+            }),
+        ).rejects.toThrow(/Circular committee reference/);
+    });
+
+    it("leaves an ordinary model on the normal provider path", async () => {
+        await completeText({ model: "claude-opus-5", user: "question" });
+        expect(completeWithProvider).toHaveBeenCalledTimes(1);
+        expect(completeWithProvider.mock.calls[0][0].model).toBe(
+            "claude-opus-5",
+        );
+    });
+});
+
+describe("committee streaming", () => {
+    it("answers without tools and emits the synthesis as one delta", async () => {
+        const onContentDelta = vi.fn();
+        const result = await streamChatWithTools({
+            model: COMMITTEE.id,
+            systemPrompt: "Be precise.",
+            messages: [{ role: "user", content: "Is this mark registrable?" }],
+            tools: [
+                {
+                    type: "function",
+                    function: {
+                        name: "read_document",
+                        description: "",
+                        parameters: {},
+                    },
+                },
+            ],
+            committeeModels: committees,
+            callbacks: { onContentDelta },
+        });
+
+        expect(result.fullText).toBe("answer from gpt-5.5");
+        expect(onContentDelta).toHaveBeenCalledWith("answer from gpt-5.5");
+        expect(streamWithProvider).not.toHaveBeenCalled();
+        // The members must be told the tools are unavailable rather than
+        // inventing tool work they cannot do.
+        expect(completeWithProvider.mock.calls[0][0].systemPrompt).toContain(
+            "tools are not available in committee mode",
+        );
+    });
+
+    it("leaves an ordinary model on the normal streaming path", async () => {
+        streamWithProvider.mockResolvedValue({ fullText: "streamed" });
+        const result = await streamChatWithTools({
+            model: "claude-opus-5",
+            systemPrompt: "",
+            messages: [{ role: "user", content: "hi" }],
+        });
+        expect(result.fullText).toBe("streamed");
+        expect(streamWithProvider).toHaveBeenCalledTimes(1);
+    });
+});

--- a/backend/src/lib/__tests__/localModelMiddleware.test.ts
+++ b/backend/src/lib/__tests__/localModelMiddleware.test.ts
@@ -1,0 +1,244 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { localModelToleranceMiddleware } from "../llm/localModelMiddleware";
+
+const TOOL = "mcp_search_trademarks";
+const STOP = { unified: "stop", raw: "stop" } as const;
+const USAGE = { inputTokens: 1, outputTokens: 1, totalTokens: 2 };
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+type AnyPart = any;
+
+function streamOf(parts: AnyPart[]) {
+    return new ReadableStream<AnyPart>({
+        start(controller) {
+            for (const part of parts) controller.enqueue(part);
+            controller.close();
+        },
+    });
+}
+
+async function collect(stream: ReadableStream<AnyPart>): Promise<AnyPart[]> {
+    const parts: AnyPart[] = [];
+    for await (const part of stream as any) parts.push(part);
+    return parts;
+}
+
+function textParts(parts: AnyPart[]): string {
+    return parts
+        .filter((part) => part.type === "text-delta")
+        .map((part) => part.delta)
+        .join("");
+}
+
+function reasoningParts(parts: AnyPart[]): string {
+    return parts
+        .filter((part) => part.type === "reasoning-delta")
+        .map((part) => part.delta)
+        .join("");
+}
+
+async function runStream(deltas: string[], params: AnyPart = {}) {
+    const middleware = localModelToleranceMiddleware();
+    const doStream = vi.fn().mockResolvedValue({
+        stream: streamOf([
+            { type: "stream-start", warnings: [] },
+            { type: "text-start", id: "t1" },
+            ...deltas.map((delta) => ({
+                type: "text-delta",
+                id: "t1",
+                delta,
+            })),
+            { type: "text-end", id: "t1" },
+            { type: "finish", usage: USAGE, finishReason: STOP },
+        ]),
+    });
+    const doGenerate = vi.fn();
+    const result = await middleware.wrapStream!({
+        doStream,
+        doGenerate,
+        params,
+        model: {} as AnyPart,
+    } as AnyPart);
+    return { parts: await collect(result.stream), doStream, doGenerate };
+}
+
+describe("localModelToleranceMiddleware — streaming", () => {
+    it("passes an ordinary answer through untouched", async () => {
+        const { parts } = await runStream(["All ", "clear."]);
+        expect(textParts(parts)).toBe("All clear.");
+        expect(parts.some((part) => part.type === "tool-call")).toBe(false);
+        expect(parts.at(-1)).toMatchObject({ finishReason: STOP });
+    });
+
+    it("routes think blocks to reasoning instead of visible text", async () => {
+        const { parts } = await runStream([
+            "<think>weighing",
+            " it</think>The answer.",
+        ]);
+        expect(reasoningParts(parts)).toBe("weighing it");
+        expect(textParts(parts)).toBe("The answer.");
+        expect(parts.some((part) => part.type === "reasoning-end")).toBe(true);
+    });
+
+    it("recovers a tool call from prose and hides the markup", async () => {
+        const { parts } = await runStream([
+            "Calling tool.\n<tool_call>",
+            `{"name":"${TOOL}","arguments":{"query":"MIKE"}}`,
+            "</tool_call>",
+        ]);
+        expect(textParts(parts)).toBe("Calling tool.\n");
+        expect(
+            parts.filter((part) => part.type === "tool-call"),
+        ).toEqual([
+            {
+                type: "tool-call",
+                toolCallId: "call_text_0_0_0",
+                toolName: TOOL,
+                input: JSON.stringify({ query: "MIKE" }),
+            },
+        ]);
+        expect(parts.at(-1)).toMatchObject({
+            finishReason: { unified: "tool-calls", raw: "stop" },
+        });
+    });
+
+    it("leaves a provider's own structured tool call alone", async () => {
+        const middleware = localModelToleranceMiddleware();
+        const doStream = vi.fn().mockResolvedValue({
+            stream: streamOf([
+                { type: "stream-start", warnings: [] },
+                {
+                    type: "tool-call",
+                    toolCallId: "real-1",
+                    toolName: TOOL,
+                    input: "{}",
+                },
+                {
+                    type: "finish",
+                    usage: USAGE,
+                    finishReason: { unified: "tool-calls", raw: "tool_calls" },
+                },
+            ]),
+        });
+        const result = await middleware.wrapStream!({
+            doStream,
+            doGenerate: vi.fn(),
+            params: {},
+            model: {} as AnyPart,
+        } as AnyPart);
+        const parts = await collect(result.stream);
+        expect(parts.filter((part) => part.type === "tool-call")).toHaveLength(
+            1,
+        );
+        expect(parts.at(-1)).toMatchObject({
+            finishReason: { unified: "tool-calls" },
+        });
+    });
+
+    it("surfaces an unrecoverable tool call as a stream error", async () => {
+        const { parts } = await runStream([
+            "<tool_call>{not a tool at all}</tool_call>",
+        ]);
+        const error = parts.find((part) => part.type === "error");
+        expect(error).toBeDefined();
+        expect(String(error.error)).toMatch(
+            /did not identify an executable tool|could not recover/,
+        );
+    });
+
+    it("answers a tool-declaring turn through the non-streaming endpoint", async () => {
+        const middleware = localModelToleranceMiddleware();
+        const doStream = vi.fn();
+        const doGenerate = vi.fn().mockResolvedValue({
+            content: [
+                {
+                    type: "text",
+                    text: `<tool_call>{"name":"${TOOL}","arguments":{"query":"MIKE"}}</tool_call>`,
+                },
+            ],
+            finishReason: STOP,
+            usage: USAGE,
+            warnings: [],
+        });
+        const result = await middleware.wrapStream!({
+            doStream,
+            doGenerate,
+            params: { tools: [{ type: "function", name: TOOL }] },
+            model: {} as AnyPart,
+        } as AnyPart);
+        const parts = await collect(result.stream);
+
+        expect(doGenerate).toHaveBeenCalledTimes(1);
+        expect(doStream).not.toHaveBeenCalled();
+        expect(parts.filter((part) => part.type === "tool-call")).toEqual([
+            {
+                type: "tool-call",
+                toolCallId: "call_text_0_0_0",
+                toolName: TOOL,
+                input: JSON.stringify({ query: "MIKE" }),
+            },
+        ]);
+    });
+});
+
+describe("localModelToleranceMiddleware — generate", () => {
+    it("recovers a tool call and strips the markup from the text", async () => {
+        const middleware = localModelToleranceMiddleware();
+        const doGenerate = vi.fn().mockResolvedValue({
+            content: [
+                {
+                    type: "text",
+                    text: `Calling tool.\n<tool_call>{"name":"${TOOL}","arguments":{"query":"MIKE"}}</tool_call>`,
+                },
+            ],
+            finishReason: STOP,
+            usage: USAGE,
+            warnings: [],
+        });
+        const result = await middleware.wrapGenerate!({
+            doGenerate,
+            doStream: vi.fn(),
+            params: {},
+            model: {} as AnyPart,
+        } as AnyPart);
+
+        expect(result.content).toEqual([
+            { type: "text", text: "Calling tool.\n" },
+            {
+                type: "tool-call",
+                toolCallId: "call_text_0_0_0",
+                toolName: TOOL,
+                input: JSON.stringify({ query: "MIKE" }),
+            },
+        ]);
+        expect(result.finishReason).toEqual({
+            unified: "tool-calls",
+            raw: "stop",
+        });
+    });
+
+    it("moves think prose into a reasoning part", async () => {
+        const middleware = localModelToleranceMiddleware();
+        const doGenerate = vi.fn().mockResolvedValue({
+            content: [
+                { type: "text", text: "<think>hmm</think>Done." },
+            ],
+            finishReason: STOP,
+            usage: USAGE,
+            warnings: [],
+        });
+        const result = await middleware.wrapGenerate!({
+            doGenerate,
+            doStream: vi.fn(),
+            params: {},
+            model: {} as AnyPart,
+        } as AnyPart);
+
+        expect(result.content).toEqual([
+            { type: "reasoning", text: "hmm" },
+            { type: "text", text: "Done." },
+        ]);
+        expect(result.finishReason).toEqual(STOP);
+    });
+});

--- a/backend/src/lib/__tests__/registry.test.ts
+++ b/backend/src/lib/__tests__/registry.test.ts
@@ -1,0 +1,174 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import {
+    apiKeyForConfiguredModel,
+    configuredModelIds,
+    configuredModelSummaries,
+    getConfiguredModel,
+    loadModelRegistry,
+    resetModelRegistryCache,
+    tolerateTextToolCalls,
+} from "../llm/registry";
+import { providerForModel, resolveModel } from "../llm/models";
+
+const LOCAL_QWEN = {
+    id: "local-qwen",
+    label: "Local Qwen",
+    provider: "openai-compatible",
+    location: "local",
+    apiModel: "qwen3-32b",
+    baseUrl: "http://localhost:8000/v1",
+};
+
+const CLOUD_DEEPSEEK = {
+    id: "cloud-deepseek",
+    provider: "openai-compatible",
+    location: "cloud",
+    baseUrl: "https://api.example.test/v1",
+    apiKeyEnv: "DEEPSEEK_API_KEY",
+};
+
+function configure(value: unknown) {
+    process.env.MIKE_MODEL_CONFIG_JSON = JSON.stringify(value);
+    resetModelRegistryCache();
+}
+
+const originalConfig = process.env.MIKE_MODEL_CONFIG_JSON;
+const originalKey = process.env.DEEPSEEK_API_KEY;
+
+beforeEach(() => {
+    configure({ models: [LOCAL_QWEN, CLOUD_DEEPSEEK] });
+});
+
+afterEach(() => {
+    if (originalConfig === undefined) delete process.env.MIKE_MODEL_CONFIG_JSON;
+    else process.env.MIKE_MODEL_CONFIG_JSON = originalConfig;
+    if (originalKey === undefined) delete process.env.DEEPSEEK_API_KEY;
+    else process.env.DEEPSEEK_API_KEY = originalKey;
+    resetModelRegistryCache();
+});
+
+describe("loadModelRegistry", () => {
+    it("returns an empty registry when nothing is configured", () => {
+        delete process.env.MIKE_MODEL_CONFIG_JSON;
+        resetModelRegistryCache();
+        expect(loadModelRegistry()).toEqual({ models: [], committees: [] });
+    });
+
+    it("rejects invalid JSON with an actionable message", () => {
+        process.env.MIKE_MODEL_CONFIG_JSON = "{not json";
+        resetModelRegistryCache();
+        expect(() => loadModelRegistry()).toThrow(
+            /MIKE_MODEL_CONFIG_JSON is not valid JSON/,
+        );
+    });
+
+    it("drops entries that are not declarable models", () => {
+        configure({
+            models: [
+                LOCAL_QWEN,
+                { id: "no-provider", location: "cloud" },
+                { id: "hosted", provider: "claude", location: "cloud" },
+                { provider: "openai-compatible", location: "cloud" },
+            ],
+        });
+        expect(configuredModelIds()).toEqual(["local-qwen"]);
+    });
+});
+
+describe("getConfiguredModel", () => {
+    it("finds a declared model", () => {
+        expect(getConfiguredModel("local-qwen")).toMatchObject({
+            id: "local-qwen",
+            apiModel: "qwen3-32b",
+        });
+    });
+
+    it("returns null for anything undeclared", () => {
+        expect(getConfiguredModel("claude-opus-5")).toBeNull();
+    });
+});
+
+describe("configuredModelSummaries", () => {
+    it("labels each entry, falling back to the id", () => {
+        expect(configuredModelSummaries()).toEqual([
+            {
+                id: "local-qwen",
+                label: "Local Qwen",
+                provider: "openai-compatible",
+                location: "local",
+            },
+            {
+                id: "cloud-deepseek",
+                label: "cloud-deepseek",
+                provider: "openai-compatible",
+                location: "cloud",
+            },
+        ]);
+    });
+});
+
+describe("apiKeyForConfiguredModel", () => {
+    it("prefers an inline key", () => {
+        expect(
+            apiKeyForConfiguredModel({ ...CLOUD_DEEPSEEK, apiKey: "inline" }),
+        ).toBe("inline");
+    });
+
+    it("falls back to the named environment variable", () => {
+        process.env.DEEPSEEK_API_KEY = "from-env";
+        expect(apiKeyForConfiguredModel(CLOUD_DEEPSEEK)).toBe("from-env");
+    });
+
+    it("reads the user's key when the model names a provider slot", () => {
+        expect(
+            apiKeyForConfiguredModel(
+                { ...CLOUD_DEEPSEEK, apiKeyProvider: "openai" },
+                { openai: "user-key" },
+            ),
+        ).toBe("user-key");
+    });
+
+    it("returns null when no key is available", () => {
+        delete process.env.DEEPSEEK_API_KEY;
+        expect(apiKeyForConfiguredModel(CLOUD_DEEPSEEK)).toBeNull();
+    });
+});
+
+describe("tolerateTextToolCalls", () => {
+    it("defaults to on for local endpoints and off for cloud ones", () => {
+        expect(tolerateTextToolCalls(LOCAL_QWEN)).toBe(true);
+        expect(tolerateTextToolCalls(CLOUD_DEEPSEEK)).toBe(false);
+    });
+
+    it("honours an explicit override", () => {
+        expect(
+            tolerateTextToolCalls({
+                ...LOCAL_QWEN,
+                tolerateTextToolCalls: false,
+            }),
+        ).toBe(false);
+    });
+});
+
+describe("model resolution", () => {
+    it("routes a configured id to its provider", () => {
+        expect(providerForModel("local-qwen")).toBe("openai-compatible");
+    });
+
+    it("keeps the static catalog working", () => {
+        expect(providerForModel("claude-opus-5")).toBe("claude");
+    });
+
+    it("accepts a configured id as a saved preference", () => {
+        expect(resolveModel("local-qwen", "gemini-3-flash-preview")).toBe(
+            "local-qwen",
+        );
+    });
+
+    it("falls back when the id is unknown", () => {
+        expect(resolveModel("retired-model", "gemini-3-flash-preview")).toBe(
+            "gemini-3-flash-preview",
+        );
+    });
+});

--- a/backend/src/lib/__tests__/toolCallParsing.test.ts
+++ b/backend/src/lib/__tests__/toolCallParsing.test.ts
@@ -1,0 +1,190 @@
+import { describe, expect, it } from "vitest";
+
+import {
+    collapseTrademarkOwnerCalls,
+    parseTextToolCalls,
+    TextToolMarkupFilter,
+    ThinkTagFilter,
+} from "../llm/toolCallParsing";
+
+const TOOL = "mcp_search_trademarks";
+
+describe("parseTextToolCalls", () => {
+    it("returns nothing when the model simply answered", () => {
+        expect(parseTextToolCalls("Here is the answer.", 0)).toEqual([]);
+    });
+
+    it("reads a well-formed JSON tool_call block", () => {
+        const text = `Calling tool.\n<tool_call>{"name":"${TOOL}","arguments":{"query":"MIKE"}}</tool_call>`;
+        expect(parseTextToolCalls(text, 0)).toEqual([
+            { id: "call_text_0_0_0", name: TOOL, input: { query: "MIKE" } },
+        ]);
+    });
+
+    it("repairs Python-style quoting, trailing commas and a missing close tag", () => {
+        const text = `Calling tool.\n<tool_call>{'name':'${TOOL}','arguments':{'query':'JACK HENRY',},`;
+        expect(parseTextToolCalls(text, 0)).toEqual([
+            {
+                id: "call_text_0_0_0",
+                name: TOOL,
+                input: { query: "JACK HENRY" },
+            },
+        ]);
+    });
+
+    it("normalizes OpenArc's doubled-delimiter map-style call", () => {
+        const text = `Calling tool.\n<tool_call>{""${TOOL}"::{"owner_name":"Jack Henry","limit":100}}</tool_call>`;
+        expect(parseTextToolCalls(text, 0)).toEqual([
+            {
+                id: "call_text_0_0_0",
+                name: TOOL,
+                input: { owner_name: "Jack Henry", limit: 100 },
+            },
+        ]);
+    });
+
+    it("reads an XML-style function block and types its scalars", () => {
+        const text = [
+            "Calling tool.",
+            "<tool_call>",
+            `<function=${TOOL}>`,
+            "<limit>100</limit>",
+            "<owner_name>Jack Henry & Associates</owner_name>",
+            "<status_filter>live</status_filter>",
+            "</function>",
+            "</tool_call>",
+        ].join("\n");
+        expect(parseTextToolCalls(text, 0)).toEqual([
+            {
+                id: "call_text_0_0_xml",
+                name: TOOL,
+                input: {
+                    limit: 100,
+                    owner_name: "Jack Henry & Associates",
+                    status_filter: "live",
+                },
+            },
+        ]);
+    });
+
+    it("reads DeepSeek DSML invocations", () => {
+        const text = [
+            "<｜DSML｜tool_calls>",
+            `<｜DSML｜invoke name="${TOOL}">`,
+            '<｜DSML｜parameter name="owner_name" string="true">GARITY ASSOCIATES BROKERAGE INSURANCE AGENCY, LLC</｜DSML｜parameter>',
+            "</｜DSML｜invoke>",
+            `<｜DSML｜invoke name="${TOOL}">`,
+            '<｜DSML｜parameter name="owner_name" string="true">GENERAL AGENT INSURANCE NETWORK, LLC</｜DSML｜parameter>',
+            "</｜DSML｜invoke>",
+            "</｜DSML｜tool_calls>",
+        ].join("\n");
+        expect(parseTextToolCalls(text, 0)).toEqual([
+            {
+                id: "call_text_0_dsml_0",
+                name: TOOL,
+                input: {
+                    owner_name:
+                        "GARITY ASSOCIATES BROKERAGE INSURANCE AGENCY, LLC",
+                },
+            },
+            {
+                id: "call_text_0_dsml_1",
+                name: TOOL,
+                input: { owner_name: "GENERAL AGENT INSURANCE NETWORK, LLC" },
+            },
+        ]);
+    });
+
+    it("deduplicates identical repeated calls", () => {
+        const call = `<tool_call>{"name":"${TOOL}","arguments":{"query":"MIKE"}}</tool_call>`;
+        expect(parseTextToolCalls(`${call}\n${call}`, 0)).toHaveLength(1);
+    });
+
+    it("raises a recoverable-failure message when the markup names no tool", () => {
+        expect(() =>
+            parseTextToolCalls("<tool_call>{not a tool at all}</tool_call>", 0),
+        ).toThrow(/did not identify an executable tool|could not recover/);
+    });
+});
+
+// Only the MCP trademark search batches; the collapse keys off that name.
+const TM_TOOL = "mcp_uspto_patent_trade_tm_search_trademarks_f77b105c";
+
+describe("collapseTrademarkOwnerCalls", () => {
+    it("batches repeated owner searches into a single owner_names call", () => {
+        const calls = [
+            {
+                id: "call_text_0_dsml_0",
+                name: TM_TOOL,
+                input: { owner_name: "GARITY ASSOCIATES" },
+            },
+            {
+                id: "call_text_0_dsml_1",
+                name: TM_TOOL,
+                input: { owner_name: "GENERAL AGENT INSURANCE NETWORK, LLC" },
+            },
+        ];
+        expect(collapseTrademarkOwnerCalls(calls)).toEqual([
+            {
+                id: "call_text_0_dsml_0",
+                name: TM_TOOL,
+                input: {
+                    owner_names: [
+                        "GARITY ASSOCIATES",
+                        "GENERAL AGENT INSURANCE NETWORK, LLC",
+                    ],
+                },
+            },
+        ]);
+    });
+
+    it("leaves a lone owner search alone", () => {
+        const calls = [
+            { id: "a", name: TM_TOOL, input: { owner_name: "ONLY ONE" } },
+        ];
+        expect(collapseTrademarkOwnerCalls(calls)).toEqual(calls);
+    });
+});
+
+describe("ThinkTagFilter", () => {
+    it("routes think blocks to reasoning and keeps the rest visible", () => {
+        const filter = new ThinkTagFilter();
+        const fed = filter.feed("<think>weighing it</think>The answer.");
+        expect(fed.reasoning.join("")).toBe("weighing it");
+        expect(fed.content.join("")).toBe("The answer.");
+        expect(filter.sawReasoning).toBe(true);
+    });
+
+    it("holds a tag split across chunks instead of leaking it", () => {
+        const filter = new ThinkTagFilter();
+        const first = filter.feed("visible <thi");
+        expect(first.content.join("")).toBe("visible ");
+        const second = filter.feed("nk>hidden</think> tail");
+        expect(second.reasoning.join("")).toBe("hidden");
+        expect(second.content.join("")).toBe(" tail");
+    });
+});
+
+describe("TextToolMarkupFilter", () => {
+    it("suppresses everything from the tool marker onward", () => {
+        const filter = new TextToolMarkupFilter();
+        expect(filter.feed(`Calling tool.\n<tool_call>{"name":"x"}`)).toBe(
+            "Calling tool.\n",
+        );
+        expect(filter.feed("more markup")).toBe("");
+        expect(filter.flush()).toBe("");
+    });
+
+    it("suppresses a marker that arrives split across chunks", () => {
+        const filter = new TextToolMarkupFilter();
+        expect(filter.feed("Calling tool. <｜DSM")).toBe("Calling tool. ");
+        expect(filter.feed("L｜tool_calls> ...")).toBe("");
+        expect(filter.flush()).toBe("");
+    });
+
+    it("passes ordinary prose straight through", () => {
+        const filter = new TextToolMarkupFilter();
+        expect(filter.feed("A normal answer.")).toBe("A normal answer.");
+        expect(filter.flush()).toBe("");
+    });
+});

--- a/backend/src/lib/__tests__/userCommittees.test.ts
+++ b/backend/src/lib/__tests__/userCommittees.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, it } from "vitest";
+
+import {
+    MAX_COMMITTEE_MEMBERS,
+    MAX_USER_COMMITTEES,
+    isUserCommitteeId,
+    normalizeUserCommittees,
+    validateUserCommittees,
+} from "../userCommittees";
+
+const VALID = {
+    id: "user-committee/panel",
+    label: "Panel",
+    members: ["claude-opus-5", "gemini-3.5-flash"],
+    chair: "gpt-5.5",
+};
+
+describe("isUserCommitteeId", () => {
+    it("recognises the user-committee namespace only", () => {
+        expect(isUserCommitteeId("user-committee/panel")).toBe(true);
+        expect(isUserCommitteeId("claude-opus-5")).toBe(false);
+        expect(isUserCommitteeId(null)).toBe(false);
+    });
+});
+
+describe("normalizeUserCommittees", () => {
+    it("reads a stored array", () => {
+        expect(normalizeUserCommittees([VALID])).toEqual([
+            { ...VALID, strategy: "synthesize" },
+        ]);
+    });
+
+    it("parses a JSON string column", () => {
+        expect(normalizeUserCommittees(JSON.stringify([VALID]))).toHaveLength(
+            1,
+        );
+    });
+
+    it("drops malformed entries instead of throwing", () => {
+        expect(
+            normalizeUserCommittees([
+                VALID,
+                null,
+                "nonsense",
+                { ...VALID, id: "not-namespaced" },
+                { ...VALID, members: ["only-one"] },
+                { ...VALID, chair: "" },
+            ]),
+        ).toHaveLength(1);
+    });
+
+    it("returns nothing for unusable input", () => {
+        expect(normalizeUserCommittees("{not json")).toEqual([]);
+        expect(normalizeUserCommittees(undefined)).toEqual([]);
+        expect(normalizeUserCommittees({})).toEqual([]);
+    });
+
+    it("caps the number of committees and members", () => {
+        const many = Array.from({ length: MAX_USER_COMMITTEES + 3 }, (_, i) => ({
+            ...VALID,
+            id: `user-committee/p${i}`,
+        }));
+        expect(normalizeUserCommittees(many)).toHaveLength(MAX_USER_COMMITTEES);
+
+        const wide = normalizeUserCommittees([
+            {
+                ...VALID,
+                members: Array.from(
+                    { length: MAX_COMMITTEE_MEMBERS + 3 },
+                    (_, i) => `claude-opus-5-${i}`,
+                ),
+            },
+        ]);
+        expect(wide[0].members).toHaveLength(MAX_COMMITTEE_MEMBERS);
+    });
+});
+
+describe("validateUserCommittees", () => {
+    it("accepts a well-formed committee", () => {
+        expect(validateUserCommittees([VALID])).toEqual([
+            { ...VALID, strategy: "synthesize" },
+        ]);
+    });
+
+    it("requires an array", () => {
+        expect(() => validateUserCommittees("nope")).toThrow(
+            /must be an array/,
+        );
+    });
+
+    it("rejects more committees than allowed", () => {
+        const many = Array.from({ length: MAX_USER_COMMITTEES + 1 }, (_, i) => ({
+            ...VALID,
+            id: `user-committee/p${i}`,
+        }));
+        expect(() => validateUserCommittees(many)).toThrow(
+            /up to 8 committees/,
+        );
+    });
+
+    it("rejects a committee that would be silently dropped", () => {
+        expect(() =>
+            validateUserCommittees([{ ...VALID, members: ["claude-opus-5"] }]),
+        ).toThrow(/needs a name, a chair, and between 2 and 8 members/);
+    });
+
+    it("rejects duplicate ids", () => {
+        expect(() => validateUserCommittees([VALID, VALID])).toThrow(
+            /already in use/,
+        );
+    });
+
+    it("rejects a repeated member", () => {
+        expect(() =>
+            validateUserCommittees([
+                { ...VALID, members: ["claude-opus-5", "claude-opus-5"] },
+            ]),
+        ).toThrow(/same member more than once/);
+    });
+
+    it("rejects a nested committee", () => {
+        expect(() =>
+            validateUserCommittees([
+                {
+                    ...VALID,
+                    members: ["user-committee/other", "claude-opus-5"],
+                },
+            ]),
+        ).toThrow(/cannot contain another committee/);
+    });
+
+    it("rejects an unknown member model", () => {
+        expect(() =>
+            validateUserCommittees([
+                { ...VALID, members: ["claude-opus-5", "not-a-model"] },
+            ]),
+        ).toThrow(/Unknown committee model: not-a-model/);
+    });
+
+    it("rejects an unknown chair", () => {
+        expect(() =>
+            validateUserCommittees([{ ...VALID, chair: "not-a-model" }]),
+        ).toThrow(/Unknown committee model: not-a-model/);
+    });
+
+    it("rejects an over-long name", () => {
+        expect(() =>
+            validateUserCommittees([{ ...VALID, label: "x".repeat(81) }]),
+        ).toThrow(/80 characters or fewer/);
+    });
+});

--- a/backend/src/lib/__tests__/userSettings.test.ts
+++ b/backend/src/lib/__tests__/userSettings.test.ts
@@ -27,6 +27,8 @@ function profileDb(row: Record<string, unknown> | null) {
         chain[method] = vi.fn(() => chain);
     }
     chain.single = vi.fn(async () => ({ data: row, error: null }));
+    // getUserCommittees reads model_committees off the same profile row.
+    chain.maybeSingle = vi.fn(async () => ({ data: row, error: null }));
     return chain as never;
 }
 
@@ -137,6 +139,15 @@ function retryingProfileDb(
         chain[method] = vi.fn(() => chain);
     }
     chain.single = vi.fn(async () => results.shift() ?? second);
+    // A database this old has no model_committees column either; the read
+    // must degrade to "no committees" rather than fail the whole request.
+    chain.maybeSingle = vi.fn(async () => ({
+        data: null,
+        error: {
+            code: "42703",
+            message: 'column user_profiles.model_committees does not exist',
+        },
+    }));
     return chain as never;
 }
 

--- a/backend/src/lib/chat/streaming.ts
+++ b/backend/src/lib/chat/streaming.ts
@@ -197,6 +197,7 @@ export async function runLLMStream(params: {
   buildCitations?: (fullText: string) => unknown[];
   model?: string;
   apiKeys?: import("../llm").UserApiKeys;
+  committeeModels?: import("../llm").CommitteeModel[];
   signal?: AbortSignal;
   /** Let a route persist the completed turn before it signals stream success. */
   emitDone?: boolean;
@@ -230,6 +231,7 @@ export async function runLLMStream(params: {
     buildCitations,
     model,
     apiKeys,
+    committeeModels,
     signal,
     projectId,
     nonce,
@@ -401,15 +403,21 @@ export async function runLLMStream(params: {
     // asked for in THIS request. Tabular's stored preference has already been
     // normalized by getUserModelSettings, so what arrives here is either an
     // in-selection router model or a first-party id.
+    // Supplied by the caller, which has already loaded the profile — the
+    // resolution needs them to recognise the id and dispatch needs them to
+    // actually run the committee.
     const selectedModel = await resolveRequestedModel(
       model,
       DEFAULT_MAIN_MODEL,
       userId,
       db,
       "throw",
+      committeeModels,
+      apiKeys,
     );
     await streamChatWithTools({
       model: selectedModel,
+      committeeModels,
       systemPrompt,
       messages: chatMessages,
       tools: activeTools as OpenAIToolSchema[],

--- a/backend/src/lib/llm/aiSdk.ts
+++ b/backend/src/lib/llm/aiSdk.ts
@@ -374,6 +374,7 @@ export async function completeAiSdkText(
     systemPrompt?: string;
     user: string;
     maxTokens?: number;
+    abortSignal?: AbortSignal;
   },
   config: AiSdkAdapterConfig,
 ): Promise<string> {
@@ -384,6 +385,7 @@ export async function completeAiSdkText(
     prompt: params.user,
     maxOutputTokens: params.maxTokens ?? 512,
     reasoning: config.supportsReasoning === false ? undefined : "none",
+    abortSignal: params.abortSignal,
   });
   return result.text;
 }

--- a/backend/src/lib/llm/committee.ts
+++ b/backend/src/lib/llm/committee.ts
@@ -1,0 +1,142 @@
+import { completeText } from "./index";
+import { getCommitteeModel } from "./registry";
+import type {
+  CommitteeModel,
+  CompleteTextParams,
+  StreamChatParams,
+  StreamChatResult,
+} from "./types";
+
+// A committee answers one prompt with several models and has a chair
+// synthesize their replies. Members run against the ordinary provider layer,
+// so a committee can mix hosted and self-hosted models freely.
+
+type CommitteeMemberConfig = CommitteeModel["members"][number];
+
+const CHAIR_INSTRUCTION =
+  "You are chairing a legal AI model committee. Synthesize the member analyses into one accurate, concise answer. Resolve disagreements explicitly when they affect the answer. Do not invent citations or facts that are not present in the member analyses.";
+
+const NO_TOOLS_NOTICE =
+  "Note: document and case-law tools are not available in committee mode. Answer directly from the conversation context; do not claim to have created, edited, or looked up documents.";
+
+export function isCommitteeId(
+  model: string,
+  committeeModels: CommitteeModel[] = [],
+): boolean {
+  return getCommitteeModel(model, committeeModels) !== null;
+}
+
+function resolveCommitteeMember(member: CommitteeMemberConfig) {
+  if (typeof member === "string") {
+    return { model: member, label: member, systemPrompt: "" };
+  }
+  return {
+    model: member.model,
+    label: member.label || member.id || member.model,
+    systemPrompt: member.systemPrompt || "",
+  };
+}
+
+export async function completeCommitteeText(
+  params: CompleteTextParams,
+): Promise<string> {
+  const committee = getCommitteeModel(params.model, params.committeeModels);
+  if (!committee) throw new Error(`Unknown committee model: ${params.model}`);
+  if (committee.chair === params.model) {
+    throw new Error(
+      `Committee ${params.model} cannot use itself as the chair model.`,
+    );
+  }
+
+  const stack = params.committeeStack ?? [];
+  if (stack.includes(params.model)) {
+    throw new Error(
+      `Circular committee reference detected: ${[...stack, params.model].join(" -> ")}.`,
+    );
+  }
+  const nextStack = [...stack, params.model];
+
+  const members = committee.members.map(resolveCommitteeMember);
+  const selfReferencing = members.find(
+    (member) => member.model === params.model,
+  );
+  if (selfReferencing) {
+    throw new Error(
+      `Committee ${params.model} cannot include itself as member ${selfReferencing.label}.`,
+    );
+  }
+
+  // Members are independent, so run them together rather than in sequence —
+  // a committee otherwise costs the sum of its members' latency.
+  const memberResponses = await Promise.all(
+    members.map(async (member) => ({
+      member: member.label,
+      text: await completeText({
+        model: member.model,
+        systemPrompt: [params.systemPrompt, member.systemPrompt]
+          .filter(Boolean)
+          .join("\n\n"),
+        user: params.user,
+        maxTokens: params.maxTokens,
+        apiKeys: params.apiKeys,
+        committeeStack: nextStack,
+        committeeModels: params.committeeModels,
+        abortSignal: params.abortSignal,
+      }),
+    })),
+  );
+
+  return completeText({
+    model: committee.chair,
+    systemPrompt: [
+      CHAIR_INSTRUCTION,
+      params.systemPrompt
+        ? `The final answer must follow this original system instruction exactly:\n${params.systemPrompt}`
+        : "",
+    ]
+      .filter(Boolean)
+      .join("\n\n"),
+    user: [
+      `Original user request:\n${params.user}`,
+      "Committee member analyses:",
+      ...memberResponses.map(
+        (response) => `--- ${response.member} ---\n${response.text}`,
+      ),
+    ].join("\n\n"),
+    maxTokens: params.maxTokens,
+    apiKeys: params.apiKeys,
+    committeeStack: nextStack,
+    committeeModels: params.committeeModels,
+    abortSignal: params.abortSignal,
+  });
+}
+
+export async function streamCommitteeChat(
+  params: StreamChatParams,
+): Promise<StreamChatResult> {
+  // Committee mode has no tool-calling loop. When the caller passes tools
+  // (the main chat path always does), drop them and say so in the system
+  // prompt so the answer does not claim tool work it could not do.
+  const systemPrompt = [
+    params.systemPrompt,
+    params.tools?.length ? NO_TOOLS_NOTICE : "",
+  ]
+    .filter(Boolean)
+    .join("\n\n");
+
+  const conversation = params.messages
+    .map((message) => `${message.role.toUpperCase()}:\n${message.content}`)
+    .join("\n\n");
+
+  const fullText = await completeCommitteeText({
+    model: params.model,
+    systemPrompt,
+    user: conversation,
+    maxTokens: 4096,
+    apiKeys: params.apiKeys,
+    committeeModels: params.committeeModels,
+    abortSignal: params.abortSignal,
+  });
+  params.callbacks?.onContentDelta?.(fullText);
+  return { fullText };
+}

--- a/backend/src/lib/llm/index.ts
+++ b/backend/src/lib/llm/index.ts
@@ -1,5 +1,11 @@
+import { completeCommitteeText, streamCommitteeChat } from "./committee";
 import { completeWithProvider, streamWithProvider } from "./providers";
-import type { StreamChatParams, StreamChatResult, UserApiKeys } from "./types";
+import { getCommitteeModel } from "./registry";
+import type {
+    CompleteTextParams,
+    StreamChatParams,
+    StreamChatResult,
+} from "./types";
 
 export * from "./types";
 export * from "./models";
@@ -7,15 +13,17 @@ export * from "./models";
 export async function streamChatWithTools(
     params: StreamChatParams,
 ): Promise<StreamChatResult> {
+    if (getCommitteeModel(params.model, params.committeeModels)) {
+        return streamCommitteeChat(params);
+    }
     return streamWithProvider(params);
 }
 
-export async function completeText(params: {
-    model: string;
-    systemPrompt?: string;
-    user: string;
-    maxTokens?: number;
-    apiKeys?: UserApiKeys;
-}): Promise<string> {
+export async function completeText(
+    params: CompleteTextParams,
+): Promise<string> {
+    if (getCommitteeModel(params.model, params.committeeModels)) {
+        return completeCommitteeText(params);
+    }
     return completeWithProvider(params);
 }

--- a/backend/src/lib/llm/localModelMiddleware.ts
+++ b/backend/src/lib/llm/localModelMiddleware.ts
@@ -1,0 +1,353 @@
+import type { LanguageModelMiddleware } from "ai" with {
+  "resolution-mode": "import",
+};
+import {
+  collapseTrademarkOwnerCalls,
+  parseTextToolCalls,
+  TextToolMarkupFilter,
+  ThinkTagFilter,
+} from "./toolCallParsing";
+import type { NormalizedToolCall } from "./types";
+
+// Adapts endpoints that cannot be trusted to emit structured tool calls onto
+// the AI SDK's provider contract. The transport, retries and SSE parsing are
+// the SDK's job; this middleware only rewrites what the model said:
+//
+//   * <think>…</think> prose becomes reasoning parts instead of visible text,
+//   * tool markup in the text stream is suppressed rather than shown, and
+//   * tool calls described in prose become real tool-call parts.
+//
+// Models that stream tool markup mid-sentence tend to also mis-handle
+// streamed tool calls entirely, so a tolerant model answering a request that
+// declares tools is served through doGenerate and replayed as a stream. That
+// mirrors how these endpoints were driven before, without a bespoke client.
+
+type StreamResult = Awaited<
+  ReturnType<NonNullable<LanguageModelMiddleware["wrapStream"]>>
+>;
+type StreamPart =
+  StreamResult["stream"] extends ReadableStream<infer Part> ? Part : never;
+type FinishPart = Extract<StreamPart, { type: "finish" }>;
+type FinishReason = GenerateResult["finishReason"];
+type GenerateResult = Awaited<
+  ReturnType<NonNullable<LanguageModelMiddleware["wrapGenerate"]>>
+>;
+
+/** Recovered calls change why the step ended; the provider's raw reason is
+ * preserved for telemetry. */
+function toolCallsFinishReason(original: FinishReason): FinishReason {
+  return { unified: "tool-calls", raw: original.raw };
+}
+
+const TEXT_ID = "text-0";
+const REASONING_ID = "reasoning-0";
+
+function toToolCallParts(calls: NormalizedToolCall[]): StreamPart[] {
+  return collapseTrademarkOwnerCalls(calls).map(
+    (call) =>
+      ({
+        type: "tool-call",
+        toolCallId: call.id,
+        toolName: call.name,
+        input: JSON.stringify(call.input),
+      }) as StreamPart,
+  );
+}
+
+/**
+ * Parse tool calls out of assistant prose. Returns null when the text holds
+ * no tool markup at all, which is the ordinary "the model just answered"
+ * case; parse failures on text that *does* look like a tool call are
+ * surfaced, because silently dropping one strands the request.
+ */
+function toolCallsFromText(text: string): NormalizedToolCall[] | null {
+  try {
+    const calls = parseTextToolCalls(text, 0);
+    return calls.length ? calls : null;
+  } catch (error) {
+    throw error instanceof Error ? error : new Error(String(error));
+  }
+}
+
+function textFromContent(content: GenerateResult["content"]): {
+  text: string;
+  reasoning: string;
+} {
+  let text = "";
+  let reasoning = "";
+  for (const part of content) {
+    if (part.type === "text") text += part.text;
+    if (part.type === "reasoning") reasoning += part.text;
+  }
+  return { text, reasoning };
+}
+
+function replayAsStream(generated: GenerateResult): ReadableStream<StreamPart> {
+  const { text, reasoning } = textFromContent(generated.content);
+  const providerToolCalls = generated.content.filter(
+    (part) => part.type === "tool-call",
+  );
+
+  return new ReadableStream<StreamPart>({
+    start(controller) {
+      controller.enqueue({ type: "stream-start", warnings: [] } as StreamPart);
+
+      const think = new ThinkTagFilter();
+      const fed = think.feed(text);
+      const flushed = think.flush();
+      const reasoningText =
+        reasoning + [...fed.reasoning, ...flushed.reasoning].join("");
+      const visibleRaw = [...fed.content, ...flushed.content].join("");
+
+      if (reasoningText) {
+        controller.enqueue({
+          type: "reasoning-start",
+          id: REASONING_ID,
+        } as StreamPart);
+        controller.enqueue({
+          type: "reasoning-delta",
+          id: REASONING_ID,
+          delta: reasoningText,
+        } as StreamPart);
+        controller.enqueue({
+          type: "reasoning-end",
+          id: REASONING_ID,
+        } as StreamPart);
+      }
+
+      // Only mine the text for tool calls when the provider did not manage to
+      // report any itself.
+      let toolCalls: NormalizedToolCall[] | null = null;
+      if (!providerToolCalls.length) {
+        try {
+          toolCalls = toolCallsFromText(visibleRaw);
+        } catch (error) {
+          controller.enqueue({ type: "error", error } as StreamPart);
+          controller.close();
+          return;
+        }
+      }
+
+      const markup = new TextToolMarkupFilter();
+      const visible = markup.feed(visibleRaw) + markup.flush();
+      if (visible) {
+        controller.enqueue({ type: "text-start", id: TEXT_ID } as StreamPart);
+        controller.enqueue({
+          type: "text-delta",
+          id: TEXT_ID,
+          delta: visible,
+        } as StreamPart);
+        controller.enqueue({ type: "text-end", id: TEXT_ID } as StreamPart);
+      }
+
+      for (const part of providerToolCalls) {
+        controller.enqueue(part as StreamPart);
+      }
+      const recovered = toolCalls ? toToolCallParts(toolCalls) : [];
+      for (const part of recovered) controller.enqueue(part);
+
+      const finishReason: FinishReason =
+        providerToolCalls.length || recovered.length
+          ? toolCallsFinishReason(generated.finishReason)
+          : generated.finishReason;
+      controller.enqueue({
+        type: "finish",
+        usage: generated.usage,
+        finishReason,
+        providerMetadata: generated.providerMetadata,
+      } as StreamPart);
+      controller.close();
+    },
+  });
+}
+
+function tolerantTransform(): TransformStream<StreamPart, StreamPart> {
+  const think = new ThinkTagFilter();
+  const markup = new TextToolMarkupFilter();
+  let rawText = "";
+  let textId = TEXT_ID;
+  let textStarted = false;
+  let reasoningOpen = false;
+  let sawProviderToolCall = false;
+  let deferredFinish: FinishPart | null = null;
+
+  function emitReasoning(
+    controller: TransformStreamDefaultController<StreamPart>,
+    chunks: string[],
+  ) {
+    for (const delta of chunks) {
+      if (!delta) continue;
+      if (!reasoningOpen) {
+        reasoningOpen = true;
+        controller.enqueue({
+          type: "reasoning-start",
+          id: REASONING_ID,
+        } as StreamPart);
+      }
+      controller.enqueue({
+        type: "reasoning-delta",
+        id: REASONING_ID,
+        delta,
+      } as StreamPart);
+    }
+  }
+
+  function emitVisible(
+    controller: TransformStreamDefaultController<StreamPart>,
+    text: string,
+  ) {
+    if (!text) return;
+    if (!textStarted) {
+      textStarted = true;
+      controller.enqueue({ type: "text-start", id: textId } as StreamPart);
+    }
+    controller.enqueue({
+      type: "text-delta",
+      id: textId,
+      delta: text,
+    } as StreamPart);
+  }
+
+  return new TransformStream<StreamPart, StreamPart>({
+    transform(part, controller) {
+      switch (part.type) {
+        case "text-start":
+          // Held back until there is visible text to attribute to it — the
+          // whole block may turn out to be tool markup.
+          textId = part.id;
+          return;
+        case "text-end":
+          return;
+        case "text-delta": {
+          rawText += part.delta;
+          const { content, reasoning } = think.feed(part.delta);
+          emitReasoning(controller, reasoning);
+          emitVisible(controller, markup.feed(content.join("")));
+          return;
+        }
+        case "tool-call":
+          sawProviderToolCall = true;
+          controller.enqueue(part);
+          return;
+        case "finish":
+          deferredFinish = part as FinishPart;
+          return;
+        default:
+          controller.enqueue(part);
+      }
+    },
+
+    flush(controller) {
+      const tail = think.flush();
+      emitReasoning(controller, tail.reasoning);
+      emitVisible(
+        controller,
+        markup.feed(tail.content.join("")) + markup.flush(),
+      );
+      if (reasoningOpen) {
+        controller.enqueue({
+          type: "reasoning-end",
+          id: REASONING_ID,
+        } as StreamPart);
+      }
+      if (textStarted) {
+        controller.enqueue({ type: "text-end", id: textId } as StreamPart);
+      }
+
+      let recovered: StreamPart[] = [];
+      if (!sawProviderToolCall && rawText) {
+        try {
+          const calls = toolCallsFromText(rawText);
+          recovered = calls ? toToolCallParts(calls) : [];
+        } catch (error) {
+          controller.enqueue({ type: "error", error } as StreamPart);
+          if (deferredFinish) controller.enqueue(deferredFinish);
+          return;
+        }
+      }
+      for (const part of recovered) controller.enqueue(part);
+
+      if (deferredFinish) {
+        controller.enqueue(
+          recovered.length
+            ? {
+                ...deferredFinish,
+                finishReason: toolCallsFinishReason(
+                  deferredFinish.finishReason,
+                ),
+              }
+            : deferredFinish,
+        );
+      }
+    },
+  });
+}
+
+/**
+ * Wrap a model whose tool calls cannot be trusted to arrive structured.
+ */
+export function localModelToleranceMiddleware(): LanguageModelMiddleware {
+  return {
+    async wrapStream({ doStream, doGenerate, params }) {
+      // Tool-using turns go through the non-streaming endpoint: these models
+      // interleave tool markup with prose, which cannot be reassembled
+      // reliably from a partial stream.
+      if (params.tools?.length) {
+        const generated = await doGenerate();
+        return { stream: replayAsStream(generated) };
+      }
+      const { stream, ...rest } = await doStream();
+      return { stream: stream.pipeThrough(tolerantTransform()), ...rest };
+    },
+
+    async wrapGenerate({ doGenerate }) {
+      const generated = await doGenerate();
+      const { text, reasoning } = textFromContent(generated.content);
+      const hasProviderToolCall = generated.content.some(
+        (part) => part.type === "tool-call",
+      );
+
+      const think = new ThinkTagFilter();
+      const fed = think.feed(text);
+      const flushed = think.flush();
+      const reasoningText =
+        reasoning + [...fed.reasoning, ...flushed.reasoning].join("");
+      const visibleRaw = [...fed.content, ...flushed.content].join("");
+
+      const calls = hasProviderToolCall ? null : toolCallsFromText(visibleRaw);
+      const markup = new TextToolMarkupFilter();
+      const visible = markup.feed(visibleRaw) + markup.flush();
+
+      const content: GenerateResult["content"] = [];
+      if (reasoningText) {
+        content.push({
+          type: "reasoning",
+          text: reasoningText,
+        } as GenerateResult["content"][number]);
+      }
+      if (visible) {
+        content.push({
+          type: "text",
+          text: visible,
+        } as GenerateResult["content"][number]);
+      }
+      for (const part of generated.content) {
+        if (part.type === "tool-call") content.push(part);
+      }
+      const recovered = calls ? collapseTrademarkOwnerCalls(calls) : [];
+      for (const call of recovered) {
+        content.push({
+          type: "tool-call",
+          toolCallId: call.id,
+          toolName: call.name,
+          input: JSON.stringify(call.input),
+        } as GenerateResult["content"][number]);
+      }
+
+      const finishReason: FinishReason = recovered.length
+        ? toolCallsFinishReason(generated.finishReason)
+        : generated.finishReason;
+      return { ...generated, content, finishReason };
+    },
+  };
+}

--- a/backend/src/lib/llm/models.ts
+++ b/backend/src/lib/llm/models.ts
@@ -1,3 +1,4 @@
+import { getConfiguredModel } from "./registry";
 import type { Provider } from "./types";
 
 // ---------------------------------------------------------------------------
@@ -103,6 +104,10 @@ const ALL_MODELS = new Set<string>([
 // ---------------------------------------------------------------------------
 
 export function providerForModel(model: string): Provider {
+    // Deployment-declared models win over the prefix rules so an operator can
+    // name a self-hosted endpoint whatever they like.
+    const configured = getConfiguredModel(model);
+    if (configured) return configured.provider;
     if (model.startsWith("ollama")) return "ollama";
     if (model.startsWith("openrouter/")) return "openrouter";
     if (model.startsWith("vercel/")) return "vercel";
@@ -129,6 +134,7 @@ export function resolveModel(
     if (
         canonical &&
         (ALL_MODELS.has(canonical) ||
+            getConfiguredModel(canonical) !== null ||
             canonical.startsWith("ollama/") ||
             /^(?:openrouter|vercel)\/[^\s/]+\/[^\s]+$/.test(canonical) ||
             // OpenCode Go's catalog ids are single-segment ("glm-5"), not the

--- a/backend/src/lib/llm/models.ts
+++ b/backend/src/lib/llm/models.ts
@@ -1,5 +1,10 @@
-import { getConfiguredModel } from "./registry";
-import type { Provider } from "./types";
+import {
+    apiKeyForConfiguredModel,
+    configuredModelIds,
+    getCommitteeModel,
+    getConfiguredModel,
+} from "./registry";
+import type { CommitteeModel, Provider, UserApiKeys } from "./types";
 
 // ---------------------------------------------------------------------------
 // Canonical model IDs
@@ -103,11 +108,19 @@ const ALL_MODELS = new Set<string>([
 // Provider inference
 // ---------------------------------------------------------------------------
 
-export function providerForModel(model: string): Provider {
+export function providerForModel(
+    model: string,
+    committeeModels: CommitteeModel[] = [],
+): Provider {
     // Deployment-declared models win over the prefix rules so an operator can
     // name a self-hosted endpoint whatever they like.
     const configured = getConfiguredModel(model);
     if (configured) return configured.provider;
+    // A committee has no provider of its own; it is dispatched before any
+    // adapter is built. Report the chair's so callers that label a provider
+    // have something truthful to show.
+    const committee = getCommitteeModel(model, committeeModels);
+    if (committee) return providerForModel(committee.chair, committeeModels);
     if (model.startsWith("ollama")) return "ollama";
     if (model.startsWith("openrouter/")) return "openrouter";
     if (model.startsWith("vercel/")) return "vercel";
@@ -129,12 +142,14 @@ export const LEGACY_MODEL_IDS: Record<string, string> = {
 export function resolveModel(
     id: string | null | undefined,
     fallback: string,
+    committeeModels: CommitteeModel[] = [],
 ): string {
     const canonical = id ? (LEGACY_MODEL_IDS[id] ?? id) : id;
     if (
         canonical &&
         (ALL_MODELS.has(canonical) ||
             getConfiguredModel(canonical) !== null ||
+            getCommitteeModel(canonical, committeeModels) !== null ||
             canonical.startsWith("ollama/") ||
             /^(?:openrouter|vercel)\/[^\s/]+\/[^\s]+$/.test(canonical) ||
             // OpenCode Go's catalog ids are single-segment ("glm-5"), not the
@@ -172,4 +187,157 @@ export function isSupportedOpenCodeGoModel(model: string): boolean {
         isOpenCodeGoChatCompletionsModel(model) ||
         isOpenCodeGoMessagesModel(model)
     );
+}
+
+// ---------------------------------------------------------------------------
+// Availability
+// ---------------------------------------------------------------------------
+
+const PROVIDER_KEY_ENV: Record<string, string[]> = {
+    claude: ["ANTHROPIC_API_KEY"],
+    gemini: ["GEMINI_API_KEY"],
+    openai: ["OPENAI_API_KEY"],
+    openrouter: ["OPENROUTER_API_KEY"],
+    vercel: ["AI_GATEWAY_API_KEY", "VERCEL_AI_GATEWAY_API_KEY"],
+    "opencode-go": ["OPENCODE_API_KEY"],
+};
+
+function providerKeyAvailable(
+    provider: Provider,
+    apiKeys?: UserApiKeys,
+): boolean {
+    // Ollama is local, and a configured endpoint's key is checked against its
+    // own declaration rather than a provider-wide slot.
+    if (provider === "ollama" || provider === "openai-compatible") return true;
+    const userKey = apiKeys?.[provider as keyof UserApiKeys];
+    if (typeof userKey === "string" && userKey.trim()) return true;
+    return (PROVIDER_KEY_ENV[provider] ?? []).some((name) =>
+        process.env[name]?.trim(),
+    );
+}
+
+/**
+ * The leaf models that stop a model — or every member and chair of a
+ * committee — from running. Empty means it is usable.
+ */
+export function missingCommitteeApiKeyModels(
+    model: string,
+    apiKeys?: UserApiKeys,
+    committeeModels: CommitteeModel[] = [],
+    committeeStack: Set<string> = new Set(),
+): string[] {
+    const committee = getCommitteeModel(model, committeeModels);
+    if (committee) {
+        if (committeeStack.has(model)) return [model];
+        const nextStack = new Set(committeeStack).add(model);
+        const dependencies = [
+            ...committee.members.map((member) =>
+                typeof member === "string" ? member : member.model,
+            ),
+            committee.chair,
+        ];
+        return [
+            ...new Set(
+                dependencies.flatMap((dependency) =>
+                    missingCommitteeApiKeyModels(
+                        dependency,
+                        apiKeys,
+                        committeeModels,
+                        nextStack,
+                    ),
+                ),
+            ),
+        ];
+    }
+
+    const configured = getConfiguredModel(model);
+    if (configured) {
+        // An endpoint that declares no key requirement authenticates however
+        // the deployment set it up, commonly not at all.
+        if (
+            !configured.apiKey &&
+            !configured.apiKeyProvider &&
+            !configured.apiKeyEnv
+        ) {
+            return [];
+        }
+        return apiKeyForConfiguredModel(configured, apiKeys) ? [] : [model];
+    }
+
+    try {
+        return providerKeyAvailable(
+            providerForModel(model, committeeModels),
+            apiKeys,
+        )
+            ? []
+            : [model];
+    } catch {
+        return [model];
+    }
+}
+
+export function modelHasApiKey(
+    model: string,
+    apiKeys?: UserApiKeys,
+    committeeModels: CommitteeModel[] = [],
+): boolean {
+    return (
+        missingCommitteeApiKeyModels(model, apiKeys, committeeModels).length ===
+        0
+    );
+}
+
+/**
+ * Like resolveModel, but substitutes the first model that has a usable key
+ * when the resolved one does not. Returns the original resolution when
+ * nothing else is usable, so the provider's own "key not configured" error
+ * still surfaces rather than being masked.
+ */
+export function resolveUsableModel(
+    id: string | null | undefined,
+    fallback: string,
+    apiKeys?: UserApiKeys,
+    committeeModels: CommitteeModel[] = [],
+): string {
+    // A committee the user selected and then deleted must be an explicit
+    // error, not a silent downgrade to some other model.
+    if (
+        id?.startsWith("user-committee/") &&
+        !getCommitteeModel(id, committeeModels)
+    ) {
+        throw new Error(
+            `The selected committee (${id}) no longer exists or could not be loaded. Select another model or recreate the committee.`,
+        );
+    }
+
+    const selected = resolveModel(id, fallback, committeeModels);
+    const committee = getCommitteeModel(selected, committeeModels);
+    if (committee) {
+        const missing = missingCommitteeApiKeyModels(
+            selected,
+            apiKeys,
+            committeeModels,
+        );
+        if (missing.length) {
+            throw new Error(
+                `Committee ${committee.label || committee.id} cannot run because these models are unavailable or missing API keys: ${missing.join(", ")}.`,
+            );
+        }
+        return selected;
+    }
+
+    if (modelHasApiKey(selected, apiKeys, committeeModels)) return selected;
+    for (const candidate of [
+        ...configuredModelIds(committeeModels),
+        ...ALL_MODELS,
+    ]) {
+        if (
+            candidate !== selected &&
+            !getCommitteeModel(candidate, committeeModels) &&
+            modelHasApiKey(candidate, apiKeys, committeeModels)
+        ) {
+            return candidate;
+        }
+    }
+    return selected;
 }

--- a/backend/src/lib/llm/providers.ts
+++ b/backend/src/lib/llm/providers.ts
@@ -4,6 +4,7 @@ import {
   streamAiSdk,
   type AiSdkAdapterConfig,
 } from "./aiSdk";
+import { localModelToleranceMiddleware } from "./localModelMiddleware";
 import {
   isOpenCodeGoChatCompletionsModel,
   isOpenCodeGoMessagesModel,
@@ -12,7 +13,13 @@ import {
   providerForModel,
   vercelModelId,
 } from "./models";
+import {
+  apiKeyForConfiguredModel,
+  getConfiguredModel,
+  tolerateTextToolCalls,
+} from "./registry";
 import type {
+  ConfiguredModel,
   Provider,
   StreamChatParams,
   StreamChatResult,
@@ -182,6 +189,49 @@ async function createRouterAdapter(
   };
 }
 
+function configuredModelOrThrow(id: string): ConfiguredModel {
+  const configured = getConfiguredModel(id);
+  if (!configured) {
+    throw new Error(
+      `Model ${id} is not declared in MIKE_MODEL_CONFIG_JSON.`,
+    );
+  }
+  if (!configured.baseUrl?.trim()) {
+    throw new Error(`Configured model ${id} is missing a baseUrl.`);
+  }
+  return configured;
+}
+
+async function createConfiguredAdapter(
+  id: string,
+  apiKeys?: UserApiKeys,
+): Promise<AiSdkAdapterConfig> {
+  const configured = configuredModelOrThrow(id);
+  const { createOpenAICompatible } = await import("@ai-sdk/openai-compatible");
+  const client = createOpenAICompatible({
+    name: configured.id,
+    baseURL: configured.baseUrl!.replace(/\/+$/, ""),
+    // Self-hosted endpoints commonly ignore auth entirely; send a placeholder
+    // rather than failing closed the way the hosted providers do.
+    apiKey: apiKeyForConfiguredModel(configured, apiKeys) ?? "not-required",
+    fetch: aiSdkFetch,
+  });
+  const base = client(configured.apiModel ?? configured.id);
+  const { wrapLanguageModel } = await import("ai");
+  return {
+    provider: "openai-compatible",
+    label: configured.label || configured.id,
+    model: tolerateTextToolCalls(configured)
+      ? wrapLanguageModel({
+          model: base,
+          middleware: localModelToleranceMiddleware(),
+        })
+      : base,
+    modelId: configured.id,
+    supportsReasoning: false,
+  };
+}
+
 function unsupportedOpenCodeGoModel(model: string): Error {
   return new Error(
     `OpenCode Go model ${openCodeGoModelId(model)} requires a protocol Mike does not support yet. Select a model listed in Settings → Bring Your Own Keys → Routers.`,
@@ -260,6 +310,10 @@ async function createProviderAdapter(
       });
     }
     return createRouterAdapter(provider, model, apiKeys);
+  }
+
+  if (provider === "openai-compatible") {
+    return createConfiguredAdapter(model, apiKeys);
   }
 
   const { createOpenAICompatible } = await import("@ai-sdk/openai-compatible");

--- a/backend/src/lib/llm/providers.ts
+++ b/backend/src/lib/llm/providers.ts
@@ -41,6 +41,7 @@ type CompleteProviderParams = {
   user: string;
   maxTokens?: number;
   apiKeys?: UserApiKeys;
+  abortSignal?: AbortSignal;
 };
 
 type RouterProvider = Extract<

--- a/backend/src/lib/llm/registry.ts
+++ b/backend/src/lib/llm/registry.ts
@@ -1,0 +1,170 @@
+import type {
+  CommitteeModel,
+  ConfiguredModel,
+  Provider,
+  UserApiKeys,
+} from "./types";
+
+// Deployment-declared models. The static catalog in models.ts covers the
+// hosted providers Mike ships with; this registry is how an operator adds a
+// self-hosted or third-party endpoint (and, in a later change, committees)
+// without a code change. Everything is read from one env var so the
+// configuration travels with the deployment rather than the database.
+
+type ModelRegistryConfig = {
+  models: ConfiguredModel[];
+  committees: CommitteeModel[];
+};
+
+const EMPTY_CONFIG: ModelRegistryConfig = { models: [], committees: [] };
+
+let cached: ModelRegistryConfig | undefined;
+
+export function loadModelRegistry(): ModelRegistryConfig {
+  if (cached) return cached;
+
+  const raw = process.env.MIKE_MODEL_CONFIG_JSON?.trim();
+  if (!raw) {
+    cached = EMPTY_CONFIG;
+    return cached;
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (error) {
+    throw new Error(
+      `MIKE_MODEL_CONFIG_JSON is not valid JSON: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    );
+  }
+
+  const record =
+    parsed && typeof parsed === "object" && !Array.isArray(parsed)
+      ? (parsed as Record<string, unknown>)
+      : {};
+  cached = {
+    models: Array.isArray(record.models)
+      ? record.models.filter(isConfiguredModel)
+      : [],
+    committees: Array.isArray(record.committees)
+      ? record.committees.filter(isCommitteeModel)
+      : [],
+  };
+  return cached;
+}
+
+/** Test seam — the registry is otherwise parsed once per process. */
+export function resetModelRegistryCache(): void {
+  cached = undefined;
+}
+
+export function getConfiguredModel(id: string): ConfiguredModel | null {
+  return loadModelRegistry().models.find((model) => model.id === id) ?? null;
+}
+
+export function getCommitteeModel(
+  id: string,
+  additionalCommittees: CommitteeModel[] = [],
+): CommitteeModel | null {
+  return (
+    additionalCommittees.find((committee) => committee.id === id) ??
+    loadModelRegistry().committees.find((committee) => committee.id === id) ??
+    null
+  );
+}
+
+export function configuredModelIds(
+  additionalCommittees: CommitteeModel[] = [],
+): string[] {
+  return configuredModelSummaries(additionalCommittees).map(
+    (summary) => summary.id,
+  );
+}
+
+export type ConfiguredModelSummary = {
+  id: string;
+  label: string;
+  provider: Provider | "committee";
+  location: ModelSummaryLocation;
+};
+
+type ModelSummaryLocation = ConfiguredModel["location"] | "committee";
+
+export function configuredModelSummaries(
+  additionalCommittees: CommitteeModel[] = [],
+): ConfiguredModelSummary[] {
+  const registry = loadModelRegistry();
+  const committees = [...registry.committees, ...additionalCommittees];
+  return [
+    ...registry.models.map((model) => ({
+      id: model.id,
+      label: model.label || model.id,
+      provider: model.provider,
+      location: model.location,
+    })),
+    ...committees.map((committee) => ({
+      id: committee.id,
+      label: committee.label || committee.id,
+      provider: "committee" as const,
+      location: "committee" as const,
+    })),
+  ];
+}
+
+export function apiKeyForConfiguredModel(
+  model: ConfiguredModel,
+  apiKeys?: UserApiKeys,
+): string | null {
+  if (model.apiKey?.trim()) return model.apiKey.trim();
+  if (model.apiKeyProvider) {
+    const userKey = apiKeys?.[model.apiKeyProvider];
+    if (typeof userKey === "string" && userKey.trim()) return userKey.trim();
+  }
+  if (model.apiKeyEnv?.trim()) {
+    return process.env[model.apiKeyEnv.trim()]?.trim() || null;
+  }
+  return null;
+}
+
+/**
+ * Local endpoints are the ones that routinely emit tool calls as prose, so
+ * they get the tolerant parsing path unless the config says otherwise.
+ */
+export function tolerateTextToolCalls(model: ConfiguredModel): boolean {
+  return model.tolerateTextToolCalls ?? model.location === "local";
+}
+
+// Only OpenAI-compatible endpoints are declarable. The hosted providers are
+// covered by the static catalog in models.ts and by the router prefixes
+// (openrouter/, vercel/, opencode-go/), so a configured entry for one of them
+// would be a second, subtly different way to say the same thing.
+function isConfiguredModel(value: unknown): value is ConfiguredModel {
+  if (!value || typeof value !== "object") return false;
+  const record = value as Record<string, unknown>;
+  return (
+    typeof record.id === "string" &&
+    record.id.trim().length > 0 &&
+    record.provider === "openai-compatible" &&
+    (record.location === "cloud" || record.location === "local")
+  );
+}
+
+function isCommitteeModel(value: unknown): value is CommitteeModel {
+  if (!value || typeof value !== "object") return false;
+  const record = value as Record<string, unknown>;
+  return (
+    typeof record.id === "string" &&
+    record.id.trim().length > 0 &&
+    typeof record.chair === "string" &&
+    Array.isArray(record.members) &&
+    record.members.every(
+      (member) =>
+        typeof member === "string" ||
+        (!!member &&
+          typeof member === "object" &&
+          typeof (member as Record<string, unknown>).model === "string"),
+    )
+  );
+}

--- a/backend/src/lib/llm/toolCallParsing.ts
+++ b/backend/src/lib/llm/toolCallParsing.ts
@@ -1,0 +1,473 @@
+// jsonrepair declares "type": "module" but ships a CommonJS build; importing
+// it normally trips TS1479 under this package's Node16 CJS resolution.
+const { jsonrepair } = require("jsonrepair") as {
+  jsonrepair: (text: string) => string;
+};
+
+import type { NormalizedToolCall } from "./types";
+
+// Tolerance for models that describe tool calls in prose instead of emitting
+// them as structured tool-call fields. Self-hosted builds of Qwen, DeepSeek,
+// GLM and friends routinely do this, in a different dialect each: a JSON
+// object inside <tool_call> markers, an XML-ish <function=name> block, a
+// DeepSeek DSML invoke, or a bare map whose single key is the tool name.
+// Hosted providers never need any of it, so this module is only wired up for
+// endpoints the registry marks as tolerant (see localModelMiddleware.ts).
+//
+// Everything here is pure text handling: no transport, no provider SDK.
+
+const THINK_OPEN = "<think>";
+
+const THINK_CLOSE = "</think>";
+
+// Routes inline <think>...</think> blocks (qwen/deepseek style) to the
+// reasoning channel instead of the visible content stream. Tags can be
+// split across SSE chunks, so partial-tag suffixes are buffered.
+export class ThinkTagFilter {
+  private insideThink = false;
+  private buffer = "";
+  sawReasoning = false;
+
+  feed(text: string): { content: string[]; reasoning: string[] } {
+    this.buffer += text;
+    const content: string[] = [];
+    const reasoning: string[] = [];
+
+    while (this.buffer.length) {
+      const tag = this.insideThink ? THINK_CLOSE : THINK_OPEN;
+      const idx = this.buffer.indexOf(tag);
+      if (idx === -1) {
+        const hold = this.partialTagSuffixLength(tag);
+        const emit = this.buffer.slice(0, this.buffer.length - hold);
+        this.buffer = this.buffer.slice(this.buffer.length - hold);
+        if (emit) this.emit(emit, content, reasoning);
+        break;
+      }
+      const before = this.buffer.slice(0, idx);
+      if (before) this.emit(before, content, reasoning);
+      this.buffer = this.buffer.slice(idx + tag.length);
+      this.insideThink = !this.insideThink;
+    }
+
+    return { content, reasoning };
+  }
+
+  flush(): { content: string[]; reasoning: string[] } {
+    const content: string[] = [];
+    const reasoning: string[] = [];
+    if (this.buffer) {
+      this.emit(this.buffer, content, reasoning);
+      this.buffer = "";
+    }
+    return { content, reasoning };
+  }
+
+  private emit(text: string, content: string[], reasoning: string[]) {
+    if (this.insideThink) {
+      this.sawReasoning = true;
+      reasoning.push(text);
+    } else {
+      content.push(text);
+    }
+  }
+
+  private partialTagSuffixLength(tag: string): number {
+    const max = Math.min(this.buffer.length, tag.length - 1);
+    for (let len = max; len > 0; len--) {
+      if (this.buffer.endsWith(tag.slice(0, len))) return len;
+    }
+    return 0;
+  }
+}
+
+const TEXT_TOOL_MARKERS = [
+  "<tool_call",
+  "<toolcall",
+  "<|tool_call",
+  "<function=",
+  "<function name=",
+  "<｜dsml｜tool_calls",
+  "<｜dsml｜invoke",
+  "<|dsml|tool_calls",
+  "<|dsml|invoke",
+];
+
+/** Suppress textual tool markup even when its opening marker spans chunks. */
+export class TextToolMarkupFilter {
+  private buffer = "";
+  private suppressing = false;
+
+  feed(text: string): string {
+    if (this.suppressing || !text) return "";
+    this.buffer += text;
+    const lower = this.buffer.toLowerCase();
+    let markerIndex = -1;
+    for (const marker of TEXT_TOOL_MARKERS) {
+      const index = lower.indexOf(marker);
+      if (index >= 0 && (markerIndex < 0 || index < markerIndex)) {
+        markerIndex = index;
+      }
+    }
+    if (markerIndex >= 0) {
+      const visible = this.buffer.slice(0, markerIndex);
+      this.buffer = "";
+      this.suppressing = true;
+      return visible;
+    }
+
+    for (
+      let index = lower.lastIndexOf("<");
+      index >= 0;
+      index = lower.lastIndexOf("<", index - 1)
+    ) {
+      const suffix = lower.slice(index);
+      if (TEXT_TOOL_MARKERS.some((marker) => marker.startsWith(suffix))) {
+        const visible = this.buffer.slice(0, index);
+        this.buffer = this.buffer.slice(index);
+        return visible;
+      }
+    }
+    const visible = this.buffer;
+    this.buffer = "";
+    return visible;
+  }
+
+  flush(): string {
+    if (this.suppressing) return "";
+    const visible = this.buffer;
+    this.buffer = "";
+    return visible;
+  }
+}
+
+export function stripThinkTags(text: string): string {
+  return text
+    .replace(/<think>[\s\S]*?<\/think>/g, "")
+    .replace(/<\/?think>/g, "")
+    .trim();
+}
+
+export function parseToolInput(value: unknown): Record<string, unknown> {
+  if (value && typeof value === "object" && !Array.isArray(value)) {
+    return value as Record<string, unknown>;
+  }
+  if (typeof value !== "string" || !value.trim()) return {};
+  try {
+    const parsed = JSON.parse(value);
+    return parsed && typeof parsed === "object" && !Array.isArray(parsed)
+      ? (parsed as Record<string, unknown>)
+      : {};
+  } catch {
+    return {};
+  }
+}
+
+export function deduplicateToolCalls(
+  calls: NormalizedToolCall[],
+): NormalizedToolCall[] {
+  const seen = new Set<string>();
+  return calls.filter((call) => {
+    const key = `${call.name}\n${JSON.stringify(call.input)}`;
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
+}
+
+export function parseTextToolCalls(
+  text: string,
+  iteration: number,
+): NormalizedToolCall[] {
+  const dsmlCalls = parseDsmlToolCalls(text, iteration);
+  if (dsmlCalls.length) return deduplicateToolCalls(dsmlCalls);
+  if (
+    !/<(?:tool_call|toolcall)\b|<\|tool_call(?:_start)?\|>|<function(?:=|\s+name=)|(?:^|\n)\s*(?:tool|function|name)\s*[:=]/i.test(
+      text,
+    )
+  )
+    return [];
+  const bodies: string[] = [];
+  const tagPattern =
+    /<(?:tool_call|toolcall)\b[^>]*>|<\|tool_call(?:_start)?\|>/gi;
+  const openTags = [...text.matchAll(tagPattern)];
+  for (const [index, openTag] of openTags.entries()) {
+    const start = (openTag.index ?? 0) + openTag[0].length;
+    const nextStart = openTags[index + 1]?.index ?? text.length;
+    const segment = text.slice(start, nextStart);
+    const closeIndex = segment.search(
+      /<\/(?:tool_call|toolcall)>|<\|tool_call_end\|>/i,
+    );
+    bodies.push(closeIndex >= 0 ? segment.slice(0, closeIndex) : segment);
+  }
+
+  const calls = bodies.flatMap((body, bodyIndex): NormalizedToolCall[] => {
+    const xmlStyleCall = parseXmlStyleToolCall(body, iteration, bodyIndex);
+    if (xmlStyleCall) return [xmlStyleCall];
+    try {
+      const candidate = normalizeQwenToolMapSyntax(extractJsonCandidate(body));
+      const parsed = JSON.parse(jsonrepair(candidate)) as unknown;
+      const rows = Array.isArray(parsed) ? parsed : [parsed];
+      const parsedCalls = rows.flatMap(
+        (row, rowIndex): NormalizedToolCall[] => {
+          if (!row || typeof row !== "object" || Array.isArray(row)) return [];
+          const record = row as Record<string, unknown>;
+          const functionRecord =
+            record.function &&
+            typeof record.function === "object" &&
+            !Array.isArray(record.function)
+              ? (record.function as Record<string, unknown>)
+              : null;
+          const entries = Object.entries(record);
+          const mapStyleCall =
+            record.name == null &&
+            functionRecord?.name == null &&
+            entries.length === 1 &&
+            entries[0][1] &&
+            typeof entries[0][1] === "object" &&
+            !Array.isArray(entries[0][1])
+              ? entries[0]
+              : null;
+          const rawName =
+            record.name ?? functionRecord?.name ?? mapStyleCall?.[0];
+          const name = typeof rawName === "string" ? rawName.trim() : "";
+          if (!name) return [];
+          return [
+            {
+              id:
+                typeof record.id === "string" && record.id
+                  ? record.id
+                  : `call_text_${iteration}_${bodyIndex}_${rowIndex}`,
+              name,
+              input: parseToolInput(
+                record.arguments ??
+                  record.input ??
+                  record.parameters ??
+                  functionRecord?.arguments ??
+                  mapStyleCall?.[1],
+              ),
+            },
+          ];
+        },
+      );
+      const looseCall = parseLooseTextToolCall(body, iteration, bodyIndex);
+      return parsedCalls.length ? parsedCalls : looseCall ? [looseCall] : [];
+    } catch (error) {
+      const looseCall = parseLooseTextToolCall(body, iteration, bodyIndex);
+      if (looseCall) return [looseCall];
+      if (process.env.DEBUG_LLM_TOOL_CALLS === "1") {
+        console.error("[openai-compatible] unrecoverable textual tool call", {
+          body: body.slice(0, 4_000),
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
+      throw new Error(
+        "The local model returned a tool call that Mike could not recover. Retry the request or use the deterministic Trademark Monitor mode.",
+      );
+    }
+  });
+  if (!calls.length) {
+    throw new Error(
+      "The local model did not identify an executable tool. Retry the request or use the deterministic Trademark Monitor mode.",
+    );
+  }
+  return deduplicateToolCalls(calls);
+}
+
+export function parseDsmlToolCalls(
+  value: string,
+  iteration: number,
+): NormalizedToolCall[] {
+  if (!/<[｜|]DSML[｜|]invoke\b/i.test(value)) return [];
+  const calls: NormalizedToolCall[] = [];
+  const invokePattern =
+    /<[｜|]DSML[｜|]invoke\s+name=["']?([^>"'\s]+)["']?\s*>([\s\S]*?)<\/[｜|]DSML[｜|]invoke\s*>/gi;
+  for (const [index, invoke] of [...value.matchAll(invokePattern)].entries()) {
+    const input: Record<string, unknown> = {};
+    const parameterPattern =
+      /<[｜|]DSML[｜|]parameter\s+name=["']?([^>"'\s]+)["']?(?:\s+[^>]*)?>([\s\S]*?)<\/[｜|]DSML[｜|]parameter\s*>/gi;
+    for (const parameter of invoke[2].matchAll(parameterPattern)) {
+      input[parameter[1]] = parseToolScalar(parameter[2]);
+    }
+    calls.push({
+      id: `call_text_${iteration}_dsml_${index}`,
+      name: invoke[1].trim(),
+      input,
+    });
+  }
+  return calls;
+}
+
+export function collapseTrademarkOwnerCalls(
+  calls: NormalizedToolCall[],
+): NormalizedToolCall[] {
+  const groups = new Map<string, NormalizedToolCall[]>();
+  for (const call of calls) {
+    if (
+      !call.name.startsWith("mcp_") ||
+      !/tm_search_trademarks/i.test(call.name) ||
+      typeof call.input.owner_name !== "string" ||
+      !call.input.owner_name.trim()
+    ) {
+      continue;
+    }
+    const group = groups.get(call.name) ?? [];
+    group.push(call);
+    groups.set(call.name, group);
+  }
+  if (![...groups.values()].some((group) => group.length > 1)) return calls;
+
+  const collapsed = new Set<NormalizedToolCall>();
+  const replacements = new Map<string, NormalizedToolCall>();
+  for (const [name, group] of groups) {
+    if (group.length < 2) continue;
+    const first = group[0];
+    const ownerNames = group
+      .map((call) => String(call.input.owner_name).trim())
+      .filter(Boolean);
+    replacements.set(name, {
+      id: first.id,
+      name,
+      input: {
+        ...first.input,
+        owner_name: undefined,
+        owner_names: ownerNames,
+      },
+    });
+    group.forEach((call) => collapsed.add(call));
+  }
+  return calls.flatMap((call) => {
+    if (!collapsed.has(call)) return [call];
+    const replacement = replacements.get(call.name);
+    if (!replacement || replacement.id !== call.id) return [];
+    const input = Object.fromEntries(
+      Object.entries(replacement.input).filter(
+        ([, value]) => value !== undefined,
+      ),
+    );
+    return [{ ...replacement, input }];
+  });
+}
+
+function parseLooseTextToolCall(
+  value: string,
+  iteration: number,
+  bodyIndex: number,
+): NormalizedToolCall | null {
+  const nameMatch = value.match(
+    /(?:["']?name["']?|["']?(?:tool|function)["']?)\s*[:=]\s*["']?([^"'\s,}]+)["']?/i,
+  );
+  const name = nameMatch?.[1]?.trim();
+  if (!name) return null;
+
+  const input: Record<string, unknown> = {};
+  const argumentsMatch = value.match(
+    /["']?(?:arguments|input|parameters)["']?\s*[:=]\s*/i,
+  );
+  if (argumentsMatch && argumentsMatch.index != null) {
+    const candidate = value.slice(
+      argumentsMatch.index + argumentsMatch[0].length,
+    );
+    const repaired = normalizeQwenToolMapSyntax(
+      extractJsonCandidate(candidate),
+    );
+    try {
+      const parsed = JSON.parse(jsonrepair(repaired));
+      if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+        Object.assign(input, parsed);
+      }
+    } catch {
+      // A call with an unrecoverable argument payload is still returned so the
+      // connector can provide its normal validation error instead of hiding the
+      // model's tool name behind a generic parser failure.
+    }
+  }
+  return {
+    id: `call_text_${iteration}_${bodyIndex}_loose`,
+    name,
+    input,
+  };
+}
+
+function parseXmlStyleToolCall(
+  value: string,
+  iteration: number,
+  bodyIndex: number,
+): NormalizedToolCall | null {
+  const functionMatch = value.match(
+    /<function(?:=|\s+name=["'])([^>"'\s]+)["']?\s*>/i,
+  );
+  if (!functionMatch) return null;
+  const input: Record<string, unknown> = {};
+  const fieldPattern = /<([a-zA-Z_][\w.-]*)>\s*([\s\S]*?)\s*<\/\1>/g;
+  for (const match of value.matchAll(fieldPattern)) {
+    input[match[1]] = parseToolScalar(match[2]);
+  }
+  return {
+    id: `call_text_${iteration}_${bodyIndex}_xml`,
+    name: functionMatch[1],
+    input,
+  };
+}
+
+export function parseToolScalar(value: string): unknown {
+  const trimmed = value.trim();
+  if (/^-?(?:0|[1-9]\d*)(?:\.\d+)?$/.test(trimmed)) {
+    const number = Number(trimmed);
+    if (Number.isFinite(number)) return number;
+  }
+  if (/^true$/i.test(trimmed)) return true;
+  if (/^false$/i.test(trimmed)) return false;
+  if (/^(?:null|none)$/i.test(trimmed)) return null;
+  if (/^[\[{]/.test(trimmed)) {
+    try {
+      return JSON.parse(jsonrepair(trimmed));
+    } catch {
+      // Preserve the original string when a nested value is not JSON-like.
+    }
+  }
+  return trimmed;
+}
+
+export function normalizeQwenToolMapSyntax(value: string): string {
+  return value
+    .replace(/^(\s*\{\s*)"{2,}/, '$1"')
+    .replace(/^(\s*\{\s*"[^"]+")\s*:{2,}/, "$1:");
+}
+
+export function extractJsonCandidate(value: string): string {
+  const cleaned = value
+    .replace(/^\s*```(?:json)?\s*/i, "")
+    .replace(/\s*```\s*$/i, "")
+    .trim();
+  const start = cleaned.search(/[\[{]/);
+  if (start < 0) return cleaned;
+
+  const opening = cleaned[start];
+  const closing = opening === "[" ? "]" : "}";
+  let depth = 0;
+  let quote: "'" | '"' | null = null;
+  let escaped = false;
+  for (let index = start; index < cleaned.length; index++) {
+    const char = cleaned[index];
+    if (quote) {
+      if (escaped) {
+        escaped = false;
+      } else if (char === "\\") {
+        escaped = true;
+      } else if (char === quote) {
+        quote = null;
+      }
+      continue;
+    }
+    if (char === "'" || char === '"') {
+      quote = char;
+      continue;
+    }
+    if (char === opening) depth += 1;
+    if (char === closing) {
+      depth -= 1;
+      if (depth === 0) return cleaned.slice(start, index + 1);
+    }
+  }
+  return cleaned.slice(start);
+}

--- a/backend/src/lib/llm/types.ts
+++ b/backend/src/lib/llm/types.ts
@@ -6,6 +6,7 @@ export type Provider =
     | "claude"
     | "gemini"
     | "openai"
+    | "openai-compatible"
     | "openrouter"
     | "vercel"
     | "opencode-go"
@@ -74,4 +75,51 @@ export type StreamChatParams = {
 
 export type StreamChatResult = {
     fullText: string;
+};
+
+// ---------------------------------------------------------------------------
+// Configured models
+// ---------------------------------------------------------------------------
+// The static catalog in models.ts covers the hosted providers Mike ships with.
+// Deployments that also run self-hosted or third-party OpenAI-compatible
+// endpoints declare them through MIKE_MODEL_CONFIG_JSON; see registry.ts.
+
+export type ModelLocation = "cloud" | "local";
+
+export type ConfiguredModel = {
+    id: string;
+    provider: Provider;
+    location: ModelLocation;
+    label?: string;
+    /** Model name to send upstream when it differs from the Mike-facing id. */
+    apiModel?: string;
+    baseUrl?: string;
+    apiKeyEnv?: string;
+    apiKeyProvider?: keyof UserApiKeys;
+    apiKey?: string;
+    /**
+     * Local models frequently emit tool calls as prose rather than as
+     * structured tool-call fields. Leave unset to infer from `location`.
+     */
+    tolerateTextToolCalls?: boolean;
+};
+
+/**
+ * A committee answers one prompt with several models and has a chair model
+ * synthesize their replies into the single response the caller sees.
+ */
+export type CommitteeModel = {
+    id: string;
+    label?: string;
+    members: Array<
+        | string
+        | {
+              id?: string;
+              model: string;
+              label?: string;
+              systemPrompt?: string;
+          }
+    >;
+    chair: string;
+    strategy?: "synthesize";
 };

--- a/backend/src/lib/llm/types.ts
+++ b/backend/src/lib/llm/types.ts
@@ -63,6 +63,8 @@ export type StreamChatParams = {
     callbacks?: StreamCallbacks;
     runTools?: (calls: NormalizedToolCall[]) => Promise<NormalizedToolResult[]>;
     apiKeys?: UserApiKeys;
+    /** Committees the caller owns, on top of any the deployment declares. */
+    committeeModels?: CommitteeModel[];
     /**
      * Enable provider-side reasoning/thinking. Off by default — should only
      * be turned on for interactive chat surfaces where the user actually
@@ -75,6 +77,18 @@ export type StreamChatParams = {
 
 export type StreamChatResult = {
     fullText: string;
+};
+
+export type CompleteTextParams = {
+    model: string;
+    systemPrompt?: string;
+    user: string;
+    maxTokens?: number;
+    apiKeys?: UserApiKeys;
+    committeeModels?: CommitteeModel[];
+    /** Committee ids already being resolved, used to catch cycles. */
+    committeeStack?: string[];
+    abortSignal?: AbortSignal;
 };
 
 // ---------------------------------------------------------------------------

--- a/backend/src/lib/routerModels.ts
+++ b/backend/src/lib/routerModels.ts
@@ -1,6 +1,11 @@
 import { createServerSupabase } from "./supabase";
 import { UserFacingError } from "./userFacingError";
-import { resolveModel } from "./llm/models";
+import {
+    missingCommitteeApiKeyModels,
+    resolveModel,
+} from "./llm/models";
+import { getCommitteeModel } from "./llm/registry";
+import type { CommitteeModel, UserApiKeys } from "./llm/types";
 
 type Db = ReturnType<typeof createServerSupabase>;
 
@@ -61,6 +66,10 @@ const ROUTER_LABELS: Record<RouterSlug, string> = {
  * - "fallback" (the default, for stored preferences): a preference the user
  *   set long ago must not brick every request; degrade to the caller's
  *   default exactly like an invalid model id, with a warning for operators.
+ *
+ * Callers that support committees pass `committeeModels` from the profile
+ * read they already made; omitting them simply means no committee ids are
+ * recognised, which is right for the paths that cannot run one.
  */
 export async function resolveRequestedModel(
     requested: string | null | undefined,
@@ -68,8 +77,40 @@ export async function resolveRequestedModel(
     userId: string,
     db: Db = createServerSupabase(),
     onOutsideSelection: "throw" | "fallback" = "fallback",
+    committeeModels?: CommitteeModel[],
+    apiKeys?: UserApiKeys,
 ): Promise<string> {
-    const resolved = resolveModel(requested, fallback);
+    const committees = committeeModels ?? [];
+    const resolved = resolveModel(requested, fallback, committees);
+
+    // A committee is dispatched before any provider adapter exists, so its
+    // gating is whether every member and chair is actually usable.
+    const committee = getCommitteeModel(resolved, committees);
+    if (committee) {
+        const missing = missingCommitteeApiKeyModels(
+            resolved,
+            apiKeys,
+            committees,
+        );
+        if (missing.length) {
+            throw new UserFacingError(
+                `Committee ${committee.label || committee.id} cannot run because these models are unavailable or missing API keys: ${missing.join(", ")}.`,
+            );
+        }
+        return resolved;
+    }
+
+    // A committee the user selected and later deleted must be an explicit
+    // error rather than a silent switch to some other model.
+    if (
+        requested?.startsWith("user-committee/") &&
+        onOutsideSelection === "throw"
+    ) {
+        throw new UserFacingError(
+            `The selected committee no longer exists. Select another model or recreate the committee in Settings → Models.`,
+        );
+    }
+
     const router = routerForModelId(resolved);
     if (!router) return resolved;
     const selection = await getUserRouterModels(userId, router, db);

--- a/backend/src/lib/userCommittees.ts
+++ b/backend/src/lib/userCommittees.ts
@@ -1,0 +1,175 @@
+import { resolveModel } from "./llm/models";
+import { getCommitteeModel } from "./llm/registry";
+import type { CommitteeModel } from "./llm/types";
+import { createServerSupabase } from "./supabase";
+
+// Committees a user builds in Settings, as opposed to the ones a deployment
+// declares in MIKE_MODEL_CONFIG_JSON. User committees are namespaced so the
+// two can never collide, and are deliberately shallow: a user committee may
+// not contain another committee.
+
+export const USER_COMMITTEE_PREFIX = "user-committee/";
+export const MAX_USER_COMMITTEES = 8;
+export const MAX_COMMITTEE_MEMBERS = 8;
+export const MIN_COMMITTEE_MEMBERS = 2;
+export const MAX_COMMITTEE_LABEL_LENGTH = 80;
+
+export function isUserCommitteeId(value: string | null | undefined): boolean {
+    return !!value?.startsWith(USER_COMMITTEE_PREFIX);
+}
+
+function memberModelId(member: CommitteeModel["members"][number]): string {
+    return typeof member === "string" ? member : member.model;
+}
+
+/**
+ * Best-effort read of whatever is stored on the profile. Anything malformed
+ * is dropped rather than thrown: a bad row must not lock a user out of their
+ * own settings page.
+ */
+export function normalizeUserCommittees(value: unknown): CommitteeModel[] {
+    let candidate = value;
+    if (typeof candidate === "string") {
+        try {
+            candidate = JSON.parse(candidate);
+        } catch {
+            return [];
+        }
+    }
+    if (!Array.isArray(candidate)) return [];
+
+    return candidate
+        .slice(0, MAX_USER_COMMITTEES)
+        .map((entry): CommitteeModel | null => {
+            if (!entry || typeof entry !== "object" || Array.isArray(entry)) {
+                return null;
+            }
+            const record = entry as Record<string, unknown>;
+            const id = typeof record.id === "string" ? record.id.trim() : "";
+            const label =
+                typeof record.label === "string" ? record.label.trim() : "";
+            const chair =
+                typeof record.chair === "string" ? record.chair.trim() : "";
+            if (
+                !isUserCommitteeId(id) ||
+                !label ||
+                !chair ||
+                !Array.isArray(record.members)
+            ) {
+                return null;
+            }
+            const members = record.members
+                .map((member) => {
+                    if (typeof member === "string") return member.trim();
+                    if (
+                        !member ||
+                        typeof member !== "object" ||
+                        Array.isArray(member)
+                    ) {
+                        return "";
+                    }
+                    const model = (member as Record<string, unknown>).model;
+                    return typeof model === "string" ? model.trim() : "";
+                })
+                .filter(Boolean)
+                .slice(0, MAX_COMMITTEE_MEMBERS);
+            if (members.length < MIN_COMMITTEE_MEMBERS) return null;
+            return { id, label, members, chair, strategy: "synthesize" };
+        })
+        .filter((committee): committee is CommitteeModel => committee !== null);
+}
+
+/**
+ * Strict check for the write path, where a bad payload should be an explicit
+ * 4xx rather than silently dropped data.
+ */
+export function validateUserCommittees(value: unknown): CommitteeModel[] {
+    if (!Array.isArray(value)) {
+        throw new Error("modelCommittees must be an array.");
+    }
+    if (value.length > MAX_USER_COMMITTEES) {
+        throw new Error(
+            `You can configure up to ${MAX_USER_COMMITTEES} committees.`,
+        );
+    }
+
+    const normalized = normalizeUserCommittees(value);
+    if (normalized.length !== value.length) {
+        throw new Error(
+            `Each committee needs a name, a chair, and between ${MIN_COMMITTEE_MEMBERS} and ${MAX_COMMITTEE_MEMBERS} members.`,
+        );
+    }
+
+    const ids = new Set<string>();
+    for (const committee of normalized) {
+        const label = committee.label ?? "";
+        if (label.length > MAX_COMMITTEE_LABEL_LENGTH) {
+            throw new Error(
+                `Committee names must be ${MAX_COMMITTEE_LABEL_LENGTH} characters or fewer.`,
+            );
+        }
+        if (ids.has(committee.id) || getCommitteeModel(committee.id)) {
+            throw new Error(`Committee id ${committee.id} is already in use.`);
+        }
+        ids.add(committee.id);
+
+        const memberIds = committee.members.map(memberModelId);
+        if (new Set(memberIds).size !== memberIds.length) {
+            throw new Error(
+                `${label} contains the same member more than once.`,
+            );
+        }
+        for (const model of [...memberIds, committee.chair]) {
+            if (isUserCommitteeId(model) || getCommitteeModel(model)) {
+                throw new Error("A committee cannot contain another committee.");
+            }
+            if (resolveModel(model, "") !== model) {
+                throw new Error(`Unknown committee model: ${model}`);
+            }
+        }
+    }
+    return normalized;
+}
+
+// Postgres raises undefined_column (42703); PostgREST reports a column that
+// is missing from its schema cache as PGRST204. Both arms require the message
+// to name model_committees, so an unrelated schema fault still surfaces
+// instead of being reported as "you have no committees".
+function isMissingCommitteesColumn(error: unknown): boolean {
+    const record =
+        error && typeof error === "object"
+            ? (error as { code?: unknown; message?: unknown })
+            : {};
+    const code = typeof record.code === "string" ? record.code : "";
+    const message = typeof record.message === "string" ? record.message : "";
+    return (
+        (code === "42703" || code === "PGRST204") &&
+        message.includes("model_committees")
+    );
+}
+
+export async function getUserCommittees(
+    userId: string,
+    db: ReturnType<typeof createServerSupabase> = createServerSupabase(),
+): Promise<CommitteeModel[]> {
+    const { data, error } = await db
+        .from("user_profiles")
+        .select("model_committees")
+        .eq("user_id", userId)
+        .maybeSingle();
+    if (error) {
+        // Deploy-before-migrate tolerance, matching selectProfile: a database
+        // without the model_committees column reports "no committees" rather
+        // than failing every chat and tabular request.
+        if (isMissingCommitteesColumn(error)) return [];
+        const detail =
+            typeof error === "object" && error && "message" in error
+                ? String(error.message)
+                : String(error);
+        throw new Error(`Unable to load model committees: ${detail}`);
+    }
+    if (!data) return [];
+    return normalizeUserCommittees(
+        (data as { model_committees?: unknown }).model_committees,
+    );
+}

--- a/backend/src/lib/userSettings.ts
+++ b/backend/src/lib/userSettings.ts
@@ -7,6 +7,8 @@ import {
     type UserApiKeys,
 } from "./llm";
 import { getUserApiKeys as getStoredUserApiKeys } from "./userApiKeys";
+import { getUserCommittees } from "./userCommittees";
+import type { CommitteeModel } from "./llm/types";
 import {
     getAllUserRouterModels,
     isRouterModelSelected,
@@ -20,6 +22,7 @@ export type UserModelSettings = {
     tabular_model: string;
     legal_research_us: boolean;
     api_keys: UserApiKeys;
+    committees: CommitteeModel[];
     personalisation?: {
         displayName: string | null;
         organisation: string | null;
@@ -54,7 +57,8 @@ export async function getUserModelSettings(
     db?: ReturnType<typeof createServerSupabase>,
 ): Promise<UserModelSettings> {
     const client = db ?? createServerSupabase();
-    const [profileResult, api_keys, routerModels] = await Promise.all([
+    const [profileResult, api_keys, routerModels, committees] =
+        await Promise.all([
         client
             .from("user_profiles")
             .select(
@@ -64,6 +68,7 @@ export async function getUserModelSettings(
             .single(),
         getStoredUserApiKeys(userId, client),
         getAllUserRouterModels(userId, client),
+        getUserCommittees(userId, client),
     ]);
     let data = profileResult.data;
 
@@ -104,12 +109,13 @@ export async function getUserModelSettings(
     const titleFallback = resolveTitleModel(api_keys, routerModels);
 
     return {
+        committees,
         title_model: guardRouterModel(
-            resolveModel(data?.title_model, titleFallback),
+            resolveModel(data?.title_model, titleFallback, committees),
             titleFallback,
         ),
         tabular_model: guardRouterModel(
-            resolveModel(data?.tabular_model, DEFAULT_TABULAR_MODEL),
+            resolveModel(data?.tabular_model, DEFAULT_TABULAR_MODEL, committees),
             DEFAULT_TABULAR_MODEL,
         ),
         legal_research_us:

--- a/backend/src/routes/chat.ts
+++ b/backend/src/routes/chat.ts
@@ -508,6 +508,7 @@ chatRouter.post("/", requireAuth, async (req, res) => {
         legal_research_us: legalResearchUs,
         title_model: titleModel,
         personalisation,
+        committees: committeeModels,
     } = await getUserModelSettings(userId, db);
     const personalisationPrompt = buildUserPersonalisationPrompt(
         personalisation,
@@ -625,6 +626,7 @@ chatRouter.post("/", requireAuth, async (req, res) => {
             includeResearchTools: legalResearchUs,
             model,
             apiKeys,
+            committeeModels,
             signal: stream.signal,
             projectId: resolvedProjectId,
             nonce,

--- a/backend/src/routes/tabular.ts
+++ b/backend/src/routes/tabular.ts
@@ -32,6 +32,10 @@ import {
     type Provider,
     type UserApiKeys,
 } from "../lib/llm";
+import {
+    apiKeyForConfiguredModel,
+    getConfiguredModel,
+} from "../lib/llm/registry";
 import { getUserModelSettings } from "../lib/userSettings";
 import {
     checkProjectAccess,
@@ -492,12 +496,25 @@ function providerLabel(provider: Provider): string {
     if (provider === "vercel") return "Vercel AI Gateway";
     if (provider === "opencode-go") return "OpenCode Go";
     if (provider === "ollama") return "Local (Ollama)";
+    if (provider === "openai-compatible") return "Configured endpoint";
     return "Gemini";
 }
 
 function missingModelApiKey(model: string, apiKeys: UserApiKeys) {
     const provider = providerForModel(model);
     if (provider === "ollama") return null; // local, no key
+    if (provider === "openai-compatible") {
+        const configured = getConfiguredModel(model);
+        // A self-hosted endpoint authenticates however the deployment set it
+        // up, including not at all, so only cloud entries can be short a key.
+        if (!configured || configured.location === "local") return null;
+        if (apiKeyForConfiguredModel(configured, apiKeys)) return null;
+        return {
+            provider,
+            model,
+            detail: `An API key is required to use ${configured.label || model}. Add an API key or select a different tabular review model.`,
+        };
+    }
     if (apiKeys[provider]?.trim()) return null;
     return {
         provider,

--- a/backend/src/routes/tabular.ts
+++ b/backend/src/routes/tabular.ts
@@ -31,11 +31,14 @@ import {
     streamChatWithTools,
     type Provider,
     type UserApiKeys,
+    missingCommitteeApiKeyModels,
 } from "../lib/llm";
 import {
     apiKeyForConfiguredModel,
+    getCommitteeModel,
     getConfiguredModel,
 } from "../lib/llm/registry";
+import type { CommitteeModel } from "../lib/llm/types";
 import { getUserModelSettings } from "../lib/userSettings";
 import {
     checkProjectAccess,
@@ -500,8 +503,27 @@ function providerLabel(provider: Provider): string {
     return "Gemini";
 }
 
-function missingModelApiKey(model: string, apiKeys: UserApiKeys) {
-    const provider = providerForModel(model);
+function missingModelApiKey(
+    model: string,
+    apiKeys: UserApiKeys,
+    committees: CommitteeModel[] = [],
+) {
+    // A committee runs only if every member and its chair can run.
+    const committee = getCommitteeModel(model, committees);
+    if (committee) {
+        const missing = missingCommitteeApiKeyModels(
+            model,
+            apiKeys,
+            committees,
+        );
+        if (!missing.length) return null;
+        return {
+            provider: "committee" as const,
+            model,
+            detail: `Committee ${committee.label || committee.id} cannot run because these models are unavailable or missing API keys: ${missing.join(", ")}. Add the missing API keys or select a different tabular review model.`,
+        };
+    }
+    const provider = providerForModel(model, committees);
     if (provider === "ollama") return null; // local, no key
     if (provider === "openai-compatible") {
         const configured = getConfiguredModel(model);
@@ -1209,11 +1231,15 @@ tabularRouter.post(
                 .status(404)
                 .json({ detail: "Review row not found" });
 
-        const { tabular_model, api_keys } = await getUserModelSettings(
+        const { tabular_model, api_keys, committees } = await getUserModelSettings(
             userId,
             db,
         );
-        const missingKey = missingModelApiKey(tabular_model, api_keys);
+        const missingKey = missingModelApiKey(
+            tabular_model,
+            api_keys,
+            committees,
+        );
         if (missingKey) {
             return void res.status(422).json({
                 code: "missing_api_key",
@@ -1408,8 +1434,12 @@ tabularRouter.post("/:reviewId/generate", requireAuth, async (req, res) => {
     if (columns.length === 0)
         return void res.status(400).json({ detail: "No columns configured" });
 
-    const { tabular_model, api_keys } = await getUserModelSettings(userId, db);
-    const missingKey = missingModelApiKey(tabular_model, api_keys);
+    const { tabular_model, api_keys, committees } = await getUserModelSettings(userId, db);
+    const missingKey = missingModelApiKey(
+            tabular_model,
+            api_keys,
+            committees,
+        );
     if (missingKey) {
         return void res.status(422).json({
             code: "missing_api_key",
@@ -1988,8 +2018,12 @@ tabularRouter.post("/:reviewId/chat", requireAuth, async (req, res) => {
         ),
     };
 
-    const { tabular_model, api_keys } = await getUserModelSettings(userId, db);
-    const missingKey = missingModelApiKey(tabular_model, api_keys);
+    const { tabular_model, api_keys, committees } = await getUserModelSettings(userId, db);
+    const missingKey = missingModelApiKey(
+            tabular_model,
+            api_keys,
+            committees,
+        );
     if (missingKey) {
         return void res.status(422).json({
             code: "missing_api_key",

--- a/backend/src/routes/user.ts
+++ b/backend/src/routes/user.ts
@@ -45,6 +45,13 @@ import {
 } from "../lib/userDataExport";
 import { findProfileUserByEmail } from "../lib/userLookup";
 import {
+    getUserCommittees,
+    normalizeUserCommittees,
+    validateUserCommittees,
+} from "../lib/userCommittees";
+import { configuredModelSummaries } from "../lib/llm/registry";
+import type { CommitteeModel } from "../lib/llm/types";
+import {
     getAllUserRouterModels,
     replaceUserRouterModels,
     ROUTER_SLUGS,
@@ -74,6 +81,7 @@ type UserProfileRow = {
     legal_research_us: boolean | null;
     quick_actions_visible: boolean | null;
     dark_mode: boolean | null;
+    model_committees?: unknown;
 };
 
 function errorMessage(error: unknown): string {
@@ -182,6 +190,11 @@ function mcpOAuthPopupCsp(nonce: string) {
 }
 
 const PROFILE_SELECT =
+    "display_name, organisation, jurisdiction, practice_setting, professional_title, practice_areas, onboarding_version, password_set_at, message_credits_used, credits_reset_date, tier, title_model, tabular_model, mfa_on_login, legal_research_us, quick_actions_visible, dark_mode, model_committees";
+// model_committees is the newest column, so it gets the topmost retry
+// tier: a database missing only it keeps every other live column and
+// reports no committees.
+const PROFILE_SELECT_NO_COMMITTEES =
     "display_name, organisation, jurisdiction, practice_setting, professional_title, practice_areas, onboarding_version, password_set_at, message_credits_used, credits_reset_date, tier, title_model, tabular_model, mfa_on_login, legal_research_us, quick_actions_visible, dark_mode";
 // Deploy-before-migrate tolerance is per column: a database that already has
 // the 20260821 onboarding/password columns but not yet dark_mode must keep
@@ -248,6 +261,26 @@ async function selectProfile(
     // to light. A database old enough to lack the 20260821 columns too
     // fails the full select on one of those instead (they sort earlier in
     // the select list), so this tier is skipped and the tiers below handle it.
+    if (isMissingProfileColumn(cascadeError, "model_committees")) {
+        const noCommitteesQuery = db
+            .from("user_profiles")
+            .select(PROFILE_SELECT_NO_COMMITTEES)
+            .eq("user_id", userId);
+        const noCommittees =
+            mode === "single"
+                ? await noCommitteesQuery.single()
+                : await noCommitteesQuery.maybeSingle();
+        if (!noCommittees.error) {
+            if (noCommittees.data && typeof noCommittees.data === "object") {
+                Object.assign(noCommittees.data as Record<string, unknown>, {
+                    model_committees: [],
+                });
+            }
+            return noCommittees;
+        }
+        cascadeError = noCommittees.error;
+    }
+
     if (isMissingProfileColumn(cascadeError, "dark_mode")) {
         const noDarkQuery = db
             .from("user_profiles")
@@ -521,6 +554,7 @@ function serializeProfile(
         legalResearchUs: row.legal_research_us !== false,
         quickActionsVisible: row.quick_actions_visible !== false,
         darkMode: row.dark_mode === true,
+        modelCommittees: normalizeUserCommittees(row.model_committees),
         ...Object.fromEntries(
             ROUTER_SLUGS.map((slug) => [
                 ROUTER_PROFILE_FIELDS[slug],
@@ -700,6 +734,7 @@ function validateProfilePayload(body: unknown):
         "legalResearchUs",
         "quickActionsVisible",
         "darkMode",
+        "modelCommittees",
         ...ROUTER_SLUGS.map((slug) => ROUTER_PROFILE_FIELDS[slug]),
     ]);
     const invalidField = Object.keys(raw).find(
@@ -724,6 +759,7 @@ function validateProfilePayload(body: unknown):
         legal_research_us?: boolean;
         quick_actions_visible?: boolean;
         dark_mode?: boolean;
+        model_committees?: CommitteeModel[];
         updated_at: string;
     } = { updated_at: new Date().toISOString() };
     const routerModels: Partial<Record<RouterSlug, string[]>> = {};
@@ -771,6 +807,22 @@ function validateProfilePayload(body: unknown):
             return { ok: false, detail: "Unsupported tabularModel" };
         }
         update.tabular_model = resolved;
+    }
+
+    if ("modelCommittees" in raw) {
+        try {
+            update.model_committees = validateUserCommittees(
+                raw.modelCommittees,
+            );
+        } catch (error) {
+            return {
+                ok: false,
+                detail:
+                    error instanceof Error
+                        ? error.message
+                        : "Invalid modelCommittees",
+            };
+        }
     }
 
     if ("titleModel" in raw) {
@@ -1163,6 +1215,21 @@ userRouter.patch(
 );
 
 // GET /user/api-keys
+// Models this user can select beyond the static catalog the client already
+// knows: whatever the deployment declared, plus the user's own committees.
+userRouter.get("/models", requireAuth, async (_req, res) => {
+    const userId = res.locals.userId as string;
+    try {
+        const committees = await getUserCommittees(userId);
+        res.json({
+            models: configuredModelSummaries(committees),
+            committees,
+        });
+    } catch (error) {
+        sendInternalError(res, error);
+    }
+});
+
 userRouter.get("/api-keys", requireAuth, async (_req, res) => {
     const userId = res.locals.userId as string;
     const db = createServerSupabase();

--- a/docs/configured-models.md
+++ b/docs/configured-models.md
@@ -1,0 +1,78 @@
+# Declaring OpenAI-compatible models
+
+Mike ships with a static catalog of hosted models (Anthropic, Google, OpenAI)
+and accepts router-prefixed ids for OpenRouter, the Vercel AI Gateway and
+OpenCode Go. A deployment that also runs a self-hosted or third-party
+OpenAI-compatible endpoint declares it with `MIKE_MODEL_CONFIG_JSON`, without
+a code change.
+
+## Configuration
+
+Set `MIKE_MODEL_CONFIG_JSON` on the backend to a JSON object with a `models`
+array:
+
+```json
+{
+  "models": [
+    {
+      "id": "local-qwen",
+      "label": "Local Qwen 3",
+      "provider": "openai-compatible",
+      "location": "local",
+      "apiModel": "qwen3-32b",
+      "baseUrl": "http://localhost:8000/v1"
+    },
+    {
+      "id": "cloud-deepseek",
+      "label": "DeepSeek",
+      "provider": "openai-compatible",
+      "location": "cloud",
+      "baseUrl": "https://api.deepseek.com/v1",
+      "apiKeyEnv": "DEEPSEEK_API_KEY"
+    }
+  ]
+}
+```
+
+| Field | Required | Meaning |
+| --- | --- | --- |
+| `id` | yes | The id Mike uses everywhere: model pickers, stored preferences, committee members. |
+| `provider` | yes | Must be `openai-compatible`. Hosted providers are already covered by the static catalog and the router prefixes. |
+| `location` | yes | `local` or `cloud`. Also the default for tool-call tolerance (below). |
+| `label` | no | Display name. Defaults to the id. |
+| `apiModel` | no | Model name to send upstream, when it differs from `id`. |
+| `baseUrl` | yes | The endpoint's OpenAI-compatible base URL. |
+| `apiKey` | no | Literal key. Prefer `apiKeyEnv`. |
+| `apiKeyEnv` | no | Environment variable holding the key. |
+| `apiKeyProvider` | no | Use the requesting user's saved key for that provider. |
+| `tolerateTextToolCalls` | no | Override the tolerance default. |
+
+An entry that declares no key at all is treated as needing none, which is
+usually right for a self-hosted endpoint on a private network. Malformed
+entries are dropped; invalid JSON fails loudly at startup.
+
+Declared models are served through the same AI SDK provider layer as
+everything else, so they inherit its transport, retries and streaming.
+
+## Tool-call tolerance
+
+Self-hosted builds of Qwen, DeepSeek and GLM often describe tool calls in
+prose rather than emitting them as structured tool calls, and wrap their
+reasoning in `<think>` tags. Models whose `location` is `local` are therefore
+wrapped in a middleware that:
+
+- routes `<think>` prose to the reasoning channel instead of visible text,
+- suppresses tool markup in the visible text, and
+- converts described tool calls — JSON in `<tool_call>` markers, XML-ish
+  `<function=name>` blocks, DeepSeek DSML invocations, and single-key maps —
+  into real tool calls, repairing malformed JSON where it can.
+
+A tolerant model answering a request that declares tools is served through the
+endpoint's non-streaming path, because these models interleave markup with
+prose in a way a partial stream cannot be reassembled from.
+
+Set `tolerateTextToolCalls` explicitly to turn this on for a cloud endpoint
+that needs it, or off for a local one that behaves properly.
+
+Set `DEBUG_LLM_TOOL_CALLS=1` to log the raw text of a tool call that could not
+be recovered.

--- a/docs/model-committees.md
+++ b/docs/model-committees.md
@@ -1,0 +1,49 @@
+# Model committees
+
+A committee answers one prompt with several models at once and has a chair
+model synthesize their replies into the single answer the user sees. It is
+selected like any other model, from the **Committee** group in the model
+picker.
+
+Users build their own committees under **Settings > Models**; a deployment can
+also declare committees centrally in `MIKE_MODEL_CONFIG_JSON` (see
+[Declaring OpenAI-compatible models](configured-models.md)).
+
+## How a committee runs
+
+1. Every member receives the original system prompt, plus its own optional
+   extra instruction, and answers independently. Members run concurrently.
+2. The chair receives the original request and all member answers, and is
+   instructed to reconcile them without inventing citations or facts that no
+   member provided.
+3. The chair's answer is what the user sees.
+
+Committee mode has no tool-calling loop. When the caller supplies tools — the
+main chat path always does — they are dropped and the members are told so, so
+the answer does not claim document or case-law work it could not do.
+
+Because members are separate model calls, a committee costs roughly the sum of
+its members plus the chair.
+
+## Rules
+
+- Between 2 and 8 members, up to 8 committees per user.
+- A committee may not contain another committee, chair itself, or list itself
+  as a member. Cycles are rejected at request time as well as on save.
+- Every member and the chair must be usable — a committee is hidden from the
+  picker, and refused at request time, when any of them is missing an API key.
+  A committee that half-runs is not a usable answer.
+- Selecting a committee that has since been deleted is an explicit error
+  rather than a silent fallback to another model, because quietly answering
+  with a different model misrepresents which model wrote the response.
+
+## Storage
+
+User committees live in `user_profiles.model_committees` (jsonb, default
+`[]`), added by migration `20260823_02_user_model_committees.sql`. Their ids
+are namespaced with `user-committee/` so they can never collide with a
+deployment-declared committee or a catalog model.
+
+Reads tolerate a database that has not applied the migration yet: a missing
+column reports "no committees" rather than failing every chat and tabular
+request.

--- a/frontend/src/app/(pages)/settings/models/page.tsx
+++ b/frontend/src/app/(pages)/settings/models/page.tsx
@@ -28,6 +28,7 @@ import { isModelAvailable } from "@/app/lib/modelAvailability";
 import { FieldLabel } from "@/app/components/ui/form-field";
 import { SETTINGS_CONTROL_CLASS } from "@/app/components/settings/SettingsTextInput";
 import { SettingsSection } from "../SettingsSection";
+import { CommitteeSettingsSection } from "@/app/components/settings/CommitteeSettingsSection";
 import { useOllamaModels } from "@/app/hooks/useOllamaModels";
 
 type ModelPreferenceField = "titleModel" | "tabularModel";
@@ -147,6 +148,21 @@ export default function ModelPreferencesPage() {
                         />
                     </div>
                 </SettingsSection>
+            </section>
+            <section className="space-y-3">
+                <h2 className="text-2xl font-medium font-serif text-gray-900">
+                    Committees
+                </h2>
+                <CommitteeSettingsSection
+                    options={[
+                        ...MODELS,
+                        ...selectedOpenRouterOptions,
+                        ...selectedVercelOptions,
+                        ...selectedOpenCodeGoOptions,
+                        ...ollamaModels,
+                    ]}
+                    apiKeys={profile?.apiKeys}
+                />
             </section>
         </div>
     );

--- a/frontend/src/app/components/assistant/ChatInput.tsx
+++ b/frontend/src/app/components/assistant/ChatInput.tsx
@@ -626,6 +626,7 @@ export const ChatInput = forwardRef<ChatInputHandle, Props>(function ChatInput(
                                 openRouterModels={profile?.openRouterModels}
                                 vercelModels={profile?.vercelModels}
                                 openCodeGoModels={profile?.openCodeGoModels}
+                                committees={profile?.modelCommittees}
                                 compact={compactControls}
                             />
                             <button

--- a/frontend/src/app/components/assistant/ModelToggle.render.test.tsx
+++ b/frontend/src/app/components/assistant/ModelToggle.render.test.tsx
@@ -178,3 +178,65 @@ describe("ModelToggle OpenCode Go group", () => {
         expect(screen.queryByText("OpenCode Go")).not.toBeInTheDocument();
     });
 });
+
+describe("ModelToggle committee group", () => {
+    const panel = {
+        id: "user-committee/panel",
+        label: "Trademark panel",
+        members: ["claude-opus-5", "gemini-3-flash-preview"],
+        chair: "gpt-5.5",
+    };
+
+    it("offers a committee whose members and chair are all usable", async () => {
+        const user = userEvent.setup();
+        render(
+            <ModelToggle
+                value="gemini-3-flash-preview"
+                onChange={vi.fn()}
+                apiKeys={keys({ claude: true, gemini: true, openai: true })}
+                committees={[panel]}
+            />,
+        );
+
+        await user.click(screen.getByRole("button", { name: "Choose model" }));
+        await user.click(await screen.findByText("Committee"));
+
+        expect(await screen.findByText("Trademark panel")).toBeInTheDocument();
+    });
+
+    it("hides a committee when one member's key is missing", async () => {
+        const user = userEvent.setup();
+        render(
+            <ModelToggle
+                value="gemini-3-flash-preview"
+                onChange={vi.fn()}
+                // No OpenAI key, so the chair cannot run.
+                apiKeys={keys({ claude: true, gemini: true })}
+                committees={[panel]}
+            />,
+        );
+
+        await user.click(screen.getByRole("button", { name: "Choose model" }));
+
+        expect(screen.queryByText("Committee")).not.toBeInTheDocument();
+    });
+
+    it("selects the committee by its id", async () => {
+        const onChange = vi.fn();
+        const user = userEvent.setup();
+        render(
+            <ModelToggle
+                value="gemini-3-flash-preview"
+                onChange={onChange}
+                apiKeys={keys({ claude: true, gemini: true, openai: true })}
+                committees={[panel]}
+            />,
+        );
+
+        await user.click(screen.getByRole("button", { name: "Choose model" }));
+        await user.click(await screen.findByText("Committee"));
+        await user.click(await screen.findByText("Trademark panel"));
+
+        expect(onChange).toHaveBeenCalledWith("user-committee/panel");
+    });
+});

--- a/frontend/src/app/components/assistant/ModelToggle.tsx
+++ b/frontend/src/app/components/assistant/ModelToggle.tsx
@@ -5,7 +5,7 @@ import {
   type ModelToggleOption,
 } from "@/shared/ui/ModelToggleUI";
 import { isModelAvailable } from "@/app/lib/modelAvailability";
-import type { ApiKeyState } from "@/app/lib/mikeApi";
+import type { ApiKeyState, ModelCommittee } from "@/app/lib/mikeApi";
 import { useOllamaModels } from "@/app/hooks/useOllamaModels";
 
 export type ModelOption = ModelToggleOption;
@@ -120,6 +120,8 @@ interface Props {
   openRouterModels?: string[];
   vercelModels?: string[];
   openCodeGoModels?: string[];
+  /** The user's committees, offered as selectable models of their own. */
+  committees?: ModelCommittee[];
   compact?: boolean;
 }
 
@@ -147,6 +149,16 @@ export function openCodeGoModelOptions(models: string[]): ModelOption[] {
   }));
 }
 
+export function committeeModelOptions(
+  committees: ModelCommittee[],
+): ModelOption[] {
+  return committees.map((committee) => ({
+    id: committee.id,
+    label: committee.label || committee.id,
+    group: "Committee",
+  }));
+}
+
 export function ModelToggle({
   value,
   onChange,
@@ -155,6 +167,7 @@ export function ModelToggle({
   openRouterModels = [],
   vercelModels = [],
   openCodeGoModels = [],
+  committees = [],
   compact = false,
 }: Props) {
   const ollamaModels = useOllamaModels();
@@ -163,15 +176,27 @@ export function ModelToggle({
     ...openRouterModelOptions(openRouterModels),
     ...vercelModelOptions(vercelModels),
     ...openCodeGoModelOptions(openCodeGoModels),
+    ...committeeModelOptions(committees),
     ...ollamaModels.map((model) => ({
       ...model,
       label: modelDisplayName(model.id),
     })),
   ];
+  const committeeById = new Map(
+    committees.map((committee) => [committee.id, committee] as const),
+  );
   const availableModels = models.filter((model) => {
     if (model.group === "Local") return true;
     if (apiKeysLoading) return false; // nothing offered until known
     if (!apiKeys) return true; // unknown after a failed load → fail open
+    // A committee is only offered when every member and its chair can run;
+    // half a committee is not a usable answer.
+    const committee = committeeById.get(model.id);
+    if (committee) {
+      return [...committee.members, committee.chair].every((member) =>
+        isModelAvailable(member, apiKeys),
+      );
+    }
     return isModelAvailable(model.id, apiKeys);
   });
   const selected = availableModels.find((model) => model.id === value);

--- a/frontend/src/app/components/settings/CommitteeSettingsSection.tsx
+++ b/frontend/src/app/components/settings/CommitteeSettingsSection.tsx
@@ -1,0 +1,386 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { Check, ChevronDown, Loader2, Plus, Trash2 } from "lucide-react";
+import {
+    DropdownMenu,
+    DropdownMenuLabel,
+    DropdownMenuSeparator,
+    DropdownMenuTrigger,
+} from "@/app/components/ui/dropdown-menu";
+import {
+    LiquidDropdownContent,
+    LiquidDropdownItem,
+} from "@/app/components/ui/liquid-dropdown";
+import { FieldLabel } from "@/app/components/ui/form-field";
+import { OptionPill } from "@/app/components/ui/option-pill";
+import { SETTINGS_CONTROL_CLASS } from "@/app/components/settings/SettingsTextInput";
+import { useUserProfile } from "@/app/contexts/UserProfileContext";
+import {
+    MAX_COMMITTEE_MEMBERS,
+    MAX_USER_COMMITTEES,
+    MIN_COMMITTEE_MEMBERS,
+    USER_COMMITTEE_PREFIX,
+    type ApiKeyState,
+    type ModelCommittee,
+} from "@/app/lib/mikeApi";
+import type { ModelOption } from "@/app/components/assistant/ModelToggle";
+import { MODEL_TOGGLE_GROUPS } from "@/shared/ui/ModelToggleUI";
+import { isModelAvailable } from "@/app/lib/modelAvailability";
+import { SettingsSection } from "@/app/(pages)/settings/SettingsSection";
+
+const MAX_LABEL_LENGTH = 80;
+
+function newCommitteeId(): string {
+    const unique =
+        typeof crypto !== "undefined" && "randomUUID" in crypto
+            ? crypto.randomUUID()
+            : `${Date.now()}-${Math.random().toString(16).slice(2)}`;
+    return `${USER_COMMITTEE_PREFIX}${unique}`;
+}
+
+/** What stops a committee from being saved, or null when it is ready. */
+function committeeProblem(committee: ModelCommittee): string | null {
+    if (!committee.label.trim()) return "Give the committee a name.";
+    if (committee.label.length > MAX_LABEL_LENGTH) {
+        return `Names must be ${MAX_LABEL_LENGTH} characters or fewer.`;
+    }
+    if (committee.members.length < MIN_COMMITTEE_MEMBERS) {
+        return `Add at least ${MIN_COMMITTEE_MEMBERS} members.`;
+    }
+    if (!committee.chair) return "Choose a chair model.";
+    return null;
+}
+
+function ModelSelect({
+    value,
+    placeholder,
+    options,
+    exclude = [],
+    onChange,
+    ariaLabel,
+}: {
+    value: string;
+    placeholder: string;
+    options: ModelOption[];
+    exclude?: string[];
+    onChange: (id: string) => void;
+    ariaLabel: string;
+}) {
+    const [isOpen, setIsOpen] = useState(false);
+    const choices = options.filter((option) => !exclude.includes(option.id));
+    const selected = choices.find((option) => option.id === value);
+    const groups = MODEL_TOGGLE_GROUPS.flatMap((group) => {
+        const items = choices.filter((option) => option.group === group);
+        return items.length ? [{ group, items }] : [];
+    });
+
+    return (
+        <DropdownMenu onOpenChange={setIsOpen}>
+            <DropdownMenuTrigger asChild>
+                <button
+                    type="button"
+                    aria-label={ariaLabel}
+                    disabled={choices.length === 0}
+                    className={`flex h-9 items-center justify-between gap-2 hover:bg-gray-200/70 ${SETTINGS_CONTROL_CLASS}`}
+                >
+                    <span className="truncate text-gray-900">
+                        {selected?.label ??
+                            (choices.length ? placeholder : "No models available")}
+                    </span>
+                    <ChevronDown
+                        className={`h-3.5 w-3.5 shrink-0 text-gray-500 transition-transform duration-200 ${isOpen ? "rotate-180" : ""}`}
+                    />
+                </button>
+            </DropdownMenuTrigger>
+            <LiquidDropdownContent
+                className="z-50"
+                style={{ width: "var(--radix-dropdown-menu-trigger-width)" }}
+                align="start"
+            >
+                {groups.map(({ group, items }, groupIndex) => (
+                    <div key={group}>
+                        {groupIndex > 0 && <DropdownMenuSeparator />}
+                        <DropdownMenuLabel className="text-[10px] uppercase tracking-wider text-gray-400">
+                            {group}
+                        </DropdownMenuLabel>
+                        {items.map((option) => (
+                            <LiquidDropdownItem
+                                key={option.id}
+                                className="cursor-pointer"
+                                onSelect={() => onChange(option.id)}
+                            >
+                                <span className="flex-1">{option.label}</span>
+                                {option.id === value && (
+                                    <Check className="ml-1 h-3.5 w-3.5 text-gray-600" />
+                                )}
+                            </LiquidDropdownItem>
+                        ))}
+                    </div>
+                ))}
+            </LiquidDropdownContent>
+        </DropdownMenu>
+    );
+}
+
+export function CommitteeSettingsSection({
+    options,
+    apiKeys,
+}: {
+    options: ModelOption[];
+    apiKeys?: ApiKeyState;
+}) {
+    const { profile, updateModelCommittees } = useUserProfile();
+    const saved = useMemo(
+        () => profile?.modelCommittees ?? [],
+        [profile?.modelCommittees],
+    );
+    const [drafts, setDrafts] = useState<ModelCommittee[]>(saved);
+    const [syncedFrom, setSyncedFrom] = useState(saved);
+    const [savingId, setSavingId] = useState<string | null>(null);
+    const [error, setError] = useState<string | null>(null);
+
+    // Follow the profile whenever it reloads. Local edits are per-card and
+    // committed explicitly, so there is no half-typed state to protect.
+    if (syncedFrom !== saved) {
+        setSyncedFrom(saved);
+        setDrafts(saved);
+    }
+
+    // A committee can only contain models the user can actually run, or it
+    // would be offered in the picker and then fail at request time.
+    const selectable = useMemo(
+        () =>
+            options.filter((option) =>
+                option.group === "Local"
+                    ? true
+                    : apiKeys
+                      ? isModelAvailable(option.id, apiKeys)
+                      : false,
+            ),
+        [options, apiKeys],
+    );
+    const labelFor = (id: string) =>
+        selectable.find((option) => option.id === id)?.label ?? id;
+
+    const patch = (id: string, changes: Partial<ModelCommittee>) => {
+        setError(null);
+        setDrafts((current) =>
+            current.map((committee) =>
+                committee.id === id ? { ...committee, ...changes } : committee,
+            ),
+        );
+    };
+
+    const persist = async (next: ModelCommittee[], id: string | null) => {
+        setSavingId(id);
+        const ok = await updateModelCommittees(next);
+        setSavingId(null);
+        if (!ok) {
+            setError("Could not save your committees. Try again.");
+            return false;
+        }
+        setError(null);
+        return true;
+    };
+
+    const addCommittee = () => {
+        setError(null);
+        setDrafts((current) => [
+            ...current,
+            {
+                id: newCommitteeId(),
+                label: "",
+                members: [],
+                chair: "",
+                strategy: "synthesize",
+            },
+        ]);
+    };
+
+    const saveCommittee = async (committee: ModelCommittee) => {
+        const problem = committeeProblem(committee);
+        if (problem) {
+            setError(problem);
+            return;
+        }
+        // Only complete committees are sent; a half-built card stays local.
+        const next = drafts
+            .map((entry) => (entry.id === committee.id ? committee : entry))
+            .filter((entry) => committeeProblem(entry) === null);
+        await persist(next, committee.id);
+    };
+
+    const removeCommittee = async (id: string) => {
+        const next = drafts
+            .filter((committee) => committee.id !== id)
+            .filter((committee) => committeeProblem(committee) === null);
+        const wasSaved = saved.some((committee) => committee.id === id);
+        setDrafts((current) =>
+            current.filter((committee) => committee.id !== id),
+        );
+        if (wasSaved) await persist(next, id);
+    };
+
+    return (
+        <SettingsSection>
+            <div className="space-y-4 px-4 py-5">
+                <div>
+                    <FieldLabel>Committees</FieldLabel>
+                    <p className="text-xs text-gray-400">
+                        A committee sends your message to several models at
+                        once and has a chair model combine their answers into
+                        one. Committees appear in the model picker alongside
+                        individual models.
+                    </p>
+                </div>
+
+                {drafts.length === 0 && (
+                    <p className="text-sm text-gray-500">
+                        You have not created any committees yet.
+                    </p>
+                )}
+
+                {drafts.map((committee) => {
+                    const problem = committeeProblem(committee);
+                    const isSaving = savingId === committee.id;
+                    const memberOptions = committee.chair
+                        ? [committee.chair, ...committee.members]
+                        : committee.members;
+                    return (
+                        <div
+                            key={committee.id}
+                            className="space-y-3 rounded-xl border border-gray-200/70 p-3"
+                        >
+                            <div className="flex items-start gap-2">
+                                <input
+                                    type="text"
+                                    value={committee.label}
+                                    maxLength={MAX_LABEL_LENGTH}
+                                    placeholder="Committee name"
+                                    aria-label="Committee name"
+                                    onChange={(event) =>
+                                        patch(committee.id, {
+                                            label: event.target.value,
+                                        })
+                                    }
+                                    className={`h-9 flex-1 ${SETTINGS_CONTROL_CLASS}`}
+                                />
+                                <button
+                                    type="button"
+                                    aria-label={`Delete ${committee.label || "committee"}`}
+                                    title="Delete committee"
+                                    disabled={isSaving}
+                                    onClick={() =>
+                                        void removeCommittee(committee.id)
+                                    }
+                                    className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg text-gray-400 transition-colors hover:bg-gray-200/70 hover:text-gray-700 disabled:opacity-40"
+                                >
+                                    <Trash2 className="h-4 w-4" />
+                                </button>
+                            </div>
+
+                            <div>
+                                <FieldLabel>Members</FieldLabel>
+                                {committee.members.length > 0 && (
+                                    <div className="mb-2 mt-1 flex flex-wrap gap-1.5">
+                                        {committee.members.map((member) => (
+                                            <OptionPill
+                                                key={member}
+                                                disabled={isSaving}
+                                                aria-label={`Remove ${labelFor(member)}`}
+                                                title={`Remove ${labelFor(member)}`}
+                                                onClick={() =>
+                                                    patch(committee.id, {
+                                                        members:
+                                                            committee.members.filter(
+                                                                (entry) =>
+                                                                    entry !==
+                                                                    member,
+                                                            ),
+                                                    })
+                                                }
+                                            >
+                                                {labelFor(member)}
+                                            </OptionPill>
+                                        ))}
+                                    </div>
+                                )}
+                                {committee.members.length <
+                                    MAX_COMMITTEE_MEMBERS && (
+                                    <ModelSelect
+                                        value=""
+                                        placeholder="Add a member"
+                                        ariaLabel="Add a committee member"
+                                        options={selectable}
+                                        exclude={memberOptions}
+                                        onChange={(id) =>
+                                            patch(committee.id, {
+                                                members: [
+                                                    ...committee.members,
+                                                    id,
+                                                ],
+                                            })
+                                        }
+                                    />
+                                )}
+                            </div>
+
+                            <div>
+                                <FieldLabel>Chair</FieldLabel>
+                                <p className="mb-1 text-xs text-gray-400">
+                                    Combines the members&apos; answers into the
+                                    final response.
+                                </p>
+                                <ModelSelect
+                                    value={committee.chair}
+                                    placeholder="Choose a chair"
+                                    ariaLabel="Committee chair model"
+                                    options={selectable}
+                                    exclude={committee.members}
+                                    onChange={(id) =>
+                                        patch(committee.id, { chair: id })
+                                    }
+                                />
+                            </div>
+
+                            <div className="flex items-center justify-between gap-3">
+                                <p className="text-xs text-gray-400">
+                                    {problem ?? "Ready to use."}
+                                </p>
+                                <button
+                                    type="button"
+                                    disabled={isSaving || problem !== null}
+                                    onClick={() => void saveCommittee(committee)}
+                                    className="flex h-8 items-center gap-1.5 rounded-lg bg-gray-900 px-3 text-xs font-medium text-white transition-colors hover:bg-gray-700 disabled:cursor-default disabled:opacity-40"
+                                >
+                                    {isSaving && (
+                                        <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                                    )}
+                                    Save committee
+                                </button>
+                            </div>
+                        </div>
+                    );
+                })}
+
+                {error && (
+                    <p role="alert" className="text-xs text-red-600">
+                        {error}
+                    </p>
+                )}
+
+                {drafts.length < MAX_USER_COMMITTEES && (
+                    <button
+                        type="button"
+                        onClick={addCommittee}
+                        className="flex h-9 items-center gap-1.5 rounded-lg px-3 text-sm text-gray-600 transition-colors hover:bg-gray-200/70 hover:text-gray-900"
+                    >
+                        <Plus className="h-4 w-4" />
+                        New committee
+                    </button>
+                )}
+            </div>
+        </SettingsSection>
+    );
+}

--- a/frontend/src/app/components/tabular/TRChatPanel.tsx
+++ b/frontend/src/app/components/tabular/TRChatPanel.tsx
@@ -41,7 +41,7 @@ import {
     isModelAvailable,
     type ModelProvider,
 } from "@/app/lib/modelAvailability";
-import type { ApiKeyState } from "@/app/lib/mikeApi";
+import type { ApiKeyState, ModelCommittee } from "@/app/lib/mikeApi";
 import {
     LIQUID_GLASS_SELECTED_CLASS,
     LIQUID_GLASS_HOVER_CLASS,
@@ -442,6 +442,7 @@ function TRChatInput({
     openRouterModels,
     vercelModels,
     openCodeGoModels,
+    committees,
     onHeightChange,
 }: {
     isLoading: boolean;
@@ -454,6 +455,7 @@ function TRChatInput({
     openRouterModels?: string[];
     vercelModels?: string[];
     openCodeGoModels?: string[];
+    committees?: ModelCommittee[];
     onHeightChange: (height: number) => void;
 }) {
     const [value, setValue] = useState("");
@@ -543,6 +545,7 @@ function TRChatInput({
                         openRouterModels={openRouterModels}
                         vercelModels={vercelModels}
                         openCodeGoModels={openCodeGoModels}
+                        committees={committees}
                     />
                     <button
                         type="button"
@@ -1933,6 +1936,7 @@ export function TRChatPanel({
                 openRouterModels={profile?.openRouterModels}
                 vercelModels={profile?.vercelModels}
                 openCodeGoModels={profile?.openCodeGoModels}
+                committees={profile?.modelCommittees}
                 onHeightChange={setInputHeight}
             />
 

--- a/frontend/src/app/contexts/UserProfileContext.tsx
+++ b/frontend/src/app/contexts/UserProfileContext.tsx
@@ -12,6 +12,7 @@ import { useAuth } from "@/app/contexts/AuthContext";
 import {
     type ApiKeyState,
     type ApiKeyProvider,
+    type ModelCommittee,
     type PersonalisationDetails,
     type PracticeSetting,
     type ProfessionalTitle,
@@ -49,6 +50,7 @@ interface UserProfile {
     vercelModels: string[];
     openCodeGoModels: string[];
     darkMode: boolean;
+    modelCommittees: ModelCommittee[];
     apiKeys: ApiKeyState;
 }
 
@@ -78,6 +80,7 @@ interface UserProfileContextType {
         field: "titleModel" | "tabularModel",
         value: string,
     ) => Promise<boolean>;
+    updateModelCommittees: (committees: ModelCommittee[]) => Promise<boolean>;
     updateMfaOnLogin: (enabled: boolean) => Promise<boolean>;
     updateLegalResearchUs: (enabled: boolean) => Promise<boolean>;
     updateQuickActionsVisible: (visible: boolean) => Promise<boolean>;
@@ -152,6 +155,9 @@ function toProfile(data: ApiUserProfile): UserProfile {
         openCodeGoModels: Array.isArray(profile.openCodeGoModels)
             ? profile.openCodeGoModels
             : [],
+        modelCommittees: Array.isArray(profile.modelCommittees)
+            ? profile.modelCommittees
+            : [],
         apiKeys,
     };
 }
@@ -210,6 +216,7 @@ export function UserProfileProvider({ children }: { children: ReactNode }) {
                 vercelModels: [],
                 openCodeGoModels: [],
                 darkMode: false,
+                modelCommittees: [],
                 apiKeys: emptyApiKeys(),
             });
         } finally {
@@ -315,6 +322,24 @@ export function UserProfileProvider({ children }: { children: ReactNode }) {
             try {
                 const updated = await updateUserProfile({
                     [field]: value,
+                });
+                setProfile((prev) =>
+                    prev ? { ...prev, ...toProfile(updated) } : null,
+                );
+                return true;
+            } catch {
+                return false;
+            }
+        },
+        [user],
+    );
+
+    const updateModelCommittees = useCallback(
+        async (committees: ModelCommittee[]): Promise<boolean> => {
+            if (!user) return false;
+            try {
+                const updated = await updateUserProfile({
+                    modelCommittees: committees,
                 });
                 setProfile((prev) =>
                     prev ? { ...prev, ...toProfile(updated) } : null,
@@ -512,6 +537,7 @@ export function UserProfileProvider({ children }: { children: ReactNode }) {
                 updatePersonalisation,
                 syncPasswordSet,
                 updateModelPreference,
+                updateModelCommittees,
                 updateMfaOnLogin,
                 updateLegalResearchUs,
                 updateQuickActionsVisible,

--- a/frontend/src/app/lib/mikeApi.ts
+++ b/frontend/src/app/lib/mikeApi.ts
@@ -407,6 +407,27 @@ export interface PersonalisationDetails {
     practiceAreas?: string[];
 }
 
+/**
+ * A committee answers one prompt with several models and has a chair model
+ * synthesize their replies into the single answer shown to the user.
+ */
+export interface ModelCommittee {
+    id: string;
+    label: string;
+    members: string[];
+    chair: string;
+    strategy?: "synthesize";
+}
+
+export const USER_COMMITTEE_PREFIX = "user-committee/";
+export const MAX_USER_COMMITTEES = 8;
+export const MAX_COMMITTEE_MEMBERS = 8;
+export const MIN_COMMITTEE_MEMBERS = 2;
+
+export function isCommitteeId(model: string | null | undefined): boolean {
+    return !!model?.startsWith(USER_COMMITTEE_PREFIX);
+}
+
 export interface UserProfile {
     displayName: string | null;
     organisation: string | null;
@@ -430,6 +451,7 @@ export interface UserProfile {
     openRouterModels: string[];
     vercelModels: string[];
     openCodeGoModels: string[];
+    modelCommittees: ModelCommittee[];
     apiKeyStatus: ApiKeyStatus;
 }
 
@@ -526,6 +548,24 @@ export async function lookupUserByEmail(
     );
 }
 
+export interface ConfiguredModelSummary {
+    id: string;
+    label: string;
+    provider: string;
+    location: "cloud" | "local" | "committee";
+}
+
+/**
+ * Models beyond the static catalog the client already knows: whatever the
+ * deployment declared, plus the user's own committees.
+ */
+export async function getUserModels(): Promise<{
+    models: ConfiguredModelSummary[];
+    committees: ModelCommittee[];
+}> {
+    return apiRequest("/user/models");
+}
+
 export async function updateUserProfile(payload: {
     displayName?: string | null;
     organisation?: string | null;
@@ -541,6 +581,7 @@ export async function updateUserProfile(payload: {
     openRouterModels?: string[];
     vercelModels?: string[];
     openCodeGoModels?: string[];
+    modelCommittees?: ModelCommittee[];
 }): Promise<UserProfile> {
     return apiRequest<UserProfile>("/user/profile", {
         method: "PATCH",

--- a/frontend/src/shared/ui/ModelToggleUI.tsx
+++ b/frontend/src/shared/ui/ModelToggleUI.tsx
@@ -22,6 +22,7 @@ export type ModelToggleGroup =
   | "OpenRouter"
   | "Vercel AI Gateway"
   | "OpenCode Go"
+  | "Committee"
   | "Local";
 
 export interface ModelToggleOption {
@@ -37,6 +38,7 @@ export const MODEL_TOGGLE_GROUPS: readonly ModelToggleGroup[] = [
   "OpenRouter",
   "Vercel AI Gateway",
   "OpenCode Go",
+  "Committee",
   "Local",
 ];
 


### PR DESCRIPTION
## Summary

Adds user-defined model committees: a committee answers one prompt with several
models at once and has a chair model synthesize their replies into the single
answer the user sees. Committees are built under **Settings > Models**, stored
on the profile (`user_profiles.model_committees`), and selected from a
**Committee** group in the model picker like any other model.

Stacked on #339 — the first commit here is that PR's foundation. Retarget or
rebase once it merges.

## What changed

**Backend**
- `lib/llm/committee.ts` — members run **concurrently** against the ordinary
  provider layer, then the chair synthesizes. Guards against self-chairing,
  self-membership and cycles.
- `lib/userCommittees.ts` — normalization for reads (malformed rows are
  dropped, never thrown, so a bad row cannot lock a user out of Settings) and
  strict validation for writes (max 8 committees, 2–8 members).
- `lib/llm/models.ts` — `missingCommitteeApiKeyModels` / `modelHasApiKey` /
  `resolveUsableModel`: availability resolves recursively through a
  committee's members and chair.
- `lib/routerModels.ts` — `resolveRequestedModel` recognises committee ids and
  gates them on availability, taking committees the caller already loaded so
  no request reads the profile twice.
- `lib/userSettings.ts`, `lib/chat/streaming.ts`, `routes/chat.ts`,
  `routes/tabular.ts` — committees are loaded once with the rest of the
  profile and threaded to dispatch.
- `routes/user.ts` — `modelCommittees` on the profile (select / serialize /
  PATCH) plus `GET /user/models`. Profile reads get their own retry tier, so a
  database without the column keeps every other live column.
- `migrations/20260823_02_user_model_committees.sql` + `schema.sql`.

**Frontend**
- `components/settings/CommitteeSettingsSection.tsx` — create, edit and delete
  committees. Only models the user can actually run are offered as members.
- `ModelToggle` — a Committee group, shown only when every member and the
  chair is usable.
- `mikeApi` / `UserProfileContext` — committee types, profile state, save.

## Design notes

**Availability is all-or-nothing.** A committee is hidden from the picker and
refused at request time unless every member and its chair is usable. Half a
committee is not a usable answer.

**A deleted committee is an explicit error,** not a silent fallback to another
model — quietly answering with a different model misrepresents which model
wrote the response.

**No tool-calling loop.** When the caller supplies tools (the main chat path
always does) they are dropped and the members are told so, rather than being
left to claim document or case-law work they could not do.

**Cost.** Members are separate model calls, so a committee costs roughly the
sum of its members plus the chair. Running them concurrently keeps the latency
close to the slowest member instead of the sum.

## Why

Different models disagree in useful ways on legal questions. A committee makes
that disagreement visible to a synthesizing model rather than making the user
run the same prompt several times by hand.

## Testing

- `backend`: `tsc --noEmit` clean; `vitest run` — **789 passed, 25 skipped**
  (+25 over #339's foundation, covering committee dispatch, concurrency,
  cycle/self-reference guards, and committee validation).
- `frontend`: `tsc --noEmit` clean; `npm run lint` **0 errors**; `vitest run` —
  **564 passed**, 14 failed. All 14 failures are pre-existing on `main`
  (`mikeApi.test.ts` Blob handling, `useSelectedModel`,
  `ChatInput.modelSelection`) and were confirmed against the baseline before
  these changes.
- Migration follows the dated convention with `schema.sql` updated to match.

28 files changed in this commit (1681 insertions); 37 files and 3498 insertions
including #339's foundation.
