### PR TITLE
feat(chat): highlight a response and add the excerpt to the chat

### DIFF
--- a/frontend/src/app/(pages)/projects/[id]/assistant/chat/[chatId]/page.tsx
+++ b/frontend/src/app/(pages)/projects/[id]/assistant/chat/[chatId]/page.tsx
@@ -61,6 +61,8 @@ import type {
 } from "@/app/components/shared/types";
 import { expandCitationToEntries } from "@/app/components/shared/types";
 import { resolveDocumentViewType } from "@/app/lib/documentViewType";
+import { useQuotableSelection } from "@/app/hooks/useQuotableSelection";
+import { QuoteSelectionPopup } from "@/app/components/shared/QuoteSelectionPopup";
 import {
     INITIAL_FOLDER_DELETE_DIALOG_STATE,
     clearDeletedDocumentId,
@@ -542,6 +544,19 @@ export default function ProjectAssistantChatPage({ params }: Props) {
             });
         },
         [activeTab, handleChat],
+    );
+
+    // Highlighting inside an assistant response offers "Add to Chat", scoped
+    // to this page's own message scroller.
+    const { selection: quotableSelection, clear: clearQuotableSelection } =
+        useQuotableSelection(messagesContainerRef);
+
+    const addQuotedExcerpt = useCallback(
+        (text: string) => {
+            chatInputRef.current?.addQuotedExcerpt(text);
+            clearQuotableSelection();
+        },
+        [clearQuotableSelection],
     );
 
     const handleDocClick = (doc: Document) => {
@@ -1443,6 +1458,10 @@ export default function ProjectAssistantChatPage({ params }: Props) {
                     </div>
                 </div>
             </div>
+            <QuoteSelectionPopup
+                selection={quotableSelection}
+                onAdd={addQuotedExcerpt}
+            />
             <OwnerOnlyPopup
                 open={!!ownerOnlyAction}
                 action={ownerOnlyAction ?? undefined}

--- a/frontend/src/app/components/assistant/ChatInput.quotedExcerpts.test.tsx
+++ b/frontend/src/app/components/assistant/ChatInput.quotedExcerpts.test.tsx
@@ -25,10 +25,20 @@ vi.mock("@/app/lib/modelAvailability", () => ({
 }));
 
 // Keep the real module's constants — useSelectedModel imports
-// DEFAULT_MODEL_ID/ALLOWED_MODEL_IDS from it — but drop the widget.
+// ALLOWED_MODEL_IDS from it — but drop the widget.
 vi.mock("./ModelToggle", async (importOriginal) => ({
     ...(await importOriginal<typeof import("./ModelToggle")>()),
     ModelToggle: () => null,
+}));
+
+// There is no default model any more: an unselected composer refuses to send
+// before it reaches the excerpt fold. These cases are about the excerpt
+// plumbing, not model selection, so pin a resolvable selection the way the
+// sibling composer suites do.
+vi.mock("@/app/hooks/useSelectedModel", async (importOriginal) => ({
+    ...(await importOriginal<typeof import("@/app/hooks/useSelectedModel")>()),
+    useSelectedModel: () => ["claude-sonnet-4-6", vi.fn()],
+    useSelectedReasoning: () => ["high", vi.fn()],
 }));
 vi.mock("./AddDocButton", () => ({ AddDocButton: () => null }));
 vi.mock("./UploadOverlay", () => ({ UploadOverlay: () => null }));

--- a/frontend/src/app/components/assistant/ChatInput.quotedExcerpts.test.tsx
+++ b/frontend/src/app/components/assistant/ChatInput.quotedExcerpts.test.tsx
@@ -1,0 +1,191 @@
+import { createRef } from "react";
+import { act, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useUserProfile } from "@/app/contexts/UserProfileContext";
+import { ChatInput, type ChatInputHandle } from "./ChatInput";
+import {
+    MAX_QUOTED_EXCERPT_CHARS,
+    parseQuotedMessageContent,
+} from "@/app/lib/quotedExcerpts";
+
+vi.mock("@/app/lib/mikeApi", () => ({
+    listWorkflows: vi.fn(async () => []),
+    uploadProjectDocument: vi.fn(),
+    uploadStandaloneDocument: vi.fn(),
+}));
+
+vi.mock("@/app/contexts/UserProfileContext", () => ({
+    useUserProfile: vi.fn(),
+}));
+
+vi.mock("@/app/lib/modelAvailability", () => ({
+    getModelProvider: vi.fn(),
+    isModelAvailable: vi.fn(() => true),
+}));
+
+// Keep the real module's constants — useSelectedModel imports
+// DEFAULT_MODEL_ID/ALLOWED_MODEL_IDS from it — but drop the widget.
+vi.mock("./ModelToggle", async (importOriginal) => ({
+    ...(await importOriginal<typeof import("./ModelToggle")>()),
+    ModelToggle: () => null,
+}));
+vi.mock("./AddDocButton", () => ({ AddDocButton: () => null }));
+vi.mock("./UploadOverlay", () => ({ UploadOverlay: () => null }));
+vi.mock("../shared/FileTypeIcon", () => ({ FileTypeIcon: () => null }));
+vi.mock("../modals/AddDocumentsModal", () => ({
+    AddDocumentsModal: () => null,
+}));
+vi.mock("./AssistantWorkflowModal", () => ({
+    AssistantWorkflowModal: () => null,
+}));
+vi.mock("../popups/ApiKeyMissingPopup", () => ({
+    ApiKeyMissingPopup: () => null,
+}));
+
+class ResizeObserverMock {
+    observe() {}
+    disconnect() {}
+}
+
+function mockProfile() {
+    vi.mocked(useUserProfile).mockReturnValue({
+        profile: {
+            openRouterModels: [],
+            vercelModels: [],
+            openCodeGoModels: [],
+            apiKeys: undefined,
+        },
+        loading: false,
+        apiKeysDegraded: false,
+    } as unknown as ReturnType<typeof useUserProfile>);
+}
+
+function renderComposer() {
+    const onSubmit = vi.fn();
+    const ref = createRef<ChatInputHandle>();
+    render(
+        <ChatInput
+            ref={ref}
+            onSubmit={onSubmit}
+            onCancel={vi.fn()}
+            isLoading={false}
+        />,
+    );
+    return { onSubmit, ref };
+}
+
+const attach = (ref: React.RefObject<ChatInputHandle | null>, text: string) =>
+    act(() => {
+        ref.current!.addQuotedExcerpt(text);
+    });
+
+const send = async (text: string) => {
+    const textarea = screen.getByRole("combobox");
+    await userEvent.type(textarea, text);
+    await userEvent.click(screen.getByRole("button", { name: "Send message" }));
+};
+
+describe("ChatInput quoted excerpts", () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        window.localStorage.clear();
+        vi.stubGlobal("ResizeObserver", ResizeObserverMock);
+        mockProfile();
+    });
+
+    it("shows an attached excerpt as a chip above the composer", () => {
+        const { ref } = renderComposer();
+        attach(ref, "  the   indemnity clause  ");
+        // Normalized on the way in.
+        expect(screen.getByText("the indemnity clause")).toBeInTheDocument();
+        expect(screen.getByText("Quoted from response")).toBeInTheDocument();
+    });
+
+    it("stacks multiple excerpts", () => {
+        const { ref } = renderComposer();
+        attach(ref, "first point");
+        attach(ref, "second point");
+        expect(screen.getAllByRole("listitem")).toHaveLength(2);
+    });
+
+    it("does not attach the same excerpt twice", () => {
+        const { ref } = renderComposer();
+        attach(ref, "same passage");
+        attach(ref, "same passage");
+        expect(screen.getAllByRole("listitem")).toHaveLength(1);
+    });
+
+    it("ignores a whitespace-only selection", () => {
+        const { ref } = renderComposer();
+        attach(ref, "   \n  ");
+        expect(screen.queryByRole("listitem")).toBeNull();
+    });
+
+    it("removes a chip when its remove button is clicked", async () => {
+        const { ref } = renderComposer();
+        attach(ref, "first point");
+        attach(ref, "second point");
+        await userEvent.click(
+            screen.getByRole("button", { name: "Remove quoted excerpt 1" }),
+        );
+        expect(screen.getAllByRole("listitem")).toHaveLength(1);
+        expect(screen.getByText("second point")).toBeInTheDocument();
+        expect(screen.queryByText("first point")).toBeNull();
+    });
+
+    it("caps an over-long excerpt and says so", () => {
+        const { ref } = renderComposer();
+        attach(ref, "word ".repeat(MAX_QUOTED_EXCERPT_CHARS));
+        expect(screen.getByRole("status")).toHaveTextContent(
+            "Excerpt shortened to 4,000 characters.",
+        );
+        expect(
+            screen.getByRole("listitem").textContent?.length,
+        ).toBeLessThan(MAX_QUOTED_EXCERPT_CHARS + 100);
+    });
+
+    it("sends the typed text unchanged when nothing is attached", async () => {
+        const { onSubmit } = renderComposer();
+        await send("plain question");
+        expect(onSubmit).toHaveBeenCalledWith(
+            expect.objectContaining({ role: "user", content: "plain question" }),
+        );
+    });
+
+    it("prefixes attached excerpts onto the outgoing message content", async () => {
+        const { onSubmit, ref } = renderComposer();
+        attach(ref, "the indemnity clause");
+        attach(ref, "the arbitration clause");
+        await send("how do these interact?");
+
+        const content = onSubmit.mock.calls[0][0].content as string;
+        expect(parseQuotedMessageContent(content)).toEqual({
+            excerpts: ["the indemnity clause", "the arbitration clause"],
+            body: "how do these interact?",
+        });
+        // The excerpts travel inside `content`; no new request field.
+        expect(Object.keys(onSubmit.mock.calls[0][0])).not.toContain(
+            "quotedExcerpts",
+        );
+    });
+
+    it("clears the chips after sending", async () => {
+        const { ref } = renderComposer();
+        attach(ref, "an excerpt");
+        await send("question");
+        await waitFor(() =>
+            expect(screen.queryByRole("listitem")).toBeNull(),
+        );
+        expect(screen.queryByRole("status")).toBeNull();
+    });
+
+    it("keeps the chips when the send is refused for an empty draft", async () => {
+        const { onSubmit, ref } = renderComposer();
+        attach(ref, "an excerpt");
+        const textarea = screen.getByRole("combobox");
+        await userEvent.type(textarea, "{Enter}");
+        expect(onSubmit).not.toHaveBeenCalled();
+        expect(screen.getByRole("listitem")).toBeInTheDocument();
+    });
+});

--- a/frontend/src/app/components/assistant/ChatInput.tsx
+++ b/frontend/src/app/components/assistant/ChatInput.tsx
@@ -67,9 +67,22 @@ import {
     partitionSupportedDocumentFiles,
 } from "@/app/lib/documentUploadValidation";
 import { userFacingApiError } from "@/app/lib/userFacingError";
