### PR TITLE
fix(citations): reject out-of-order, distant, and meaning-inverting ellipsis quotes

### DIFF
--- a/backend/src/lib/chat/verifyCitations.test.ts
+++ b/backend/src/lib/chat/verifyCitations.test.ts
@@ -137,6 +137,132 @@ describe("verifyQuoteAgainstSource", () => {
     expect(v.verified).toBe(false);
   });
 
+  // ── Adversarial ellipsis abuse ─────────────────────────────────────────
+  // These tests ATTACK the matcher instead of confirming it: each quote is
+  // built from real source words, so a matcher that merely finds every
+  // fragment somewhere would happily verify all of them. The original
+  // implementation did exactly that (each segment located independently),
+  // so every rejection case below verified as true before this fix.
+
+  it("rejects an ellipsis that swallows a negator and inverts meaning", () => {
+    const src =
+      "Under clause 9, the landlord is not permitted to terminate this lease during the fixed term.";
+    // Reads as "the landlord IS permitted to terminate" — the omitted word
+    // is "not". A verified badge here endorses the opposite of the source.
+    const v = verifyQuoteAgainstSource(
+      src,
+      "the landlord is ... permitted to terminate",
+    );
+    expect(v.verified).toBe(false);
+  });
+
+  it("rejects an ellipsis that swallows a negating contraction", () => {
+    const src = "The guarantor isn't liable for the tenant's costs.";
+    const v = verifyQuoteAgainstSource(
+      src,
+      "The guarantor ... liable for the tenant's costs",
+    );
+    expect(v.verified).toBe(false);
+  });
+
+  it("rejects an ellipsis that swallows an exception carve-out", () => {
+    const src =
+      "The deposit shall be returned in full except where the tenant is in breach.";
+    const v = verifyQuoteAgainstSource(
+      src,
+      "The deposit shall be returned in full ... the tenant is in breach",
+    );
+    expect(v.verified).toBe(false);
+  });
+
+  it("rejects fragments stitched together in reverse document order", () => {
+    const src =
+      "The alpha clause applies to assignments. The beta clause applies to subletting.";
+    const v = verifyQuoteAgainstSource(
+      src,
+      "beta clause applies to subletting ... alpha clause applies to assignments",
+    );
+    expect(v.verified).toBe(false);
+  });
+
+  it("rejects fragments quilted from distant parts of the document", () => {
+    const filler = "Unrelated boilerplate filler sentence follows here. ".repeat(
+      15,
+    ); // ~795 chars — far beyond any plausible single omission
+    const src = `The tenant shall maintain the garden. ${filler}The landlord shall insure the building.`;
+    const v = verifyQuoteAgainstSource(
+      src,
+      "The tenant shall maintain the garden ... The landlord shall insure the building",
+    );
+    expect(v.verified).toBe(false);
+  });
+
+  it("rejects a leading ellipsis that truncates away a same-clause negator", () => {
+    const src =
+      "Under clause 9, the landlord is not permitted to terminate this lease.";
+    const v = verifyQuoteAgainstSource(
+      src,
+      "... permitted to terminate this lease",
+    );
+    expect(v.verified).toBe(false);
+  });
+
+  it("rejects a trailing ellipsis that truncates before a same-clause carve-out", () => {
+    const src =
+      "The tenant may assign this lease unless the landlord objects in writing.";
+    const v = verifyQuoteAgainstSource(src, "The tenant may assign this lease ...");
+    expect(v.verified).toBe(false);
+  });
+
+  it("rejects a repeated fragment the source only contains once", () => {
+    const src = "Rent is payable monthly by standing order.";
+    const v = verifyQuoteAgainstSource(src, "standing order ... standing order");
+    expect(v.verified).toBe(false);
+  });
+
+  // ── Guards against over-blocking: legitimate abbreviations still pass ──
+
+  it("verifies an in-order abbreviation with a benign short omission", () => {
+    const src =
+      "The tenant shall, at reasonable times, permit the landlord to inspect the premises.";
+    const v = verifyQuoteAgainstSource(
+      src,
+      "The tenant shall ... permit the landlord to inspect",
+    );
+    expect(v.verified).toBe(true);
+    expect(v.needs_correction).toBe(false);
+    expect(v.source_excerpt).toBe(
+      "The tenant shall ... permit the landlord to inspect",
+    );
+  });
+
+  it("verifies a leading ellipsis whose negator sits in the previous sentence", () => {
+    const src =
+      "No pets are allowed on the premises. The tenant shall keep the garden tidy.";
+    // "No" belongs to the prior sentence — beyond the clause boundary, it
+    // does not bind the quoted fragment and must not veto it.
+    const v = verifyQuoteAgainstSource(
+      src,
+      "... The tenant shall keep the garden tidy",
+    );
+    expect(v.verified).toBe(true);
+  });
+
+  it("backtracks to a later occurrence when the first strands the chain", () => {
+    const filler = "Unrelated boilerplate filler sentence follows here. ".repeat(
+      15,
+    );
+    // "Rent is payable monthly" appears twice; only anchoring on the SECOND
+    // occurrence keeps the omission within bounds.
+    const src = `Rent is payable monthly. ${filler}Rent is payable monthly in advance by standing order.`;
+    const v = verifyQuoteAgainstSource(
+      src,
+      "Rent is payable monthly ... standing order",
+    );
+    expect(v.verified).toBe(true);
+    expect(v.source_excerpt).toBe("Rent is payable monthly ... standing order");
+  });
+
   it("supports ellipsis omissions inside a cross-page quote", () => {
     const quote =
       "The Tenant shall pay...first day of each month[[PAGE_BREAK]]The Landlord may terminate...written notice";

--- a/backend/src/lib/chat/verifyCitations.ts
+++ b/backend/src/lib/chat/verifyCitations.ts
@@ -20,6 +20,52 @@ type QuoteVerificationResult = QuoteVerification & {
   needs_correction: boolean;
 };
 
+// An ellipsis attests "contiguous text with a short omission", so the omitted
+// span between two located segments is bounded. 500 chars ≈ two long legal
+// sentences; beyond that the fragments are being quilted from unrelated parts
+// of the document rather than abbreviated from one passage.
+const MAX_OMITTED_SPAN_CHARS = 500;
+
+// Omissions that swallow a negator or exception word invert the sentence's
+// meaning ("is not permitted" → "is ... permitted"), which a verified badge
+// must never endorse. Word-list heuristic, deliberately conservative: a hit
+// yields "unverified" (no badge), never "wrong", so a false positive only
+// withholds the badge from an abbreviation a human should eyeball anyway.
+const MEANING_INVERTING_OMISSION =
+  /(?:\b(?:not|no|never|neither|nor|none|cannot|without|except|unless|exclud\w*|prohibit\w*|forbid\w*|denie[sd]|deny(?:ing)?|void)\b|n[''’]t\b)/i;
+
+// Backtracking budget for in-order segment matching. Each attempt is one
+// substring search; the cap keeps pathological inputs (many repeated
+// segments) from scanning forever and fails CLOSED — an unmatched chain is
+// reported unverified, never verified.
+const MAX_LOCATE_ATTEMPTS = 64;
+
+// A LEADING or TRAILING ellipsis truncates within a sentence, so the same
+// inversion hazard applies to the text it hides ("not permitted to
+// terminate" quoted as "... permitted to terminate"). Negators bind within
+// their clause, so only the source text between the match and the nearest
+// clause boundary is inspected — a negator in a *previous sentence* must not
+// veto an unrelated quote.
+const CLAUSE_BOUNDARY = /[.;:!?\n]/;
+const MAX_CLAUSE_CONTEXT_CHARS = 200;
+
+function clauseBefore(source: string, index: number): string {
+  const windowStart = Math.max(0, index - MAX_CLAUSE_CONTEXT_CHARS);
+  const window = source.slice(windowStart, index);
+  for (let i = window.length - 1; i >= 0; i -= 1) {
+    if (CLAUSE_BOUNDARY.test(window[i])) return window.slice(i + 1);
+  }
+  return window;
+}
+
+function clauseAfter(source: string, index: number): string {
+  const window = source.slice(index, index + MAX_CLAUSE_CONTEXT_CHARS);
+  for (let i = 0; i < window.length; i += 1) {
+    if (CLAUSE_BOUNDARY.test(window[i])) return window.slice(0, i);
+  }
+  return window;
+}
+
 /**
  * Locate `quote` inside `source`, returning the exact original substring
  * (`excerpt`) plus its char offsets into `source`. Tries progressively more
@@ -46,6 +92,63 @@ export function locateQuote(
     locateNormalized(source, quote, {}) ??
     locateNormalized(source, quote, { stripPunctuation: true })
   );
+}
+
+/**
+ * `locateQuote`, but only considering matches at or after `from` (offsets into
+ * the original source). Implemented by searching the suffix slice; the
+ * normalized tiers therefore renormalize the suffix, which is O(n) per call —
+ * acceptable because callers bound their attempt count.
+ */
+function locateQuoteFrom(
+  source: string,
+  quote: string,
+  from: number,
+): QuoteLocation | null {
+  if (from <= 0) return locateQuote(source, quote);
+  if (from >= source.length) return null;
+  const loc = locateQuote(source.slice(from), quote);
+  return loc
+    ? { start: loc.start + from, end: loc.end + from, excerpt: loc.excerpt }
+    : null;
+}
+
+/**
+ * Locate every segment of an abbreviated quote IN DOCUMENT ORDER, with at most
+ * `maxGap` original chars omitted between consecutive segments. Backtracks
+ * over earlier segments' candidate positions (a segment may recur, and only a
+ * later occurrence may leave room for the rest of the chain). Returns null —
+ * unverifiable — when no ordered, gap-bounded chain exists or the attempt
+ * budget runs out.
+ */
+function locateSegmentsInOrder(
+  source: string,
+  segments: string[],
+  maxGap: number,
+): QuoteLocation[] | null {
+  let attempts = 0;
+  const search = (
+    index: number,
+    from: number,
+    prevEnd: number | null,
+  ): QuoteLocation[] | null => {
+    if (index === segments.length) return [];
+    let cursor = from;
+    while (attempts < MAX_LOCATE_ATTEMPTS) {
+      attempts += 1;
+      const loc = locateQuoteFrom(source, segments[index], cursor);
+      if (!loc) return null;
+      // Every later occurrence of this segment sits even further from the
+      // previous one, so a gap violation ends this branch outright.
+      if (prevEnd !== null && loc.start - prevEnd > maxGap) return null;
+      const rest = search(index + 1, loc.end, loc.end);
+      if (rest) return [loc, ...rest];
+      // This occurrence strands a later segment; try the next one.
+      cursor = loc.start + 1;
+    }
+    return null;
+  };
+  return search(0, 0, null);
 }
 
 function locateNormalized(
@@ -104,8 +207,15 @@ export function verifyQuoteAgainstSource(
 
   // The document viewers treat ASCII and Unicode ellipses as omission
   // separators and highlight each quoted segment independently. Mirror that
-  // behavior here so a legitimate abbreviated quote is not rejected merely
-  // because text was intentionally omitted between its verbatim segments.
+  // tolerance here — but an ellipsis is a claim about the SHAPE of the
+  // omission, so the segments must additionally satisfy what the ellipsis
+  // asserts to the reader:
+  //   1. they appear in document order (no rearranged fragments),
+  //   2. the omitted span is short (no quilting distant parts together),
+  //   3. the omitted span contains no negator/exception word (an omission
+  //      that swallows "not" flips the sentence's meaning).
+  // Any violation returns unverified: in a legal product a green badge on a
+  // meaning-inverting or rearranged quote is worse than no verification.
   if (ELLIPSIS_PATTERN.test(quote)) {
     const segments = quote
       .split(ELLIPSIS_PATTERN)
@@ -114,21 +224,41 @@ export function verifyQuoteAgainstSource(
       // example, the fourth dot in "....") do not form quoted segments.
       .filter((segment) => /[\p{L}\p{N}]/u.test(segment));
     if (!segments.length) return { verified: false, needs_correction: false };
-    const located = segments.map((segment) => ({
-      segment,
-      location: locateQuote(source, segment),
-    }));
-    if (located.some(({ location }) => !location)) {
+    const located = locateSegmentsInOrder(
+      source,
+      segments,
+      MAX_OMITTED_SPAN_CHARS,
+    );
+    if (!located) return { verified: false, needs_correction: false };
+    for (let i = 1; i < located.length; i += 1) {
+      const omitted = source.slice(located[i - 1].end, located[i].start);
+      if (MEANING_INVERTING_OMISSION.test(omitted)) {
+        return { verified: false, needs_correction: false };
+      }
+    }
+    // Edge ellipses hide same-clause context the reader cannot see; refuse
+    // the badge when that hidden context negates or carves out the fragment.
+    const trimmedQuote = quote.trim();
+    if (
+      /^(?:\.{3}|…)/.test(trimmedQuote) &&
+      MEANING_INVERTING_OMISSION.test(clauseBefore(source, located[0].start))
+    ) {
+      return { verified: false, needs_correction: false };
+    }
+    if (
+      /(?:\.{3}|…)$/.test(trimmedQuote) &&
+      MEANING_INVERTING_OMISSION.test(
+        clauseAfter(source, located[located.length - 1].end),
+      )
+    ) {
       return { verified: false, needs_correction: false };
     }
     return {
       verified: true,
       needs_correction: located.some(
-        ({ segment, location }) => location!.excerpt !== segment,
+        (location, index) => location.excerpt !== segments[index],
       ),
-      source_excerpt: located
-        .map(({ location }) => location!.excerpt)
-        .join(" ... "),
+      source_excerpt: located.map((location) => location.excerpt).join(" ... "),
     };
   }
 


### PR DESCRIPTION
## Summary

Fixes #391.

On `main`, this verifies — badge and all:

```ts
const source = "Under clause 9, the landlord is not permitted to terminate this lease during the fixed term.";
verifyQuoteAgainstSource(source, "the landlord is ... permitted to terminate");
// → { verified: true }   // the quote asserts the OPPOSITE of the source
```

The ellipsis branch of `verifyQuoteAgainstSource` located each quoted fragment **independently, anywhere** in the source. Fragment order, omission size, and omission content were never checked, so reversed fragments, fragments quilted from distant pages, and omissions that swallow "not" all earned `verified: true`. In a product whose purpose is that users *don't* re-read the source, a badge that can endorse a meaning-inverted quote is worse than no badge.

## What changed

`backend/src/lib/chat/verifyCitations.ts` — the ellipsis branch now enforces what an ellipsis actually claims to a reader:

1. **In-order matching with backtracking** (`locateSegmentsInOrder`): fragments must appear in document order; each search starts after the previous match. If an early match strands a later fragment or overruns the gap bound, the matcher retries from the next occurrence, under a fixed attempt budget (64) that fails **closed**.
2. **Bounded omission**: at most `MAX_OMITTED_SPAN_CHARS` (500) may be omitted between consecutive fragments — ~two long legal sentences. Beyond that the quote is quilting distant text, not abbreviating one passage.
3. **Meaning-inversion guard**: if the omitted span contains a negation/exception word (`not`, `no`, `never`, `cannot`, `n't`, `without`, `except`, `unless`, `exclud*`, `prohibit*`, `forbid*`, `denie[sd]/deny`, `void`), the badge is refused. A **leading/trailing** ellipsis gets the same check against the hidden *same-clause* context (up to the nearest `.;:!?\n`), closing the trivial bypass of moving the ellipsis to the quote's edge.

`backend/src/lib/chat/verifyCitations.test.ts` — 11 new tests. Eight **attack** the matcher (inversion, contraction, exception carve-out, reversed order, distant quilting, leading/trailing edge-truncation, repeated fragment); all eight verified as `true` under the old implementation. Three guard against over-blocking (benign in-order omission, negator safely in a *previous* sentence, backtracking to a later anchor).

## Reproduce the bug on `main`

```bash
git checkout main
git checkout olp-pr/citation-quote-ordering -- backend/src/lib/chat/verifyCitations.test.ts
npm test --prefix backend -- src/lib/chat/verifyCitations.test.ts
```

Expected: **8 failed | 27 passed** — every `rejects …` test fails because `main` verifies the abuse quotes (run performed on `1b58c7aa`; output in the demo below).

## Verify the fix on this branch

```bash
git checkout olp-pr/citation-quote-ordering
npm test --prefix backend -- src/lib/chat/verifyCitations.test.ts
```

Expected: **35 passed** — all 24 pre-existing tests unchanged and green (legitimate abbreviated quotes still verify), all 8 attacks rejected.

## Demo

Live recording of the replication above — the identical test file run against `main`'s implementation (8 attack quotes verify → 8 failures) and then against this branch (all 35 pass):

![PR #392 demo: adversarial tests vs main, then vs this branch](https://raw.githubusercontent.com/amal66/mike/assets/pr392-demo-2026-08-27/pr392-adversarial-tests-demo.gif)

## Testing performed

- `npm test --prefix backend -- src/lib/chat/verifyCitations.test.ts`: 35/35 pass on this branch; the 8 new rejection tests fail on `main`'s implementation (red-before-green demonstrated by swapping only the source module).
- Full `npm test --prefix backend`: 68 files / 851 tests pass, 4 stack-gated files skipped as usual.
- `npm run build --prefix backend` (tsc): clean.

## Tradeoffs & design decisions

- **The inversion guard is a word-list heuristic, biased conservative.** A false positive only *withholds* the badge from an abbreviation a human should eyeball (e.g. omitting a harmless "without prejudice to clause 4" now yields unverified); a false negative would endorse a misquote. Given the badge's meaning, the asymmetry favors withholding.
- **`MAX_OMITTED_SPAN_CHARS = 500` is a calibration, not a derivation** — roughly two long legal sentences. Legitimate omissions of an entire long paragraph now come back unverified; reviewers may prefer a different constant, and the constant is the single knob.
- **Clause boundaries are approximated** as `[.;:!?\n]` for the edge-ellipsis checks. Qualifiers that *limit* rather than negate ("only", "provided that", "to the extent") are not in the word list, and a negator beyond an abbreviation like "cl. 9" is cut off by the period — residual risk accepted to keep false positives down.
- **Cross-page `[[PAGE_BREAK]]` segments are still verified per-segment without cross-segment ordering.** Deferred deliberately: the sentinel is constructed by our own viewer expansion rather than free-form model text, so the abuse surface is far smaller — but it is the same defect class, and I'll file it as a follow-up rather than widen this PR.
- **No char offsets for ellipsis quotes** (unchanged from before): offsets remain attached only to contiguous single-segment quotes.
- **Perf**: backtracking re-normalizes the source suffix per attempt (O(n) each). Bounded by the 64-attempt budget; typical quotes use 2–4 attempts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S4VRDD1DZat4SLYtt2q2eU

