### PR TITLE
fix(pdf): extract AcroForm field values, not just drawn page text

### DIFF
--- a/backend/src/lib/chat/tools/documentOps.test.ts
+++ b/backend/src/lib/chat/tools/documentOps.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it, vi } from "vitest";
+
+const getPageMock = vi.fn();
+
+vi.mock("pdfjs-dist/legacy/build/pdf.mjs", () => ({
+  getDocument: () => ({
+    promise: Promise.resolve({
+      numPages: 1,
+      getPage: getPageMock,
+    }),
+  }),
+}));
+
+import { extractPdfText } from "./documentOps";
+
+describe("extractPdfText", () => {
+  it("includes filled AcroForm field values alongside page text", async () => {
+    getPageMock.mockResolvedValue({
+      getTextContent: () =>
+        Promise.resolve({ items: [{ str: "Case No.:" }] }),
+      getAnnotations: () =>
+        Promise.resolve([
+          { fieldName: "CaseNumber", fieldValue: "24CV-1234" },
+          { fieldName: "EmptyField", fieldValue: "" },
+          { fieldName: undefined, fieldValue: "ignored" },
+        ]),
+    });
+
+    const text = await extractPdfText(new ArrayBuffer(0));
+
+    expect(text).toContain("Case No.:");
+    expect(text).toContain("[Page 1 form fields]");
+    expect(text).toContain("CaseNumber: 24CV-1234");
+    expect(text).not.toContain("EmptyField");
+  });
+
+  it("keeps page text when reading annotations fails", async () => {
+    getPageMock.mockResolvedValue({
+      getTextContent: () =>
+        Promise.resolve({ items: [{ str: "Visible text" }] }),
+      getAnnotations: () => Promise.reject(new Error("boom")),
+    });
+
+    const text = await extractPdfText(new ArrayBuffer(0));
+
+    expect(text).toContain("Visible text");
+    expect(text).not.toContain("form fields");
+  });
+});

--- a/backend/src/lib/chat/tools/documentOps.ts
+++ b/backend/src/lib/chat/tools/documentOps.ts
@@ -66,6 +66,9 @@ export async function extractPdfText(buf: ArrayBuffer): Promise<string> {
               getTextContent: () => Promise<{
                 items: { str?: string }[];
               }>;
+              getAnnotations: () => Promise<
+                { fieldName?: string; fieldValue?: unknown }[]
+              >;
             }>;
           }>;
         };
@@ -78,9 +81,26 @@ export async function extractPdfText(buf: ArrayBuffer): Promise<string> {
     for (let i = 1; i <= pdf.numPages; i++) {
       const page = await pdf.getPage(i);
       const textContent = await page.getTextContent();
-      parts.push(
-        `[Page ${i}]\n${textContent.items.map((it) => it.str ?? "").join(" ")}`,
-      );
+      let pageText = `[Page ${i}]\n${textContent.items.map((it) => it.str ?? "").join(" ")}`;
+      try {
+        const annotations = await page.getAnnotations();
+        const fields = annotations
+          .filter(
+            (a): a is { fieldName: string; fieldValue: unknown } =>
+              !!a.fieldName &&
+              a.fieldValue !== undefined &&
+              a.fieldValue !== null &&
+              a.fieldValue !== "",
+          )
+          .map((a) => `${a.fieldName}: ${a.fieldValue}`);
+        if (fields.length) {
+          pageText += `\n[Page ${i} form fields]\n${fields.join("\n")}`;
+        }
+      } catch {
+        // Fall back to page text alone; a filled but unflattened form on
+        // this page just won't surface its field values.
+      }
+      parts.push(pageText);
     }
     return parts.join("\n\n");
   } catch {


### PR DESCRIPTION
## Summary

`extractPdfText` only reads `page.getTextContent()`, which returns page **content-stream** text. It never sees a filled-but-unflattened PDF form, because those values live in annotation field data (`fieldName`/`fieldValue`), not on the page itself.

## Why

A PDF form filled out in a viewer that doesn't flatten the form (e.g. macOS Preview's plain Save/Export) writes typed values into AcroForm field annotations rather than drawing them onto the page. `page.getTextContent()` is blind to that — it only sees what's actually drawn. Command-line `pdftotext` reads the field values directly and correctly shows the form as filled; this app's PDF extraction returned the page as if it were blank, and since `extractPdfText` is the only source of PDF text for `read_document` (`documentOps.ts`), this happened regardless of which LLM read it downstream.

## Changes

`backend/src/lib/chat/tools/documentOps.ts` — `extractPdfText` now also calls `page.getAnnotations()` per page and appends any non-empty field values as a `[Page N form fields]` block after that page's normal text. The annotations read is wrapped in its own try/catch so a failure on one page falls back to that page's already-extracted text instead of losing it to the function's outer catch-all.

No other call site needed changes — `readDocumentContent` and both callers of `extractPdfText` just forward the returned string as-is.

## Testing

New `backend/src/lib/chat/tools/documentOps.test.ts` — mocks `pdfjs-dist`'s `getDocument`, and covers:
- filled field values are merged into the extracted text
- empty and unnamed fields are skipped
- an annotation-read failure falls back to page text instead of losing it

```
vitest run src/lib/chat/tools/documentOps.test.ts   2 passed
npm test --prefix backend                           841 passed | 25 skipped (1 unrelated pre-existing flake, passes in isolation)
tsc --noEmit --prefix backend                       clean
npm run build --prefix backend                      clean
```

The investigation and code in this PR were done by Claude (Sonnet 5) via Claude Code; I reviewed and am submitting it.