+import {
+    buildQuotedMessageContent,
+    MAX_QUOTED_EXCERPT_CHARS,
+    prepareExcerpt,
+} from "@/app/lib/quotedExcerpts";
+import { QuotedExcerptChips } from "../shared/QuotedExcerptChip";
 
 export interface ChatInputHandle {
     addDoc: (doc: Document) => void;
+    /**
+     * Attach a highlighted excerpt of an assistant response as quoted
+     * context for the next message. Imperative for the same reason `addDoc`
+     * is: the composer owns the draft, and the surface that captured the
+     * selection has no business duplicating the draft state.
+     */
+    addQuotedExcerpt: (raw: string) => void;
     startWorkflow: (
         workflow: { id: string; title: string },
         prompt?: string,
@@ -117,6 +130,8 @@ export const ChatInput = forwardRef<ChatInputHandle, Props>(function ChatInput(
 ) {
     const [value, setValue] = useState("");
     const [attachedDocs, setAttachedDocs] = useState<Document[]>([]);
+    const [quotedExcerpts, setQuotedExcerpts] = useState<string[]>([]);
+    const [quoteNotice, setQuoteNotice] = useState<string | null>(null);
     const [selectedWorkflow, setSelectedWorkflow] = useState<{
         id: string;
         title: string;
@@ -235,6 +250,21 @@ export const ChatInput = forwardRef<ChatInputHandle, Props>(function ChatInput(
                 if (prev.some((d) => d.id === doc.id)) return prev;
                 return [...prev, doc];
             });
+        },
+        addQuotedExcerpt: (raw: string) => {
+            const { text, truncated } = prepareExcerpt(raw);
+            if (!text) return;
+            setQuoteNotice(
+                truncated
+                    ? `Excerpt shortened to ${MAX_QUOTED_EXCERPT_CHARS.toLocaleString()} characters.`
+                    : null,
+            );
+            setQuotedExcerpts((prev) =>
+                // Re-highlighting the same passage is a mis-click, not a
+                // request for the same quote twice.
+                prev.includes(text) ? prev : [...prev, text],
+            );
+            requestAnimationFrame(() => textareaRef.current?.focus());
         },
         startWorkflow: (workflow, prompt) => {
             setSelectedWorkflow(workflow);
@@ -466,10 +496,16 @@ export const ChatInput = forwardRef<ChatInputHandle, Props>(function ChatInput(
         }));
         setAttachedDocs([]);
         setSelectedWorkflow(null);
+        // Excerpts are folded into the message content itself, so the
+        // persisted user message stays self-contained and history replay
+        // needs no knowledge of this feature. Chips clear on send.
+        const content = buildQuotedMessageContent(quotedExcerpts, query);
+        setQuotedExcerpts([]);
+        setQuoteNotice(null);
 
         onSubmit?.({
             role: "user",
-            content: query,
+            content,
             files: files.length > 0 ? files : undefined,
             workflow: workflow ?? undefined,
             model,
@@ -560,6 +596,18 @@ export const ChatInput = forwardRef<ChatInputHandle, Props>(function ChatInput(
                         LIQUID_GLASS_TRANSLUCENT_CLASS,
                     )}
                 >
+                    {/* Quoted excerpts from assistant responses */}
+                    <QuotedExcerptChips
+                        excerpts={quotedExcerpts}
+                        notice={quoteNotice}
+                        onRemove={(index) =>
+                            setQuotedExcerpts((prev) =>
+                                prev.filter((_, i) => i !== index),
+                            )
+                        }
+                        className="px-2 pt-2"
+                    />
+
                     {/* Attached chips */}
                     {(selectedWorkflow || attachedDocs.length > 0) && (
                         <div className="flex flex-wrap gap-1.5 px-2 pt-2">

--- a/frontend/src/app/components/assistant/ChatView.tsx
+++ b/frontend/src/app/components/assistant/ChatView.tsx
@@ -32,6 +32,8 @@ import { useSidebar } from "@/app/contexts/SidebarContext";
 import { invalidateDocxBytes } from "@/app/hooks/useFetchDocxBytes";
 import { resolvePanelDocumentVersion } from "./panelDocumentVersion";
 import { LIQUID_GLASS_TRANSLUCENT_ACTION_CLASS } from "@/app/components/ui/liquid-surface";
+import { useQuotableSelection } from "@/app/hooks/useQuotableSelection";
+import { QuoteSelectionPopup } from "@/app/components/shared/QuoteSelectionPopup";
 
 interface Props {
     chatId?: string | null;
@@ -629,6 +631,22 @@ export function ChatView({
 
     const messagesBottomPadding = DEFAULT_ASSISTANT_BOTTOM_PADDING;
 
+    // Highlighting inside an assistant response offers "Add to Chat". Disabled
+    // while AskInputPopup has replaced the composer — there is no chip row to
+    // attach the excerpt to.
+    const { selection: quotableSelection, clear: clearQuotableSelection } =
+        useQuotableSelection(messagesContainerRef, {
+            enabled: activeInput === null,
+        });
+
+    const addQuotedExcerpt = useCallback(
+        (text: string) => {
+            chatInputRef.current?.addQuotedExcerpt(text);
+            clearQuotableSelection();
+        },
+        [clearQuotableSelection],
+    );
+
     return (
         <div className="h-full w-full flex relative">
             {/* Chat column */}
@@ -863,6 +881,11 @@ export function ChatView({
                     </div>
                 </div>
             </div>
+
+            <QuoteSelectionPopup
+                selection={quotableSelection}
+                onAdd={addQuotedExcerpt}
+            />
 
             <AssistantWorkflowModal
                 open={workflowModalOpen}

--- a/frontend/src/app/components/assistant/UserMessage.test.tsx
+++ b/frontend/src/app/components/assistant/UserMessage.test.tsx
@@ -2,6 +2,10 @@ import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
 import { UserMessage } from "./UserMessage";
+import {
+    buildQuotedMessageContent,
+    QUOTED_EXCERPT_PREFACE,
+} from "@/app/lib/quotedExcerpts";
 
 describe("UserMessage", () => {
     it("opens a document-backed file pill", async () => {
@@ -24,5 +28,31 @@ describe("UserMessage", () => {
             screen.getByRole("button", { name: "Open agreement.docx" }),
         );
         expect(onFileClick).toHaveBeenCalledWith(file);
+    });
+
+    it("renders an ordinary message as plain text", () => {
+        const { container } = render(<UserMessage content="Review this" />);
+        expect(container.querySelector("p")).toHaveTextContent("Review this");
+        expect(container.querySelector("blockquote")).toBeNull();
+    });
+
+    it("renders attached excerpts as quote blocks, not raw markdown", () => {
+        const { container } = render(
+            <UserMessage
+                content={buildQuotedMessageContent(
+                    ["the indemnity clause"],
+                    "why does this apply?",
+                )}
+            />,
+        );
+
+        expect(
+            screen.getByText("the indemnity clause").tagName,
+        ).toBe("BLOCKQUOTE");
+        expect(screen.getByText("why does this apply?")).toBeInTheDocument();
+        // The bubble is plain text, so the wire-format scaffolding would
+        // otherwise be visible verbatim.
+        expect(container.textContent).not.toContain(QUOTED_EXCERPT_PREFACE);
+        expect(container.textContent).not.toContain("> the indemnity");
     });
 });

--- a/frontend/src/app/components/assistant/UserMessage.tsx
+++ b/frontend/src/app/components/assistant/UserMessage.tsx
@@ -4,6 +4,7 @@ import { Library } from "lucide-react";
 import { FileTypeIcon } from "../shared/FileTypeIcon";
 import type { MessageFile } from "../shared/types";
 import { LIQUID_GLASS_FLAT_CLASS } from "@/shared/ui/LiquidGlassUI";
+import { QuotedMessageContent } from "../shared/QuotedMessageContent";
 
 interface Props {
     content: string;
@@ -18,7 +19,10 @@ export function UserMessage({ content, files, workflow, onFileClick }: Props) {
     return (
         <div className="w-full flex justify-end">
             <div className="max-w-[80%] bg-gray-100 rounded-xl px-4 py-3">
-                <p className="text-sm text-gray-900 whitespace-pre-wrap">{content}</p>
+                <QuotedMessageContent
+                    content={content}
+                    className="text-sm text-gray-900"
+                />
                 {(workflow || hasFiles) && (
                     <div className="flex flex-wrap justify-end gap-1.5 mt-3">
                         {workflow && (

--- a/frontend/src/app/components/assistant/message/MarkdownContent.tsx
+++ b/frontend/src/app/components/assistant/message/MarkdownContent.tsx
@@ -17,6 +17,7 @@ import {
     citationVerificationPillClassName,
 } from "./citationVerification";
 import { internalCaseHref } from "./citationUtils";
+import { QUOTABLE_ATTRIBUTE } from "@/app/hooks/useQuotableSelection";
 
 export function MarkdownContent({
     text,
@@ -49,6 +50,11 @@ export function MarkdownContent({
     return (
         <div
             ref={divRef}
+            // Marks this prose as quotable, so highlighting inside it offers
+            // "Add to Chat". Deliberately narrower than the whole message:
+            // reasoning blocks, edit cards, and the citation list are chrome,
+            // not the answer the reader wants to quote back.
+            {...{ [QUOTABLE_ATTRIBUTE]: "" }}
             className="text-gray-900 mb-4 text-base prose prose-sm max-w-none font-serif"
         >
             <ReactMarkdown

--- a/frontend/src/app/components/shared/QuoteSelectionPopup.test.tsx
+++ b/frontend/src/app/components/shared/QuoteSelectionPopup.test.tsx
@@ -1,0 +1,157 @@
+import { act, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { popupPosition, QuoteSelectionPopup } from "./QuoteSelectionPopup";
+import type { QuotableSelection } from "@/app/hooks/useQuotableSelection";
+
+const selection = (
+    rect: Partial<QuotableSelection["rect"]> = {},
+): QuotableSelection => ({
+    text: "the indemnity clause",
+    rect: { top: 200, bottom: 220, left: 300, right: 460, ...rect },
+});
+
+const viewport = { width: 1000, height: 800 };
+
+describe("popupPosition", () => {
+    it("sits above the highlight, horizontally centred on it", () => {
+        const { top, left } = popupPosition(selection().rect, viewport);
+        expect(top).toBe(200 - 32 - 8);
+        expect(left).toBe((300 + 460) / 2 - 132 / 2);
+    });
+
+    it("flips below the highlight when there is no room above", () => {
+        const { top } = popupPosition(
+            selection({ top: 4, bottom: 24 }).rect,
+            viewport,
+        );
+        expect(top).toBe(24 + 8);
+    });
+
+    it("keeps the popup inside the left edge", () => {
+        const { left } = popupPosition(
+            selection({ left: 0, right: 10 }).rect,
+            viewport,
+        );
+        expect(left).toBe(8);
+    });
+
+    it("keeps the popup inside the right edge", () => {
+        const { left } = popupPosition(
+            selection({ left: 980, right: 1000 }).rect,
+            viewport,
+        );
+        expect(left).toBe(1000 - 132 - 8);
+    });
+
+    it("keeps the popup inside the bottom edge", () => {
+        // A highlight scrolled below the fold still gets a visible popup.
+        const { top } = popupPosition(
+            selection({ top: 900, bottom: 920 }).rect,
+            viewport,
+        );
+        expect(top).toBe(800 - 32 - 8);
+    });
+
+    it("clamps to the margin in a viewport too small to fit the popup", () => {
+        const { top, left } = popupPosition(selection().rect, {
+            width: 20,
+            height: 20,
+        });
+        expect(top).toBe(8);
+        expect(left).toBe(8);
+    });
+});
+
+describe("QuoteSelectionPopup", () => {
+    it("renders nothing without a selection", () => {
+        render(<QuoteSelectionPopup selection={null} onAdd={() => {}} />);
+        expect(screen.queryByRole("button")).toBeNull();
+    });
+
+    it("renders a single Add to Chat button", () => {
+        render(<QuoteSelectionPopup selection={selection()} onAdd={vi.fn()} />);
+        const button = screen.getByRole("button", { name: "Add to Chat" });
+        expect(button).toHaveAttribute("type", "button");
+        expect(button.className).toContain("focus-visible:ring-2");
+    });
+
+    it("passes the excerpt text up when clicked", async () => {
+        const onAdd = vi.fn();
+        render(<QuoteSelectionPopup selection={selection()} onAdd={onAdd} />);
+        await userEvent.click(
+            screen.getByRole("button", { name: "Add to Chat" }),
+        );
+        expect(onAdd).toHaveBeenCalledWith("the indemnity clause");
+    });
+
+    it("activates on Enter while the highlight is live", () => {
+        const onAdd = vi.fn();
+        render(<QuoteSelectionPopup selection={selection()} onAdd={onAdd} />);
+        act(() => {
+            document.dispatchEvent(
+                new KeyboardEvent("keydown", { key: "Enter" }),
+            );
+        });
+        expect(onAdd).toHaveBeenCalledWith("the indemnity clause");
+    });
+
+    it("leaves Enter alone inside a text field", () => {
+        const onAdd = vi.fn();
+        render(
+            <>
+                <textarea data-testid="composer" />
+                <QuoteSelectionPopup selection={selection()} onAdd={onAdd} />
+            </>,
+        );
+        act(() => {
+            screen
+                .getByTestId("composer")
+                .dispatchEvent(
+                    new KeyboardEvent("keydown", {
+                        key: "Enter",
+                        bubbles: true,
+                    }),
+                );
+        });
+        expect(onAdd).not.toHaveBeenCalled();
+    });
+
+    it("ignores Shift+Enter", () => {
+        const onAdd = vi.fn();
+        render(<QuoteSelectionPopup selection={selection()} onAdd={onAdd} />);
+        act(() => {
+            document.dispatchEvent(
+                new KeyboardEvent("keydown", {
+                    key: "Enter",
+                    shiftKey: true,
+                }),
+            );
+        });
+        expect(onAdd).not.toHaveBeenCalled();
+    });
+
+    it("stops responding to Enter once the selection is gone", () => {
+        const onAdd = vi.fn();
+        const { rerender } = render(
+            <QuoteSelectionPopup selection={selection()} onAdd={onAdd} />,
+        );
+        rerender(<QuoteSelectionPopup selection={null} onAdd={onAdd} />);
+        act(() => {
+            document.dispatchEvent(
+                new KeyboardEvent("keydown", { key: "Enter" }),
+            );
+        });
+        expect(onAdd).not.toHaveBeenCalled();
+    });
+
+    it("portals to the body so a scroll container cannot clip it", () => {
+        const { container } = render(
+            <QuoteSelectionPopup selection={selection()} onAdd={vi.fn()} />,
+        );
+        expect(container).toBeEmptyDOMElement();
+        expect(
+            document.body.querySelector(".fixed")?.getAttribute("style"),
+        ).toContain("top: 160px");
+    });
+});

--- a/frontend/src/app/components/shared/QuoteSelectionPopup.tsx
+++ b/frontend/src/app/components/shared/QuoteSelectionPopup.tsx
@@ -1,0 +1,116 @@
+"use client";
+
+import { useEffect } from "react";
+import { createPortal } from "react-dom";
+import { MessageSquareQuote } from "lucide-react";
+import type { QuotableSelection } from "@/app/hooks/useQuotableSelection";
+import {
+    LIQUID_GLASS_FLOAT_CLASS,
+    LIQUID_GLASS_HOVER_CLASS,
+} from "@/app/components/ui/liquid-surface";
+import { cn } from "@/app/lib/utils";
+
+/** Gap between the highlighted text and the popup, in pixels. */
+const ANCHOR_GAP = 8;
+const ESTIMATED_WIDTH = 132;
+const ESTIMATED_HEIGHT = 32;
+const VIEWPORT_MARGIN = 8;
+
+/**
+ * Place the popup just above the middle of the highlight, flipping below it
+ * when there is no room, and keeping it inside the viewport on both axes.
+ * Coordinates are viewport-relative because the popup is `position: fixed` in
+ * a body portal — a chat transcript lives inside an `overflow` scroller that
+ * would otherwise clip it.
+ */
+export function popupPosition(
+    rect: QuotableSelection["rect"],
+    viewport: { width: number; height: number },
+): { top: number; left: number } {
+    const above = rect.top - ESTIMATED_HEIGHT - ANCHOR_GAP;
+    const top =
+        above >= VIEWPORT_MARGIN ? above : rect.bottom + ANCHOR_GAP;
+    const centered = (rect.left + rect.right) / 2 - ESTIMATED_WIDTH / 2;
+    const maxLeft = Math.max(
+        VIEWPORT_MARGIN,
+        viewport.width - ESTIMATED_WIDTH - VIEWPORT_MARGIN,
+    );
+    return {
+        top: Math.min(
+            Math.max(VIEWPORT_MARGIN, top),
+            Math.max(
+                VIEWPORT_MARGIN,
+                viewport.height - ESTIMATED_HEIGHT - VIEWPORT_MARGIN,
+            ),
+        ),
+        left: Math.min(Math.max(VIEWPORT_MARGIN, centered), maxLeft),
+    };
+}
+
+interface Props {
+    selection: QuotableSelection | null;
+    onAdd: (text: string) => void;
+}
+
+/**
+ * The one-button popup that appears beside a highlight inside an assistant
+ * response. Clicking (or pressing Enter while the highlight is live) attaches
+ * the excerpt to the composer as a quoted-context chip.
+ */
+export function QuoteSelectionPopup({ selection, onAdd }: Props) {
+    useEffect(() => {
+        if (!selection) return;
+        const handleKeyDown = (event: KeyboardEvent) => {
+            if (event.key !== "Enter" || event.shiftKey) return;
+            const target = event.target as HTMLElement | null;
+            // Never steal Enter from the composer or any other text entry —
+            // there the key means "send", and the popup is incidental.
+            if (
+                target?.closest?.(
+                    "input, textarea, select, [contenteditable='true']",
+                )
+            ) {
+                return;
+            }
+            event.preventDefault();
+            onAdd(selection.text);
+        };
+        document.addEventListener("keydown", handleKeyDown);
+        return () => document.removeEventListener("keydown", handleKeyDown);
+    }, [onAdd, selection]);
+
+    if (!selection || typeof document === "undefined") return null;
+
+    const { top, left } = popupPosition(selection.rect, {
+        width: window.innerWidth,
+        height: window.innerHeight,
+    });
+
+    return createPortal(
+        <div
+            className="fixed z-50"
+            style={{ top, left }}
+            // The popup sits over live text; a mousedown here would collapse
+            // the selection before the click handler could read it.
+            onMouseDown={(event) => event.preventDefault()}
+        >
+            <button
+                type="button"
+                onClick={() => onAdd(selection.text)}
+                className={cn(
+                    "flex h-8 cursor-pointer items-center gap-1.5 rounded-full px-3 text-xs text-gray-700 transition-colors",
+                    "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40 focus-visible:ring-offset-2",
+                    LIQUID_GLASS_FLOAT_CLASS,
+                    LIQUID_GLASS_HOVER_CLASS,
+                )}
+            >
+                <MessageSquareQuote
+                    className="h-3.5 w-3.5 shrink-0"
+                    aria-hidden
+                />
+                Add to Chat
+            </button>
+        </div>,
+        document.body,
+    );
+}

--- a/frontend/src/app/components/shared/QuotedExcerptChip.test.tsx
+++ b/frontend/src/app/components/shared/QuotedExcerptChip.test.tsx
@@ -1,0 +1,103 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import {
+    QuotedExcerptChip,
+    QuotedExcerptChips,
+} from "./QuotedExcerptChip";
+
+describe("QuotedExcerptChip", () => {
+    it("shows the excerpt with the full text available on hover", () => {
+        render(
+            <QuotedExcerptChip
+                excerpt="a very long excerpt"
+                index={1}
+                onRemove={() => {}}
+            />,
+        );
+        const quote = screen.getByText("a very long excerpt");
+        expect(quote).toHaveAttribute("title", "a very long excerpt");
+        // Clamped so a long quote cannot push the composer off screen.
+        expect(quote).toHaveClass("line-clamp-2");
+        expect(screen.getByText("Quoted from response")).toBeInTheDocument();
+    });
+
+    it("gives the remove button an accessible name and a button type", () => {
+        render(
+            <QuotedExcerptChip excerpt="q" index={3} onRemove={() => {}} />,
+        );
+        const button = screen.getByRole("button", {
+            name: "Remove quoted excerpt 3",
+        });
+        expect(button).toHaveAttribute("type", "button");
+        expect(button.className).toContain("focus-visible:ring-2");
+    });
+
+    it("calls onRemove when the remove button is clicked", async () => {
+        const onRemove = vi.fn();
+        render(<QuotedExcerptChip excerpt="q" index={1} onRemove={onRemove} />);
+        await userEvent.click(
+            screen.getByRole("button", { name: "Remove quoted excerpt 1" }),
+        );
+        expect(onRemove).toHaveBeenCalledTimes(1);
+    });
+});
+
+describe("QuotedExcerptChips", () => {
+    it("renders nothing when there is nothing to show", () => {
+        const { container } = render(
+            <QuotedExcerptChips excerpts={[]} onRemove={() => {}} />,
+        );
+        expect(container).toBeEmptyDOMElement();
+    });
+
+    it("stacks every attached excerpt", () => {
+        render(
+            <QuotedExcerptChips
+                excerpts={["first", "second", "third"]}
+                onRemove={() => {}}
+            />,
+        );
+        expect(screen.getAllByRole("listitem")).toHaveLength(3);
+        expect(screen.getByText("second")).toBeInTheDocument();
+    });
+
+    it("reports the index of the removed chip", async () => {
+        const onRemove = vi.fn();
+        render(
+            <QuotedExcerptChips
+                excerpts={["first", "second"]}
+                onRemove={onRemove}
+            />,
+        );
+        await userEvent.click(
+            screen.getByRole("button", { name: "Remove quoted excerpt 2" }),
+        );
+        expect(onRemove).toHaveBeenCalledWith(1);
+    });
+
+    it("surfaces a truncation notice as a live status", () => {
+        render(
+            <QuotedExcerptChips
+                excerpts={["first"]}
+                onRemove={() => {}}
+                notice="Excerpt shortened to 4,000 characters."
+            />,
+        );
+        expect(screen.getByRole("status")).toHaveTextContent(
+            "Excerpt shortened to 4,000 characters.",
+        );
+    });
+
+    it("shows a notice even with no chips left", () => {
+        render(
+            <QuotedExcerptChips
+                excerpts={[]}
+                onRemove={() => {}}
+                notice="heads up"
+            />,
+        );
+        expect(screen.getByRole("status")).toHaveTextContent("heads up");
+        expect(screen.queryByRole("list")).toBeNull();
+    });
+});

--- a/frontend/src/app/components/shared/QuotedExcerptChip.tsx
+++ b/frontend/src/app/components/shared/QuotedExcerptChip.tsx
@@ -1,0 +1,92 @@
+"use client";
+
+import { MessageSquareQuote, X } from "lucide-react";
+import { LIQUID_GLASS_FLAT_CLASS } from "@/app/components/ui/liquid-surface";
+import { cn } from "@/app/lib/utils";
+
+interface ChipProps {
+    excerpt: string;
+    /** 1-based position, used only for the remove button's accessible name. */
+    index: number;
+    onRemove: () => void;
+}
+
+/**
+ * One attached excerpt, sitting above the composer until the next message is
+ * sent. The quote is clamped to two lines with the full text on `title`, so a
+ * long excerpt never pushes the textarea off screen.
+ */
+export function QuotedExcerptChip({ excerpt, index, onRemove }: ChipProps) {
+    return (
+        <div
+            className={cn(
+                "flex min-w-0 max-w-full items-start gap-1.5 rounded-[10px] py-1 pl-2 pr-1 text-xs text-gray-800",
+                LIQUID_GLASS_FLAT_CLASS,
+            )}
+        >
+            <MessageSquareQuote
+                className="mt-0.5 h-2.5 w-2.5 shrink-0 text-gray-400"
+                aria-hidden
+            />
+            <span className="flex min-w-0 flex-col gap-0.5">
+                <span className="text-[10px] leading-none text-gray-500">
+                    Quoted from response
+                </span>
+                <span
+                    title={excerpt}
+                    className="line-clamp-2 max-w-[280px] text-gray-700"
+                >
+                    {excerpt}
+                </span>
+            </span>
+            <button
+                type="button"
+                onClick={onRemove}
+                aria-label={`Remove quoted excerpt ${index}`}
+                className="mt-0.5 shrink-0 rounded-full p-0.5 text-gray-400 transition-colors hover:bg-gray-900/5 hover:text-gray-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40 focus-visible:ring-offset-1"
+            >
+                <X className="h-2.5 w-2.5" />
+            </button>
+        </div>
+    );
+}
+
+interface ListProps {
+    excerpts: readonly string[];
+    onRemove: (index: number) => void;
+    /** Shown when the last attached excerpt had to be shortened. */
+    notice?: string | null;
+    className?: string;
+}
+
+/** The stack of attached excerpts rendered above a composer. */
+export function QuotedExcerptChips({
+    excerpts,
+    onRemove,
+    notice,
+    className,
+}: ListProps) {
+    if (excerpts.length === 0 && !notice) return null;
+    return (
+        <div className={cn("flex flex-col gap-1", className)}>
+            {excerpts.length > 0 && (
+                <ul className="flex flex-wrap gap-1.5" aria-label="Quoted excerpts">
+                    {excerpts.map((excerpt, index) => (
+                        <li key={`${index}-${excerpt.slice(0, 24)}`} className="min-w-0">
+                            <QuotedExcerptChip
+                                excerpt={excerpt}
+                                index={index + 1}
+                                onRemove={() => onRemove(index)}
+                            />
+                        </li>
+                    ))}
+                </ul>
+            )}
+            {notice && (
+                <p role="status" className="text-[10px] text-gray-500">
+                    {notice}
+                </p>
+            )}
+        </div>
+    );
+}

--- a/frontend/src/app/components/shared/QuotedMessageContent.test.tsx
+++ b/frontend/src/app/components/shared/QuotedMessageContent.test.tsx
@@ -1,0 +1,81 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { QuotedMessageContent } from "./QuotedMessageContent";
+import {
+    buildQuotedMessageContent,
+    QUOTED_EXCERPT_PREFACE,
+} from "@/app/lib/quotedExcerpts";
+
+describe("QuotedMessageContent", () => {
+    it("renders an ordinary message as plain preformatted text", () => {
+        const { container } = render(
+            <QuotedMessageContent content={"line one\nline two"} />,
+        );
+        const paragraph = container.querySelector("p");
+        expect(paragraph).toHaveTextContent("line one line two");
+        expect(paragraph).toHaveClass("whitespace-pre-wrap");
+        expect(container.querySelector("blockquote")).toBeNull();
+    });
+
+    it("applies the caller's typography class to the body", () => {
+        const { container } = render(
+            <QuotedMessageContent content="hello" className="text-sm" />,
+        );
+        expect(container.querySelector("p")).toHaveClass("text-sm");
+    });
+
+    it("renders a single attached excerpt as a quote block", () => {
+        render(
+            <QuotedMessageContent
+                content={buildQuotedMessageContent(
+                    ["the indemnity clause"],
+                    "why does this apply?",
+                )}
+            />,
+        );
+        expect(screen.getByText("Quoted from response")).toBeInTheDocument();
+        expect(
+            screen.getByText("the indemnity clause").tagName,
+        ).toBe("BLOCKQUOTE");
+        expect(screen.getByText("why does this apply?")).toBeInTheDocument();
+        // The wire-format scaffolding must not leak into the UI.
+        expect(screen.queryByText(QUOTED_EXCERPT_PREFACE)).toBeNull();
+    });
+
+    it("renders several excerpts with a counted label", () => {
+        const { container } = render(
+            <QuotedMessageContent
+                content={buildQuotedMessageContent(
+                    ["first point", "second point"],
+                    "compare these",
+                )}
+            />,
+        );
+        expect(
+            screen.getByText("2 quotes from response"),
+        ).toBeInTheDocument();
+        expect(container.querySelectorAll("blockquote")).toHaveLength(2);
+        expect(screen.getByText("compare these")).toBeInTheDocument();
+    });
+
+    it("omits the body paragraph when the message is quotes only", () => {
+        const { container } = render(
+            <QuotedMessageContent
+                content={buildQuotedMessageContent(["just this"], "")}
+            />,
+        );
+        expect(container.querySelectorAll("blockquote")).toHaveLength(1);
+        expect(container.querySelectorAll("p")).toHaveLength(1); // the label
+    });
+
+    it("leaves a user-authored blockquote alone", () => {
+        const content = "> I typed this myself\n\nand this";
+        const { container } = render(
+            <QuotedMessageContent content={content} />,
+        );
+        expect(container.querySelector("blockquote")).toBeNull();
+        expect(container.querySelector("p")).toHaveTextContent(
+            "> I typed this myself and this",
+        );
+    });
+});

--- a/frontend/src/app/components/shared/QuotedMessageContent.tsx
+++ b/frontend/src/app/components/shared/QuotedMessageContent.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import { parseQuotedMessageContent } from "@/app/lib/quotedExcerpts";
+import { cn } from "@/app/lib/utils";
+
+interface Props {
+    content: string;
+    /** Typography for the user's own text; the quotes render one step down. */
+    className?: string;
+}
+
+/**
+ * Renders a sent user message, turning any leading quoted-excerpt block back
+ * into styled quotes.
+ *
+ * The excerpts are stored inside the message content as markdown blockquotes
+ * (see `lib/quotedExcerpts`), which keeps the persisted message self-contained
+ * — but user messages are rendered as plain text, so without this the reader
+ * would see literal `>` characters and the preface line. Messages with no
+ * excerpts fall through to exactly the previous rendering.
+ */
+export function QuotedMessageContent({ content, className }: Props) {
+    const { excerpts, body } = parseQuotedMessageContent(content);
+
+    if (excerpts.length === 0) {
+        return <p className={cn("whitespace-pre-wrap", className)}>{content}</p>;
+    }
+
+    return (
+        <div className="flex flex-col gap-2">
+            <div className="flex flex-col gap-1.5">
+                <p className="text-[10px] uppercase tracking-wide text-gray-500">
+                    {excerpts.length === 1
+                        ? "Quoted from response"
+                        : `${excerpts.length} quotes from response`}
+                </p>
+                {excerpts.map((excerpt, index) => (
+                    <blockquote
+                        key={`${index}-${excerpt.slice(0, 24)}`}
+                        className="border-l-2 border-gray-300 pl-2.5 text-xs italic leading-5 text-gray-600 whitespace-pre-wrap"
+                    >
+                        {excerpt}
+                    </blockquote>
+                ))}
+            </div>
+            {body.length > 0 && (
+                <p className={cn("whitespace-pre-wrap", className)}>{body}</p>
+            )}
+        </div>
+    );
+}

--- a/frontend/src/app/components/tabular/TRChatPanel.tsx
+++ b/frontend/src/app/components/tabular/TRChatPanel.tsx
@@ -30,7 +30,7 @@ import {
     type AssistantEvent,
     type Message,
 } from "../shared/types";
-import { ChatInput } from "../assistant/ChatInput";
+import { ChatInput, type ChatInputHandle } from "../assistant/ChatInput";
 import { PreResponseWrapper } from "../assistant/PreResponseWrapper";
 import {
     DocReadBlock,
@@ -50,6 +50,12 @@ import {
 import { cn } from "@/app/lib/utils";
 import { CitationPillUI } from "@/shared/ui/CitationPillUI";
 import { subscribeToTabularChatSettingsUpdates } from "@/app/lib/tabularChatSettingsEvents";
+import {
+    QUOTABLE_ATTRIBUTE,
+    useQuotableSelection,
+} from "@/app/hooks/useQuotableSelection";
+import { QuoteSelectionPopup } from "../shared/QuoteSelectionPopup";
+import { QuotedMessageContent } from "../shared/QuotedMessageContent";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -291,6 +297,8 @@ function TRAssistantMessage({
     const renderContent = (text: string, key: number) => (
         <div
             key={key}
+            // Response prose only — highlighting here offers "Add to Chat".
+            {...{ [QUOTABLE_ATTRIBUTE]: "" }}
             className="prose prose-sm max-w-none text-sm leading-relaxed"
         >
             <ReactMarkdown
@@ -413,8 +421,8 @@ function MessageBubble({
     if (msg.role === "user") {
         return (
             <div className="flex justify-end">
-                <div className="max-w-[90%] rounded-md bg-gray-100 px-3 py-2 text-xs text-gray-800 whitespace-pre-wrap">
-                    {msg.content}
+                <div className="max-w-[90%] rounded-md bg-gray-100 px-3 py-2 text-xs text-gray-800">
+                    <QuotedMessageContent content={msg.content} />
                 </div>
             </div>
         );
@@ -700,6 +708,18 @@ export function TRChatPanel({
     const abortRef = useRef<AbortController | null>(null);
     const historyRef = useRef<HTMLDivElement>(null);
     const hasScrolledRef = useRef(false);
+
+    // The shared composer owns the attached excerpts, exactly as it does for
+    // the standalone and project assistant chats. The panel owns only the
+    // popup, because the selection it watches lives in the panel's scroller.
+    const chatInputRef = useRef<ChatInputHandle>(null);
+    const { selection: quotableSelection, clear: clearQuotableSelection } =
+        useQuotableSelection(messagesContainerRef);
+
+    function addQuotedExcerpt(raw: string) {
+        clearQuotableSelection();
+        chatInputRef.current?.addQuotedExcerpt(raw);
+    }
 
     // Drip animation refs
     const dripIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
@@ -1080,6 +1100,12 @@ export function TRChatPanel({
         setCurrentChatModel(message.model);
         setCurrentChatReasoningLevel(message.reasoning);
 
+        // `trimmed` already carries any attached excerpts: the shared composer
+        // folds them into the content it submits. The history this panel
+        // replays therefore carries the quotes with no new request field and
+        // no change to the tabular chat schema.
+        const content = trimmed;
+
         // Build messages array for backend (plain text history)
         const history: { role: string; content: string }[] = messages.map(
             (m) => ({
@@ -1087,9 +1113,9 @@ export function TRChatPanel({
                 content: m.content,
             }),
         );
-        const allMessages = [...history, { role: "user", content: trimmed }];
+        const allMessages = [...history, { role: "user", content }];
 
-        const userMsg: TRMessage = { role: "user", content: trimmed };
+        const userMsg: TRMessage = { role: "user", content };
         const assistantMsg: TRMessage = {
             role: "assistant",
             content: "",
@@ -1858,6 +1884,7 @@ export function TRChatPanel({
                 className="absolute bottom-0 left-0 right-0 z-10 px-3 pb-3"
             >
                 <ChatInput
+                    ref={chatInputRef}
                     onSubmit={(message) => void handleSubmit(message)}
                     onCancel={handleCancel}
                     isLoading={isLoading}
@@ -1872,6 +1899,11 @@ export function TRChatPanel({
                     }
                 />
             </div>
+
+            <QuoteSelectionPopup
+                selection={quotableSelection}
+                onAdd={addQuotedExcerpt}
+            />
         </div>
     );
 }

--- a/frontend/src/app/hooks/useQuotableSelection.test.tsx
+++ b/frontend/src/app/hooks/useQuotableSelection.test.tsx
@@ -1,0 +1,252 @@
+import { useRef } from "react";
+import { act, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+    QUOTABLE_ATTRIBUTE,
+    useQuotableSelection,
+} from "./useQuotableSelection";
+
+/**
+ * Harness mirroring a chat surface: a scroll container holding one quotable
+ * assistant response, one non-quotable user bubble, and a composer textarea.
+ */
+function Harness({ enabled = true }: { enabled?: boolean }) {
+    const containerRef = useRef<HTMLDivElement>(null);
+    const { selection, clear } = useQuotableSelection(containerRef, {
+        enabled,
+    });
+    return (
+        <div>
+            <div ref={containerRef}>
+                <div {...{ [QUOTABLE_ATTRIBUTE]: "" }} data-testid="assistant">
+                    <p data-testid="para-one">The indemnity clause applies.</p>
+                    <p data-testid="para-two">A second paragraph here.</p>
+                </div>
+                <div {...{ [QUOTABLE_ATTRIBUTE]: "" }} data-testid="assistant-2">
+                    <p data-testid="para-three">Later response text.</p>
+                </div>
+                <div data-testid="user">What the user typed earlier.</div>
+            </div>
+            <textarea data-testid="composer" defaultValue="composer draft" />
+            <div data-testid="outside">Page chrome text.</div>
+            <output data-testid="captured">{selection?.text ?? "(none)"}</output>
+            <button type="button" onClick={clear}>
+                clear
+            </button>
+        </div>
+    );
+}
+
+/** Select from the start of `startEl`'s text to the end of `endEl`'s text. */
+function selectAcross(startEl: HTMLElement, endEl: HTMLElement) {
+    const range = document.createRange();
+    range.setStart(startEl.firstChild!, 0);
+    range.setEnd(endEl.firstChild!, endEl.textContent!.length);
+    const selection = window.getSelection()!;
+    selection.removeAllRanges();
+    selection.addRange(range);
+}
+
+function selectWithin(el: HTMLElement, start: number, end: number) {
+    const range = document.createRange();
+    range.setStart(el.firstChild!, start);
+    range.setEnd(el.firstChild!, end);
+    const selection = window.getSelection()!;
+    selection.removeAllRanges();
+    selection.addRange(range);
+}
+
+function finishDrag() {
+    act(() => {
+        document.dispatchEvent(new MouseEvent("mouseup", { bubbles: true }));
+    });
+}
+
+const captured = () => screen.getByTestId("captured").textContent;
+
+afterEach(() => {
+    window.getSelection()?.removeAllRanges();
+});
+
+describe("useQuotableSelection", () => {
+    it("captures a selection made inside an assistant response", () => {
+        render(<Harness />);
+        selectWithin(screen.getByTestId("para-one"), 4, 19);
+        finishDrag();
+        expect(captured()).toBe("indemnity claus");
+    });
+
+    it("normalizes whitespace across element boundaries", () => {
+        render(<Harness />);
+        selectAcross(
+            screen.getByTestId("para-one"),
+            screen.getByTestId("para-two"),
+        );
+        finishDrag();
+        expect(captured()).toBe(
+            "The indemnity clause applies.A second paragraph here.",
+        );
+    });
+
+    it("ignores a selection inside a user bubble", () => {
+        render(<Harness />);
+        selectWithin(screen.getByTestId("user"), 0, 8);
+        finishDrag();
+        expect(captured()).toBe("(none)");
+    });
+
+    it("ignores a selection outside the watched container", () => {
+        render(<Harness />);
+        selectWithin(screen.getByTestId("outside"), 0, 4);
+        finishDrag();
+        expect(captured()).toBe("(none)");
+    });
+
+    it("ignores a collapsed selection (a plain click)", () => {
+        render(<Harness />);
+        selectWithin(screen.getByTestId("para-one"), 5, 5);
+        finishDrag();
+        expect(captured()).toBe("(none)");
+    });
+
+    it("ignores a selection that is only whitespace", () => {
+        render(
+            <Harness />,
+        );
+        const para = screen.getByTestId("para-one");
+        // The single space between "The" and "indemnity".
+        selectWithin(para, 3, 4);
+        finishDrag();
+        expect(captured()).toBe("(none)");
+    });
+
+    it("clamps a selection that runs into the next response", () => {
+        render(<Harness />);
+        selectAcross(
+            screen.getByTestId("para-two"),
+            screen.getByTestId("para-three"),
+        );
+        finishDrag();
+        // Collapsed to the bubble the drag started in.
+        expect(captured()).toBe("A second paragraph here.");
+    });
+
+    it("clamps a selection that starts in a response and ends in chrome", () => {
+        render(<Harness />);
+        selectAcross(
+            screen.getByTestId("para-one"),
+            screen.getByTestId("user"),
+        );
+        finishDrag();
+        expect(captured()).toBe(
+            "The indemnity clause applies.A second paragraph here.",
+        );
+    });
+
+    it("drops the selection when it collapses", () => {
+        render(<Harness />);
+        selectWithin(screen.getByTestId("para-one"), 0, 3);
+        finishDrag();
+        expect(captured()).toBe("The");
+
+        act(() => {
+            window.getSelection()!.removeAllRanges();
+            document.dispatchEvent(new Event("selectionchange"));
+        });
+        expect(captured()).toBe("(none)");
+    });
+
+    it("drops the selection on Escape", () => {
+        render(<Harness />);
+        selectWithin(screen.getByTestId("para-one"), 0, 3);
+        finishDrag();
+        expect(captured()).toBe("The");
+
+        act(() => {
+            document.dispatchEvent(
+                new KeyboardEvent("keydown", { key: "Escape" }),
+            );
+        });
+        expect(captured()).toBe("(none)");
+    });
+
+    it("drops the selection on scroll", () => {
+        render(<Harness />);
+        selectWithin(screen.getByTestId("para-one"), 0, 3);
+        finishDrag();
+        expect(captured()).toBe("The");
+
+        act(() => {
+            screen
+                .getByTestId("assistant")
+                .dispatchEvent(new Event("scroll", { bubbles: true }));
+        });
+        expect(captured()).toBe("(none)");
+    });
+
+    it("drops the selection on resize", () => {
+        render(<Harness />);
+        selectWithin(screen.getByTestId("para-one"), 0, 3);
+        finishDrag();
+        act(() => {
+            window.dispatchEvent(new Event("resize"));
+        });
+        expect(captured()).toBe("(none)");
+    });
+
+    it("stays cleared after clear() until the selection changes", () => {
+        render(<Harness />);
+        selectWithin(screen.getByTestId("para-one"), 0, 3);
+        finishDrag();
+        expect(captured()).toBe("The");
+
+        act(() => {
+            screen.getByText("clear").click();
+        });
+        expect(captured()).toBe("(none)");
+
+        // The browser still holds the same range; re-detecting it would make
+        // the popup pop straight back up after the user consumed it.
+        finishDrag();
+        expect(captured()).toBe("(none)");
+
+        // Collapsing re-arms detection.
+        act(() => {
+            window.getSelection()!.removeAllRanges();
+            document.dispatchEvent(new Event("selectionchange"));
+        });
+        selectWithin(screen.getByTestId("para-one"), 0, 3);
+        finishDrag();
+        expect(captured()).toBe("The");
+    });
+
+    it("captures a shift-key keyboard selection", () => {
+        render(<Harness />);
+        selectWithin(screen.getByTestId("para-one"), 0, 3);
+        act(() => {
+            document.dispatchEvent(
+                new KeyboardEvent("keyup", {
+                    key: "ArrowRight",
+                    shiftKey: true,
+                }),
+            );
+        });
+        expect(captured()).toBe("The");
+    });
+
+    it("does not capture on an ordinary keyup", () => {
+        render(<Harness />);
+        selectWithin(screen.getByTestId("para-one"), 0, 3);
+        act(() => {
+            document.dispatchEvent(new KeyboardEvent("keyup", { key: "a" }));
+        });
+        expect(captured()).toBe("(none)");
+    });
+
+    it("captures nothing while disabled", () => {
+        render(<Harness enabled={false} />);
+        selectWithin(screen.getByTestId("para-one"), 0, 3);
+        finishDrag();
+        expect(captured()).toBe("(none)");
+    });
+});

--- a/frontend/src/app/hooks/useQuotableSelection.ts
+++ b/frontend/src/app/hooks/useQuotableSelection.ts
@@ -1,0 +1,162 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import type { RefObject } from "react";
+import { normalizeExcerpt } from "@/app/lib/quotedExcerpts";
+
+/**
+ * Marker attribute a surface puts on the DOM subtree of a single assistant
+ * response. Only text inside a marked element is quotable, which is what keeps
+ * the "Add to Chat" popup out of the composer, out of user bubbles, and out of
+ * every other selectable region of the page.
+ */
+export const QUOTABLE_ATTRIBUTE = "data-mike-quotable";
+const QUOTABLE_SELECTOR = `[${QUOTABLE_ATTRIBUTE}]`;
+
+export interface QuotableSelection {
+    /** Normalized excerpt text, ready to attach as a chip. */
+    text: string;
+    /** Viewport-relative anchor rect of the highlighted range. */
+    rect: { top: number; bottom: number; left: number; right: number };
+}
+
+function closestQuotable(node: Node | null): HTMLElement | null {
+    const element =
+        node === null
+            ? null
+            : node.nodeType === Node.ELEMENT_NODE
+              ? (node as HTMLElement)
+              : node.parentElement;
+    return element?.closest?.(QUOTABLE_SELECTOR) ?? null;
+}
+
+/**
+ * Clamp `range` to the contents of `bounds`. A drag that runs off the end of
+ * one response and into the next (or into the page chrome) would otherwise
+ * quote text the user cannot see in the chip — collapsing to the in-bubble
+ * portion is both truthful and what the highlight visually suggested.
+ */
+function clampToElement(range: Range, bounds: HTMLElement): Range {
+    const limits = bounds.ownerDocument.createRange();
+    limits.selectNodeContents(bounds);
+    const clamped = range.cloneRange();
+    if (clamped.compareBoundaryPoints(Range.START_TO_START, limits) < 0) {
+        clamped.setStart(limits.startContainer, limits.startOffset);
+    }
+    if (clamped.compareBoundaryPoints(Range.END_TO_END, limits) > 0) {
+        clamped.setEnd(limits.endContainer, limits.endOffset);
+    }
+    limits.detach?.();
+    return clamped;
+}
+
+function rectOf(range: Range): QuotableSelection["rect"] {
+    // jsdom returns a zeroed rect; real browsers return the union of the
+    // highlighted client rects. Either way the popup gets a usable anchor.
+    const box = range.getBoundingClientRect?.();
+    return {
+        top: box?.top ?? 0,
+        bottom: box?.bottom ?? 0,
+        left: box?.left ?? 0,
+        right: box?.right ?? 0,
+    };
+}
+
+function readSelection(container: HTMLElement | null): QuotableSelection | null {
+    const selection = window.getSelection();
+    if (!selection || selection.isCollapsed || selection.rangeCount === 0) {
+        return null;
+    }
+    const range = selection.getRangeAt(0);
+    // Anchor on the start of the drag: that is the response the user began
+    // highlighting, and the one the excerpt should come from.
+    const quotable = closestQuotable(range.startContainer);
+    if (!quotable) return null;
+    if (container && !container.contains(quotable)) return null;
+
+    const clamped = clampToElement(range, quotable);
+    const text = normalizeExcerpt(clamped.toString());
+    if (text.length === 0) return null;
+    return { text, rect: rectOf(clamped) };
+}
+
+/**
+ * Watch for text selections inside assistant responses under `containerRef`.
+ *
+ * Returns the live selection (or null) plus a `clear` callback the caller uses
+ * once it has consumed the excerpt. The selection is dropped as soon as the
+ * user collapses it, scrolls, or presses Escape, so the floating popup never
+ * outlives the highlight it points at.
+ */
+export function useQuotableSelection(
+    containerRef: RefObject<HTMLElement | null>,
+    options?: { enabled?: boolean },
+): { selection: QuotableSelection | null; clear: () => void } {
+    const enabled = options?.enabled ?? true;
+    const [selection, setSelection] = useState<QuotableSelection | null>(null);
+    // Suppresses re-detection of a selection the caller has already consumed,
+    // until the user actually changes it.
+    const dismissedRef = useRef(false);
+
+    const clear = useCallback(() => {
+        dismissedRef.current = true;
+        setSelection(null);
+    }, []);
+
+    useEffect(() => {
+        // Listeners are the only writers, so not subscribing is the whole of
+        // "disabled"; the cleanup below drops any selection captured before
+        // the surface turned the feature off.
+        if (!enabled) return;
+
+        const settle = () => {
+            if (dismissedRef.current) return;
+            setSelection(readSelection(containerRef.current));
+        };
+
+        const handleSelectionChange = () => {
+            const current = window.getSelection();
+            if (!current || current.isCollapsed) {
+                // A plain click collapses the selection: that is our
+                // click-away dismissal, and it re-arms detection.
+                dismissedRef.current = false;
+                setSelection(null);
+            }
+        };
+
+        const handleKeyUp = (event: KeyboardEvent) => {
+            // Shift+arrow extends a selection under caret browsing; other keys
+            // are typing, which belongs to whatever field has focus.
+            if (event.shiftKey) settle();
+        };
+
+        const handleKeyDown = (event: KeyboardEvent) => {
+            if (event.key === "Escape") clear();
+        };
+
+        const handleScroll = () => setSelection(null);
+
+        document.addEventListener("mouseup", settle);
+        document.addEventListener("keyup", handleKeyUp);
+        document.addEventListener("keydown", handleKeyDown);
+        document.addEventListener("selectionchange", handleSelectionChange);
+        // Capture phase so scrolling any ancestor container counts, not just
+        // the document — chat messages live in their own scroll region.
+        window.addEventListener("scroll", handleScroll, true);
+        window.addEventListener("resize", handleScroll);
+        return () => {
+            document.removeEventListener("mouseup", settle);
+            document.removeEventListener("keyup", handleKeyUp);
+            document.removeEventListener("keydown", handleKeyDown);
+            document.removeEventListener(
+                "selectionchange",
+                handleSelectionChange,
+            );
+            window.removeEventListener("scroll", handleScroll, true);
+            window.removeEventListener("resize", handleScroll);
+            setSelection(null);
+        };
+    }, [clear, containerRef, enabled]);
+
+    return { selection: enabled ? selection : null, clear };
+}

--- a/frontend/src/app/lib/quotedExcerpts.test.ts
+++ b/frontend/src/app/lib/quotedExcerpts.test.ts
@@ -1,0 +1,306 @@
+import { describe, expect, it } from "vitest";
+import {
+    buildQuotedMessageContent,
+    capExcerpt,
+    hasQuotedExcerpts,
+    MAX_QUOTED_EXCERPT_CHARS,
+    normalizeExcerpt,
+    parseQuotedMessageContent,
+    prepareExcerpt,
+    QUOTED_EXCERPT_PREFACE,
+} from "./quotedExcerpts";
+
+describe("normalizeExcerpt", () => {
+    it("collapses whitespace runs and trims", () => {
+        expect(normalizeExcerpt("  the   quick\n\tbrown  fox \n")).toBe(
+            "the quick brown fox",
+        );
+    });
+
+    it("returns an empty string for whitespace-only input", () => {
+        expect(normalizeExcerpt("   \n\t  ")).toBe("");
+    });
+
+    it("leaves already-tidy text alone", () => {
+        expect(normalizeExcerpt("clause 4.2 applies")).toBe(
+            "clause 4.2 applies",
+        );
+    });
+});
+
+describe("capExcerpt", () => {
+    it("passes short text through untouched", () => {
+        expect(capExcerpt("short")).toEqual({
+            text: "short",
+            truncated: false,
+        });
+    });
+
+    it("passes text exactly at the cap through untouched", () => {
+        const exact = "x".repeat(MAX_QUOTED_EXCERPT_CHARS);
+        expect(capExcerpt(exact)).toEqual({ text: exact, truncated: false });
+    });
+
+    it("cuts back to a word boundary when one is near the cap", () => {
+        // A space just past 90% of the cap is a good place to break.
+        const head = "word ".repeat(MAX_QUOTED_EXCERPT_CHARS / 5 + 10);
+        const result = capExcerpt(head);
+        expect(result.truncated).toBe(true);
+        expect(result.text.endsWith("…")).toBe(true);
+        expect(result.text.endsWith("word…")).toBe(true);
+        expect(result.text.length).toBeLessThanOrEqual(
+            MAX_QUOTED_EXCERPT_CHARS + 1,
+        );
+    });
+
+    it("hard-cuts when the only space is far before the cap", () => {
+        const text = `a ${"b".repeat(MAX_QUOTED_EXCERPT_CHARS)}`;
+        const result = capExcerpt(text);
+        expect(result.truncated).toBe(true);
+        // The word boundary at index 1 would throw away the whole excerpt, so
+        // the hard cut wins.
+        expect(result.text.length).toBe(MAX_QUOTED_EXCERPT_CHARS + 1);
+        expect(result.text.endsWith("b…")).toBe(true);
+    });
+});
+
+describe("prepareExcerpt", () => {
+    it("normalizes then caps in one step", () => {
+        expect(prepareExcerpt("  hello   world  ")).toEqual({
+            text: "hello world",
+            truncated: false,
+        });
+    });
+
+    it("reports truncation for an over-long selection", () => {
+        const result = prepareExcerpt("word ".repeat(2000));
+        expect(result.truncated).toBe(true);
+        expect(result.text.length).toBeLessThanOrEqual(
+            MAX_QUOTED_EXCERPT_CHARS + 1,
+        );
+    });
+});
+
+describe("buildQuotedMessageContent", () => {
+    it("returns the body unchanged when there are no excerpts", () => {
+        expect(buildQuotedMessageContent([], "what does this mean?")).toBe(
+            "what does this mean?",
+        );
+    });
+
+    it("ignores blank excerpts", () => {
+        expect(buildQuotedMessageContent(["", "   "], "hi")).toBe("hi");
+    });
+
+    it("prefixes a single excerpt as a markdown blockquote", () => {
+        expect(buildQuotedMessageContent(["the indemnity clause"], "why?")).toBe(
+            [
+                QUOTED_EXCERPT_PREFACE,
+                "",
+                "> the indemnity clause",
+                "",
+                "why?",
+            ].join("\n"),
+        );
+    });
+
+    it("separates multiple excerpts with a blank line", () => {
+        expect(buildQuotedMessageContent(["first", "second"], "compare")).toBe(
+            [
+                QUOTED_EXCERPT_PREFACE,
+                "",
+                "> first",
+                "",
+                "> second",
+                "",
+                "compare",
+            ].join("\n"),
+        );
+    });
+
+    it("prefixes every line of a multi-line excerpt, blank lines included", () => {
+        const built = buildQuotedMessageContent(["a\n\nb"], "explain");
+        expect(built).toBe(
+            [
+                QUOTED_EXCERPT_PREFACE,
+                "",
+                "> a",
+                ">",
+                "> b",
+                "",
+                "explain",
+            ].join("\n"),
+        );
+    });
+
+    it("trims the body", () => {
+        expect(buildQuotedMessageContent(["q"], "  ask  ")).toBe(
+            [QUOTED_EXCERPT_PREFACE, "", "> q", "", "ask"].join("\n"),
+        );
+    });
+
+    it("omits the body section entirely when the body is blank", () => {
+        expect(buildQuotedMessageContent(["q"], "   ")).toBe(
+            [QUOTED_EXCERPT_PREFACE, "", "> q"].join("\n"),
+        );
+    });
+});
+
+describe("parseQuotedMessageContent", () => {
+    it("passes an ordinary message through as the body", () => {
+        expect(parseQuotedMessageContent("just a question")).toEqual({
+            excerpts: [],
+            body: "just a question",
+        });
+    });
+
+    it("passes a message that merely contains a blockquote through", () => {
+        const content = "> not ours\n\nhello";
+        expect(parseQuotedMessageContent(content)).toEqual({
+            excerpts: [],
+            body: content,
+        });
+    });
+
+    it("treats a bare preface line with no blockquote as ordinary prose", () => {
+        const content = `${QUOTED_EXCERPT_PREFACE}\n\nnothing quoted`;
+        expect(parseQuotedMessageContent(content)).toEqual({
+            excerpts: [],
+            body: content,
+        });
+    });
+
+    it("recovers one excerpt and the body", () => {
+        expect(
+            parseQuotedMessageContent(
+                [QUOTED_EXCERPT_PREFACE, "", "> clause 4.2", "", "why?"].join(
+                    "\n",
+                ),
+            ),
+        ).toEqual({ excerpts: ["clause 4.2"], body: "why?" });
+    });
+
+    it("recovers multiple excerpts", () => {
+        expect(
+            parseQuotedMessageContent(
+                [
+                    QUOTED_EXCERPT_PREFACE,
+                    "",
+                    "> first",
+                    "",
+                    "> second",
+                    "",
+                    "compare them",
+                ].join("\n"),
+            ),
+        ).toEqual({ excerpts: ["first", "second"], body: "compare them" });
+    });
+
+    it("keeps a multi-line body intact", () => {
+        expect(
+            parseQuotedMessageContent(
+                [
+                    QUOTED_EXCERPT_PREFACE,
+                    "",
+                    "> quoted",
+                    "",
+                    "line one",
+                    "line two",
+                ].join("\n"),
+            ),
+        ).toEqual({ excerpts: ["quoted"], body: "line one\nline two" });
+    });
+
+    it("handles a message with excerpts and no body", () => {
+        expect(
+            parseQuotedMessageContent(
+                [QUOTED_EXCERPT_PREFACE, "", "> only a quote"].join("\n"),
+            ),
+        ).toEqual({ excerpts: ["only a quote"], body: "" });
+    });
+
+    it("decodes a quote marker with no following space", () => {
+        expect(
+            parseQuotedMessageContent(
+                [QUOTED_EXCERPT_PREFACE, "", ">tight", "", "ok"].join("\n"),
+            ),
+        ).toEqual({ excerpts: ["tight"], body: "ok" });
+    });
+
+    it("tolerates extra blank lines after the preface", () => {
+        expect(
+            parseQuotedMessageContent(
+                [QUOTED_EXCERPT_PREFACE, "", "", "> spaced", "", "ok"].join(
+                    "\n",
+                ),
+            ),
+        ).toEqual({ excerpts: ["spaced"], body: "ok" });
+    });
+
+    it("tolerates a preface line with trailing whitespace", () => {
+        expect(
+            parseQuotedMessageContent(
+                [`${QUOTED_EXCERPT_PREFACE}  `, "", "> q", "", "ok"].join("\n"),
+            ),
+        ).toEqual({ excerpts: ["q"], body: "ok" });
+    });
+
+    it("tolerates extra blank lines between excerpts", () => {
+        expect(
+            parseQuotedMessageContent(
+                [
+                    QUOTED_EXCERPT_PREFACE,
+                    "",
+                    "> first",
+                    "",
+                    "",
+                    "> second",
+                    "",
+                    "",
+                    "ask",
+                ].join("\n"),
+            ),
+        ).toEqual({ excerpts: ["first", "second"], body: "ask" });
+    });
+
+    it("handles a body that starts immediately after the quote", () => {
+        expect(
+            parseQuotedMessageContent(
+                [QUOTED_EXCERPT_PREFACE, "", "> q", "straight on"].join("\n"),
+            ),
+        ).toEqual({ excerpts: ["q"], body: "straight on" });
+    });
+
+    it("returns an empty body for an empty message", () => {
+        expect(parseQuotedMessageContent("")).toEqual({
+            excerpts: [],
+            body: "",
+        });
+    });
+});
+
+describe("round trip", () => {
+    it.each([
+        [["one"], "body"],
+        [["one", "two", "three"], "compare these"],
+        [["line a\nline b"], "multi-line excerpt"],
+        [["with\n\nblank line"], "blank inside"],
+        [[">already quoted"], "nested marker"],
+        [["one"], "body\nwith\nlines"],
+    ])("survives build -> parse for %j / %j", (excerpts, body) => {
+        const built = buildQuotedMessageContent(excerpts, body);
+        expect(parseQuotedMessageContent(built)).toEqual({ excerpts, body });
+    });
+});
+
+describe("hasQuotedExcerpts", () => {
+    it("is false for an ordinary message", () => {
+        expect(hasQuotedExcerpts("plain")).toBe(false);
+    });
+
+    it("is true for a message carrying excerpts", () => {
+        expect(
+            hasQuotedExcerpts(buildQuotedMessageContent(["q"], "ask")),
+        ).toBe(true);
+    });
+});

--- a/frontend/src/app/lib/quotedExcerpts.ts
+++ b/frontend/src/app/lib/quotedExcerpts.ts
@@ -1,0 +1,170 @@
+/**
+ * Quoted excerpts — the wire and persistence format for "Add to Chat".
+ *
+ * When a user highlights part of an assistant response and attaches it to the
+ * composer, the excerpt has to survive three trips: to the model on this turn,
+ * into the persisted chat history, and back out again when the chat is
+ * reloaded and re-rendered.
+ *
+ * Rather than add a structured `quoted_excerpts` field to the request body
+ * (which would need a backend change, a schema migration for the messages
+ * table, and a history-replay path that knows how to fold it back into the
+ * prompt), the excerpts are encoded *into* the user message content as
+ * ordinary markdown blockquotes under a short preface line:
+ *
+ *     Referring to this part of your earlier response:
+ *
+ *     > the highlighted text
+ *     > second line of the same excerpt
+ *
+ *     > a second, separate excerpt
+ *
+ *     ...and then whatever the user actually typed.
+ *
+ * The persisted user message is therefore self-contained: history replay,
+ * chat export, and every existing backend path keep working untouched, and a
+ * model reading raw markdown sees a clearly delimited quote. The cost is that
+ * the excerpts are not machine-distinguishable from prose the user typed
+ * themselves — `parseQuotedMessageContent` recovers them heuristically so the
+ * UI can render them as quote blocks instead of raw `>` characters.
+ *
+ * Excerpt encoding rules, chosen so the round trip is lossless:
+ * - every line of an excerpt is prefixed, blank lines included ("&gt;" alone),
+ *   so a blank line unambiguously separates one excerpt from the next;
+ * - excerpts are separated by exactly one blank line;
+ * - the body is separated from the last excerpt by exactly one blank line, and
+ *   is taken verbatim from the first line that is neither blank nor a
+ *   blockquote line.
+ */
+
+/** Leading line that marks a message as carrying quoted excerpts. */
+export const QUOTED_EXCERPT_PREFACE =
+    "Referring to this part of your earlier response:";
+
+/**
+ * Longest excerpt we will attach. Long enough for several paragraphs of a
+ * response, short enough that a runaway "select all" cannot silently blow out
+ * the prompt (or the message row) behind the user's back.
+ */
+export const MAX_QUOTED_EXCERPT_CHARS = 4000;
+
+/** Collapse a DOM-derived selection into a single tidy run of text. */
+export function normalizeExcerpt(raw: string): string {
+    return raw.replace(/\s+/g, " ").trim();
+}
+
+/**
+ * Enforce {@link MAX_QUOTED_EXCERPT_CHARS}, cutting back to a word boundary
+ * where one is available so the excerpt does not end mid-word. Callers surface
+ * `truncated` to the user rather than shortening the quote silently.
+ */
+export function capExcerpt(text: string): {
+    text: string;
+    truncated: boolean;
+} {
+    if (text.length <= MAX_QUOTED_EXCERPT_CHARS) {
+        return { text, truncated: false };
+    }
+    const hard = text.slice(0, MAX_QUOTED_EXCERPT_CHARS);
+    const lastSpace = hard.lastIndexOf(" ");
+    // Only prefer the word boundary when it is not throwing away most of the
+    // cap (a 4000-character run with no spaces should still be kept).
+    const cut =
+        lastSpace > MAX_QUOTED_EXCERPT_CHARS * 0.8
+            ? hard.slice(0, lastSpace)
+            : hard;
+    return { text: `${cut.trimEnd()}…`, truncated: true };
+}
+
+/** Normalize, then cap, in the one step a caller attaching a chip needs. */
+export function prepareExcerpt(raw: string): {
+    text: string;
+    truncated: boolean;
+} {
+    return capExcerpt(normalizeExcerpt(raw));
+}
+
+function encodeExcerpt(excerpt: string): string {
+    return excerpt
+        .split("\n")
+        .map((line) => (line.length > 0 ? `> ${line}` : ">"))
+        .join("\n");
+}
+
+function decodeExcerptLine(line: string): string {
+    // "> text" -> "text", ">" -> "". A quote marker with no following space is
+    // still a quote line; only the single space after ">" is markdown syntax.
+    return line.startsWith("> ") ? line.slice(2) : line.slice(1);
+}
+
+const isQuoteLine = (line: string) => line.startsWith(">");
+
+/**
+ * Build the outgoing user message content. With no excerpts this is exactly
+ * the text the user typed, so an untouched composer produces an untouched
+ * message.
+ */
+export function buildQuotedMessageContent(
+    excerpts: readonly string[],
+    body: string,
+): string {
+    const usable = excerpts.filter((excerpt) => excerpt.trim().length > 0);
+    if (usable.length === 0) return body;
+    const blocks = usable.map(encodeExcerpt).join("\n\n");
+    const trimmedBody = body.trim();
+    const preamble = `${QUOTED_EXCERPT_PREFACE}\n\n${blocks}`;
+    return trimmedBody.length > 0 ? `${preamble}\n\n${trimmedBody}` : preamble;
+}
+
+/**
+ * Recover the excerpts and the user's own text from a persisted message.
+ *
+ * Returns `excerpts: []` and the original string as `body` for any message
+ * that does not open with the preface line, so ordinary messages — and
+ * messages written before this feature existed — render exactly as before.
+ */
+export function parseQuotedMessageContent(content: string): {
+    excerpts: string[];
+    body: string;
+} {
+    const lines = content.split("\n");
+    if (lines[0]?.trim() !== QUOTED_EXCERPT_PREFACE) {
+        return { excerpts: [], body: content };
+    }
+
+    let index = 1;
+    // Skip the blank line(s) between the preface and the first blockquote.
+    while (index < lines.length && lines[index].trim() === "") index += 1;
+
+    const excerpts: string[] = [];
+    let current: string[] | null = null;
+    for (; index < lines.length; index += 1) {
+        const line = lines[index];
+        if (isQuoteLine(line)) {
+            if (!current) current = [];
+            current.push(decodeExcerptLine(line));
+            continue;
+        }
+        if (line.trim() === "") {
+            if (current) {
+                excerpts.push(current.join("\n"));
+                current = null;
+            }
+            continue;
+        }
+        break;
+    }
+    if (current) excerpts.push(current.join("\n"));
+
+    if (excerpts.length === 0) {
+        // The preface line was the user's own prose, not our marker.
+        return { excerpts: [], body: content };
+    }
+
+    return { excerpts, body: lines.slice(index).join("\n").trim() };
+}
+
+/** True when `content` carries at least one attached excerpt. */
+export function hasQuotedExcerpts(content: string): boolean {
+    return parseQuotedMessageContent(content).excerpts.length > 0;
+}


### PR DESCRIPTION
**Explainer:** https://claude.ai/code/artifact/b2db2f9f-4f5d-4d53-97ff-fe40f9b15480

## Summary

Adds "Add to Chat": highlight any part of an assistant response, click the
floating popup that appears, and the excerpt attaches above the composer as a
removable quoted-context chip. Multiple highlights stack. The excerpts are sent
as context with the next message and clear afterwards.

Shipped on all three web chat surfaces — standalone assistant chat, project
assistant chat, and the tabular-review chat panel. Not the Word add-in.

This is PR 1 of a two-PR series and is deliberately narrow: no agents, no
multi-chat. #385 is stacked directly on this tip.

## What changed

**New — the wire format** (`lib/quotedExcerpts.ts`)
Encodes/decodes attached excerpts as markdown blockquotes inside the user
message content, plus normalization and a 4,000-character cap.

**New — selection capture** (`hooks/useQuotableSelection.ts`)
Reports a selection only when its start lies inside an element marked
`data-mike-quotable` and inside the container it was given. Clamps a selection
that runs past one response back to the bubble the drag started in. Dismisses on
collapse, Escape, scroll (captured), and resize.

**New — three shared components** (`components/shared/`)
- `QuoteSelectionPopup` — one-button liquid-glass float overlay, portalled to
  the body so the transcript's overflow scroller cannot clip it.
- `QuotedExcerptChip` / `QuotedExcerptChips` — the chip stack above a composer.
- `QuotedMessageContent` — parses the quoted prefix back out of a sent user
  message and renders it as styled quote blocks.

**Wiring**
- `MarkdownContent` and `TRChatPanel`'s prose div get `data-mike-quotable`.
- `ChatInput` gains a `addQuotedExcerpt` imperative handle, the chip row, and
  the content-prefixing send path; `ChatView` and the project chat page own the
  hook + popup for their own scroll containers.
- `TRChatPanel` holds its own excerpt state and prefixes in `handleSubmit`.
- `UserMessage` and `TRChatPanel`'s user bubble render through
  `QuotedMessageContent`.

## Why

There is no way today to point at a specific passage of an assistant response
and ask about it. Quoting by hand is lossy, and "the second paragraph" is
ambiguous once the response has scrolled.

The excerpts had to survive three trips: to the model this turn, into persisted
history, and back out on reload. The obvious design — a structured
`quoted_excerpts` request field — costs a backend change, a messages-table
shape change, a migration, and a history-replay path that folds excerpts back
into the prompt on every load. All to carry text that is already text.

Encoding them into the message content instead makes the persisted user message
self-contained. History replay, chat export, project chats, and tabular chats
keep working with no backend awareness of the feature at all, and a model
reading raw markdown sees a clearly delimited quote rather than an opaque field
it was never prompted about.

## Reproduce the base case on main

1. Check out `main` and open `/assistant`. Send any message that produces a
   prose response.
2. Highlight a sentence inside the response with the mouse.
3. Nothing happens — no popup, no way to reference that passage.
4. To ask about it you must retype or copy-paste the passage into the composer
   by hand.
5. Same in a project chat (`/projects/<id>/assistant/chat/<chatId>`) and in the
   tabular-review chat panel.

## Verify on this branch

1. Open `/assistant` and send any message that produces a prose response.
2. Highlight a sentence inside the response — an "Add to Chat" popup appears
   just above the highlight.
3. Click it. A chip labelled "Quoted from response" appears above the composer
   with the excerpt clamped to two lines (full text on hover).
4. Highlight a second passage and click again — chips stack.
5. Click a chip's ✕ — that chip is removed, the others stay.
6. Type a question and send. The sent user bubble shows the excerpts as styled
   quote blocks above your text; the chips are gone from the composer.
7. Reload the chat. The quote blocks persist and still render as quotes, not as
   literal `>` characters.
8. Repeat 2–7 in a project assistant chat and in a tabular review's chat panel.

**Edge cases worth poking**
- Highlight text in a *user* bubble, in the composer, or in the document
  viewer → no popup.
- Start a drag inside one response and end it in the next → the chip contains
  only the first response's text.
- Highlight, then press Escape / scroll the transcript / click elsewhere → the
  popup goes away.
- Highlight, then press Enter with focus outside a text field → the excerpt
  attaches. Press Enter in the composer → it still sends, as before.
- Select a very long passage (>4,000 chars) → the chip is capped at a word
  boundary and a notice says it was shortened.

## Tradeoffs & design decisions

1. **Excerpts ride inside `content` rather than a structured request field.**
   Buys zero backend change, zero migration, working history replay, and a
   self-contained persisted message. Costs machine-distinguishability: a user
   who types the exact preface line *and* a blockquote will see their own quote
   styled as an attached excerpt. The parser fails closed on everything else, so
   the blast radius is cosmetic. If a later PR needs excerpt provenance
   (which message, which offsets), that is the moment to promote it to a real
   field — this format is a deliberate floor, not a ceiling.

2. **Whitespace-collapsed excerpts.** A DOM range gives concatenated text nodes
   with no block boundaries, so a multi-paragraph highlight becomes one run-on
   line. Recovering the breaks needs a walk of the cloned fragment emitting
   newlines at block edges. Left out to keep this PR small; the encoding already
   round-trips newlines, so adding it later is a change to one function.

3. **`data-mike-quotable` on the prose div, not the message wrapper.** Excludes
   reasoning blocks, edit cards, download cards, and the citation list. This
   also means a selection spanning two `content` events in one message clamps to
   the first — consistent with the cross-bubble rule, and cheap to widen later.

4. **Selections spanning bubbles clamp rather than bail.** Bailing punishes a
   slightly-too-long drag; quoting across bubbles puts text in the chip the user
   never highlighted as one thought. Clamping to the drag's origin bubble is
   truthful and matches what the highlight looked like.

5. **Excerpt state lives in `ChatInput` (imperative, like `addDoc`) but on the
   panel in `TRChatPanel`.** The two composers differ: `ChatInput` is shared by
   two pages and already owns the adjacent document chips, so keeping the state
   there avoids duplicating it at both call sites. `TRChatInput` is used once and
   its popup is a panel-level child, so the state sits next to the popup instead.

6. **Cap-and-notify rather than reject.** A 4,001-character selection that
   silently does nothing is worse than one that attaches, cuts at a word
   boundary, and says so.

7. **Enter activates the popup, guarded.** Native button focus covers Tab users;
   a document-level Enter handler covers the case where nothing is focused. It
   bails whenever the event target is an input/textarea/contenteditable so it
   can never steal "send" from the composer.

8. **Rebase decision (2026-09-14): main's tabular history builder wins.**
   Main's chat-history hotfix (#461) replaced `TRChatPanel`'s inline
   `messages.map(...)` history with `buildTabularChatHistory(messages)`. This
   branch had renamed the same local from `trimmed` to `content`. The rename was
   dropped and main's code kept verbatim — the shared composer already folds
   excerpts into the submitted text, so the alias bought nothing. Behaviour for
   chats with no attached excerpts is byte-identical to main.

9. **Rebase decision: main's popup rename wins.** The project chat page now
   renders `PermissionDeniedPopup` where this branch expected `OwnerOnlyPopup`,
   and main's `ProjectMemoryModal` sits alongside. `QuoteSelectionPopup` was
   inserted next to them rather than in place of either.

## Testing performed

Local, on the rebased tip `056145c8` (2026-09-14):

- `npm test --prefix frontend` — **1,161 passed across 161 files**
- `npm run lint --prefix frontend` — 0 errors, 35 warnings (byte-identical to
  main's baseline)
- `npm run build --prefix frontend` — compiled successfully
- `git diff --check` — clean

Backend was not touched by this PR, so its suite was not re-run locally; CI runs
it anyway and it is green.

**GitHub CI on `056145c8` — all 14 checks green**, including Playwright, the
Supabase stack integration tests, the "Fresh install vs upgraded deployment"
schema-drift gate, and CodeQL.

One local-only failure, **pre-existing and not from this PR**:
`src/app/components/modals/AccessModal.test.tsx` fails on this machine and
reproduces identically on a clean `origin/main` worktree, while passing in CI.
It belongs to the org-access work (#426) and touches no file in this diff.

New tests, by layer:
- `lib/quotedExcerpts.test.ts` — 37 cases: normalization, capping at word and
  hard boundaries, build/parse for single, multiple, multi-line and empty-body
  messages, fail-closed cases (ordinary prose, a user-authored blockquote, a
  bare preface line), and a table-driven round-trip suite.
- `hooks/useQuotableSelection.test.tsx` — 16 cases: capture inside a response,
  rejection in user bubbles and outside the container, collapsed and
  whitespace-only selections, cross-bubble clamping, dismissal on collapse /
  Escape / scroll / resize, the clear() latch, keyboard selection, disabled mode.
- `components/shared/QuoteSelectionPopup.test.tsx` — 14 cases: placement above,
  flipped below, all four viewport clamps, click and Enter activation, the
  text-field Enter guard, Shift+Enter, teardown, and body portalling.
- `components/shared/QuotedExcerptChip.test.tsx` — 9 cases: clamping, title
  fallback, accessible remove names, removal index, truncation notice.
- `components/shared/QuotedMessageContent.test.tsx` — 6 cases: plain
  passthrough, single and multiple quote blocks, quotes-only messages, and a
  user-authored blockquote left alone.
- `components/assistant/ChatInput.quotedExcerpts.test.tsx` — 10 cases: chip
  attach/stack/dedup/remove, capping notice, unchanged content with no
  excerpts, content prefixing on send, clear-on-send, and chips surviving a
  refused send.
- `components/assistant/UserMessage.test.tsx` — 2 added cases asserting the wire
  format never leaks into the bubble as literal `>` characters.

Playwright was not needed: every behavior has a unit-level assertion.

## Demo

**Recorded 2026-08-26**, live against this branch (dev stack, real Claude
response) on an earlier base. The feature is unchanged since; the recording has
not been re-shot after the 2026-09-14 rebase.

Highlight → popup → chip attaches → second highlight stacks → chip removed →
send → the excerpt renders as a styled quote in the sent bubble → page reload →
the quote persists.

![Highlight → Add to Chat live demo](https://raw.githubusercontent.com/amal66/mike/assets/pr384-demo-2026-08-26/pr384-highlight-add-to-chat-demo.gif)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NSG87RB94ikHfQyjT6TP1E
