### PR TITLE
word-addin: replace comment-enforced design parity with mechanisms

### DIFF
--- a/word-addin/package.json
+++ b/word-addin/package.json
@@ -8,8 +8,9 @@
   "scripts": {
     "dev": "webpack serve --mode development",
     "dev:server": "webpack serve --mode development",
-    "typecheck": "npm run typecheck:app && npm run typecheck:e2e",
+    "typecheck": "npm run typecheck:app && npm run typecheck:e2e && npm run check:tokens",
     "typecheck:app": "tsc --noEmit -p tsconfig.json",
+    "check:tokens": "node scripts/check-token-drift.mjs",
     "typecheck:e2e": "tsc --noEmit -p tsconfig.e2e.json",
     "build": "npm run typecheck && webpack --mode production && node scripts/build-manifest.js",
     "prestart": "node scripts/clear-sideload.js",

--- a/word-addin/scripts/check-token-drift.mjs
+++ b/word-addin/scripts/check-token-drift.mjs
@@ -1,0 +1,96 @@
+#!/usr/bin/env node
+/*
+ * Design-token drift check: the add-in's tokens.css is a hand-maintained
+ * subset of the web app's globals.css, and for years of one comment's
+ * lifetime ("Keep values in sync with globals.css") nothing verified that
+ * anyone did. This script is the mechanism that comment wished it was:
+ * every custom property the ADD-IN declares (in `:root`, `.dark`, and
+ * `@theme inline`) must exist in globals.css in the same scope with an
+ * identical value. Web-only additions are fine (the add-in is a subset);
+ * an add-in value that differs from — or no longer exists in — the web's
+ * is a hard failure naming each drifted token.
+ *
+ * Runs as part of `npm run typecheck` (so `npm run build` and the
+ * word-addin CI workflow both enforce it) and standalone via
+ * `npm run check:tokens`.
+ */
+import { readFileSync } from "node:fs";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const ADDIN_TOKENS = resolve(here, "../src/shared/styles/tokens.css");
+const WEB_GLOBALS = resolve(here, "../../frontend/src/app/globals.css");
+
+// The scopes tokens.css duplicates from globals.css. Selector blocks the
+// add-in does not duplicate (media queries, component classes) are out of
+// scope.
+const SCOPES = [
+  [/:root\s*\{/g, ":root"],
+  [/\.dark\s*\{/g, ".dark"],
+  [/@theme inline\s*\{/g, "@theme inline"],
+];
+
+/**
+ * Collect `--custom-property: value` declarations per scope. Multiple blocks
+ * with the same selector are merged; the FIRST declaration of a property
+ * wins, matching how the add-in's single-block files are written. Values are
+ * whitespace-normalized so formatting differences don't count as drift.
+ */
+function parseTokens(path) {
+  const css = readFileSync(path, "utf8");
+  const tokens = new Map();
+  for (const [pattern, scope] of SCOPES) {
+    pattern.lastIndex = 0;
+    for (const match of css.matchAll(pattern)) {
+      let depth = 1;
+      let i = match.index + match[0].length;
+      while (depth > 0 && i < css.length) {
+        if (css[i] === "{") depth += 1;
+        else if (css[i] === "}") depth -= 1;
+        i += 1;
+      }
+      const block = css.slice(match.index + match[0].length, i - 1);
+      for (const decl of block.matchAll(/(--[\w-]+)\s*:\s*([^;]+);/g)) {
+        const key = `${scope} ${decl[1]}`;
+        if (!tokens.has(key)) {
+          tokens.set(key, decl[2].trim().replace(/\s+/g, " "));
+        }
+      }
+    }
+  }
+  return tokens;
+}
+
+const addin = parseTokens(ADDIN_TOKENS);
+const web = parseTokens(WEB_GLOBALS);
+
+if (addin.size === 0) {
+  console.error(`check-token-drift: parsed 0 tokens from ${ADDIN_TOKENS} — ` +
+    "the parser no longer matches the file's structure; fix the check.");
+  process.exit(1);
+}
+
+const problems = [];
+for (const [key, addinValue] of addin) {
+  if (!web.has(key)) {
+    problems.push(`  ${key}\n    add-in: ${addinValue}\n    web:    (not defined)`);
+  } else if (web.get(key) !== addinValue) {
+    problems.push(`  ${key}\n    add-in: ${addinValue}\n    web:    ${web.get(key)}`);
+  }
+}
+
+if (problems.length > 0) {
+  console.error(
+    `check-token-drift: ${problems.length} token(s) in word-addin/src/shared/styles/tokens.css ` +
+      "have drifted from frontend/src/app/globals.css.\n" +
+      "The web app is the source of truth — update the add-in values to match\n" +
+      "(or, if the web token was removed, remove it from tokens.css):\n\n" +
+      problems.join("\n"),
+  );
+  process.exit(1);
+}
+
+console.log(
+  `check-token-drift: ${addin.size} add-in tokens match globals.css.`,
+);

--- a/word-addin/src/shared/styles/tokens.css
+++ b/word-addin/src/shared/styles/tokens.css
@@ -2,9 +2,13 @@
  * Shared design tokens for the Mike design system.
  *
  * A local subset of the web app's tokens (frontend/src/app/globals.css),
- * adapted for the Word add-in's independently bundled task pane. Keep values
- * in sync with globals.css. Import AFTER `@import "tailwindcss";` so the
- * `@theme` mappings and base layer apply.
+ * adapted for the Word add-in's independently bundled task pane. The web app
+ * is the source of truth: every value here must match globals.css exactly,
+ * and `npm run check:tokens` (scripts/check-token-drift.mjs, part of
+ * `npm run typecheck` and therefore of every build and CI run) fails on any
+ * drift — do not edit values here except to mirror a globals.css change.
+ * Import AFTER `@import "tailwindcss";` so the `@theme` mappings and base
+ * layer apply.
  *
  * Fonts: `--font-inter` / `--font-eb-garamond` are provided by the host app
  * (the web supplies them via next/font; the add-in via a Google Fonts <link>
@@ -66,11 +70,11 @@
 
 :root {
     --radius: 0.625rem;
-    --app-background: #fafafa;
+    --app-background: #f9fafb;
     --app-surface: #fdfdfe;
-    --app-surface-hover: #f5f6f8;
-    --app-surface-active: #eceef2;
-    --app-floating: rgba(253, 253, 254, 0.82);
+    --app-surface-hover: #f9fafb;
+    --app-surface-active: #eff0f3;
+    --app-floating: #fefefe;
     --background: oklch(0.985 0 0);
     --foreground: oklch(0.145 0 0);
     --card: oklch(1 0 0);

--- a/word-addin/src/shared/ui/tab-pill-button.tsx
+++ b/word-addin/src/shared/ui/tab-pill-button.tsx
@@ -1,6 +1,10 @@
 "use client";
 
 import * as React from "react";
+import {
+    LIQUID_GLASS_HOVER_CLASS,
+    LIQUID_GLASS_SUBTLE_CLASS,
+} from "@mike/liquid-glass-ui";
 import { cn } from "../lib/utils";
 
 type TabPillButtonProps = React.ComponentProps<"button"> & {
@@ -10,7 +14,11 @@ type TabPillButtonProps = React.ComponentProps<"button"> & {
 /**
  * Duplicated from the web app's glass pill tab
  * (frontend/src/app/components/ui/tab-pill-button.tsx) so the pane's tab bar
- * looks exactly like the web's. Only the `cn` import path differs.
+ * looks exactly like the web's. The visuals come from the SAME shared
+ * LiquidGlassUI constants and classes as the web (the add-in imports
+ * LiquidGlassUI.css and lists LiquidGlassUI.ts as a Tailwind source), so
+ * only the import paths may differ from the web file — keep the class
+ * strings below byte-identical to the web's when either side changes.
  */
 export function TabPillButton({
     active,
@@ -22,15 +30,15 @@ export function TabPillButton({
         active === true
             ? "border-white/80 bg-white text-gray-900"
             : active === false
-              ? "border-white/60 bg-white/45 text-gray-400 hover:bg-white/65 hover:text-gray-700"
-              : "border-white/70 bg-white/65 text-gray-700 hover:bg-white hover:text-gray-900";
+              ? `${LIQUID_GLASS_HOVER_CLASS} text-gray-400 hover:text-gray-700`
+              : `${LIQUID_GLASS_HOVER_CLASS} text-gray-700 hover:text-gray-900`;
 
     return (
         <button
             type={type}
             aria-pressed={active}
             className={cn(
-                "inline-flex h-7 items-center justify-center gap-1.5 rounded-full border px-3 text-xs font-medium shadow-[0_3px_9px_rgba(15,23,42,0.05),inset_0_1px_0_rgba(255,255,255,0.86),inset_0_-1px_0_rgba(255,255,255,0.58)] backdrop-blur-xl transition-all active:scale-[0.98] disabled:cursor-default disabled:opacity-40 disabled:active:scale-100",
+                `inline-flex h-7 items-center justify-center gap-1.5 rounded-full px-3 text-xs font-medium ${LIQUID_GLASS_SUBTLE_CLASS} backdrop-blur-xl transition-all active:scale-[0.98] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40 focus-visible:ring-offset-2 disabled:cursor-default disabled:opacity-40 disabled:active:scale-100`,
                 stateClass,
                 className,
             )}

--- a/word-addin/tsconfig.json
+++ b/word-addin/tsconfig.json
@@ -42,6 +42,9 @@
       "@mike/glass-card-ui": [
         "../frontend/src/shared/ui/GlassCardUI.tsx"
       ],
+      "@mike/liquid-glass-ui": [
+        "../frontend/src/shared/ui/LiquidGlassUI.ts"
+      ],
       "@mike/modal-ui": [
         "../frontend/src/shared/ui/ModalUI.tsx"
       ],

--- a/word-addin/webpack.config.js
+++ b/word-addin/webpack.config.js
@@ -162,6 +162,7 @@ module.exports = async (_env, options) => {
           "DocumentEventBlocksUI.tsx",
         ),
         "@mike/glass-card-ui": frontendSharedUi("GlassCardUI.tsx"),
+        "@mike/liquid-glass-ui": frontendSharedUi("LiquidGlassUI.ts"),
         "@mike/modal-ui": frontendSharedUi("ModalUI.tsx"),
         "@mike/header-buttons-ui": frontendSharedUi(
           "HeaderButtonsUI.tsx",


### PR DESCRIPTION
**Explainer:** https://claude.ai/code/artifact/49355c06-83b2-456f-af31-b9c6c591d19a

## Summary

Two invariants in the Word add-in were enforced only by comments, and both had quietly stopped being true:

1. **`word-addin/src/shared/styles/tokens.css`** hand-duplicates 121 design tokens from the web's `globals.css`, guarded by *"Keep values in sync with globals.css."* Nothing verified it, and **four light-mode surface tokens drifted** when the web palette moved (`--app-background`, `--app-surface-hover`, `--app-surface-active`, `--app-floating`) — the pane has been rendering slightly different surfaces than the web app it mirrors.
2. **`word-addin/src/shared/ui/tab-pill-button.tsx`** was forked from the web's pill with *"Only the `cn` import path differs."* Also no longer true: the web version moved to the shared `LiquidGlassUI` constants and gained a `focus-visible` ring; the fork kept a stale hardcoded shadow and had **no visible keyboard-focus state at all**, against AGENTS.md's own accessibility baseline.

This PR turns both comments into mechanisms.

## What changed

- **`word-addin/scripts/check-token-drift.mjs`** (new, 96 lines): parses both CSS files and requires every token the add-in declares (`:root`, `.dark`, `@theme inline`) to match `globals.css` exactly (web-only additions allowed — the add-in is a subset). Fails naming each drifted token, add-in vs web value; also fails if it parses zero tokens, so a file refactor can't silently no-op the check.
- **Wired as `npm run check:tokens` inside `npm run typecheck`**, which `npm run build` and the existing word-addin CI workflow already run — drift now fails every build and PR with **zero new CI wiring**.
- **The four drifted values are fixed** to the web's palette (web is the source of truth; it moved first, deliberately).
- **TabPillButton converges on the web implementation**: same `focus-visible` ring cluster, same `LIQUID_GLASS_SUBTLE_CLASS`/`LIQUID_GLASS_HOVER_CLASS` constants, imported via a new `@mike/liquid-glass-ui` alias (the established webpack+tsconfig pattern for `frontend/src/shared/ui` modules). No new duplication — the pane already imports `LiquidGlassUI.css` and lists `LiquidGlassUI.ts` as a Tailwind `@source`; the fork just predated them.

## Why

A comment is documentation of an intention, not a guarantee. Both of these comments were written by someone who meant them, and both were false within a few months, in ways nobody noticed: an operator can't see a 1-hex-digit surface drift, and a mouse user never discovers a missing focus ring. The cost of the mechanism is 96 lines and one `&&` in a package script; the cost of not having it is that the add-in and the web app diverge silently, forever.

The accessibility half is not cosmetic — AGENTS.md states "every interactive element needs a visible focus indicator" as a baseline, and the pane's tab bar had none.

## Reproduce the base case on main

```bash
git checkout main && npm ci --prefix word-addin

# 1. The guard is a comment, and it had already failed:
grep -n "Keep values in sync" word-addin/src/shared/styles/tokens.css
git checkout olp-pr/tokens-mechanism -- word-addin/scripts/check-token-drift.mjs
node word-addin/scripts/check-token-drift.mjs
#   → exits 1, naming exactly four drifted tokens:
#     :root --app-background       add-in #fafafa                   web #f9fafb
#     :root --app-surface-hover    add-in #f5f6f8                   web #f9fafb
#     :root --app-surface-active   add-in #eceef2                   web #eff0f3
#     :root --app-floating         add-in rgba(253, 253, 254, 0.82) web #fefefe

# 2. The pill has no focus indicator:
grep -c "focus-visible" word-addin/src/shared/ui/tab-pill-button.tsx   # → 0
```

Keyboard version of step 2: build/serve the pane, open the Add Documents modal, and Tab through its tab bar — nothing visibly moves.

## Verify on this branch

```bash
npm ci --prefix word-addin
npm run check:tokens --prefix word-addin      # → 121 add-in tokens match globals.css.
npm run typecheck --prefix word-addin         # → tsc app + tsc e2e + token check, all green
grep -c "focus-visible" word-addin/src/shared/ui/tab-pill-button.tsx   # → 1 (ring cluster present)
```

Actual output of the check on the rebased tip:

```
> mike-word-addin@1.0.0 check:tokens
> node scripts/check-token-drift.mjs

check-token-drift: 121 add-in tokens match globals.css.
```

Keyboard check: build/serve the pane, Tab to the Add Documents modal's tab bar — each pill now shows the same blue focus ring the web shows.

**Worth noting from this rebase:** main's `globals.css` moved by 161 lines between this PR being cut and today, and the checker still reports parity. The mechanism survived a live move of its own source of truth — which is precisely the event it exists to catch.

## Tradeoffs & design decisions

- **Check, not code-generation.** Generating tokens.css from globals.css would remove the duplication entirely, but the add-in file is a deliberate adaptation (own header, font-variable notes, `@custom-variant` line), and a generator would need to own that structure. A fail-loud equality check gets the same guarantee with a fraction of the machinery; generation remains the natural upgrade if the token set starts churning.
- **Subset semantics.** Web-only tokens don't fail the check — the add-in intentionally declares only what the pane uses. The cost: a web token *rename* shows up as "not defined in web" only because the add-in still carries the old name, which is the desired failure anyway, just not the clearest wording.
- **Wired into `typecheck` rather than its own CI step.** This reuses an entry point build and CI already call, at the cost of a slightly surprising place to find a CSS check. The alternative — a new workflow step — is more discoverable but adds CI wiring that can be forgotten on a new pipeline.
- **The pill stays a duplicated file.** Moving it into `frontend/src/shared/ui/` per AGENTS.md's cross-target rule is the full fix, but the web copy imports from `@/app/components/ui` context and the move touches web consumers — out of scope for a mechanisms PR. The comment now states the real contract (shared constants, byte-identical class strings) instead of a false one.
- **Class-string parity for the pill is still comment-enforced** (the token check does not read .tsx files). Extending the checker to diff the two pill files' class strings would be the next mechanism if this drifts again.
- **Other hardcoded liquid-glass shadows remain** in the pane (`InitialView`, `ModalForm`, `ChatInput`) — same fork pattern, not regressed by this PR, and each needs its own visual verification to converge; deliberately not batched in here.

## Testing performed

Local, 2026-09-14, on the rebased tip `0c33c289` (rebased onto `origin/main` `aba3cfca`, two commits replayed, no conflicts; `npm ci` re-run in `word-addin/` for main's 2026-09-11 dependency bumps):

- `npm run check:tokens --prefix word-addin` → **121 add-in tokens match globals.css**
- `npm run typecheck --prefix word-addin` → green (tsc app, tsc e2e, token check)
- `npm run build --prefix word-addin` → webpack compiled, production manifest written
- Bundle inspection of `word-addin/dist/`: contains `focus-visible:ring-blue-500/40` and the rest of the ring cluster, the `liquid-glass-*` classes, and the corrected token values (`--app-background: #f9fafb` light / `#0b0f14` dark)
- **Negative test**: running the checker against `main`'s `tokens.css` exits 1 and names exactly the four drifted tokens (output quoted above)
- `git diff --check` → clean

GitHub CI on `0c33c289`, 2026-09-14: **15 / 15 checks green** — including *Typecheck and Playwright (chromium + webkit)* (the job that now runs the token check), Frontend build and tests, Backend build and tests, Playwright, Supabase stack integration tests, Fresh install vs upgraded deployment, CodeQL / Analyze, gitleaks, dependency-audit ×4, CLA.

Local build note: `npm run build --prefix word-addin` needs `REACT_APP_WEB_APP_URL` and `WORD_ADDIN_PUBLIC_URL`, and the latter must be an HTTPS origin that is **not** `https://localhost:3200` (the manifest placeholder). Pre-existing guard on main, unrelated to this PR.

## Demo

Live recording: the new checker run against main's tokens.css (4 drifted tokens named) → this branch (121 match) → the typecheck wiring → the pill's `focus-visible` count, main vs branch:

![PR #396 demo: token drift check and focus ring](https://raw.githubusercontent.com/amal66/mike/assets/pr396-demo-2026-08-27/pr396-tokens-demo.gif)

*Recorded 2026-08-27. Not re-recorded for the 2026-09-14 rebase; every command in it was re-run by hand on the rebased tip and produced the same results (the token count is still 121 even though main's `globals.css` moved in between). The visual keyboard-focus check in a running task pane has **not** been redone post-rebase — the focus ring is verified here by class string and bundle contents only.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NSG87RB94ikHfQyjT6TP1E
