### PR TITLE
feat: add OrcaRouter as a first-class router provider

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -60,6 +60,7 @@ ANTHROPIC_API_KEY=your-anthropic-key
 OPENAI_API_KEY=your-openai-key
 # Optional router keys. Users can also save any of these in Settings.
 OPENROUTER_API_KEY=
+ORCAROUTER_API_KEY=
 AI_GATEWAY_API_KEY=
 OPENCODE_API_KEY=
 USER_API_KEYS_ENCRYPTION_SECRET=your-long-random-secret

--- a/backend/migrations/20260829_01_add_orcarouter_user_api_key_provider.sql
+++ b/backend/migrations/20260829_01_add_orcarouter_user_api_key_provider.sql
@@ -1,0 +1,7 @@
+-- Migration date: 2026-08-29
+ALTER TABLE public.user_api_keys
+  DROP CONSTRAINT IF EXISTS user_api_keys_provider_check;
+
+ALTER TABLE public.user_api_keys
+  ADD CONSTRAINT user_api_keys_provider_check
+  CHECK (provider IN ('claude', 'gemini', 'openai', 'openrouter', 'orcarouter', 'vercel', 'opencode-go', 'courtlistener'));

--- a/backend/schema.sql
+++ b/backend/schema.sql
@@ -191,7 +191,7 @@ alter table public.auth_handoff_tickets enable row level security;
 create table if not exists public.user_api_keys (
   id uuid primary key default gen_random_uuid(),
   user_id uuid not null references auth.users(id) on delete cascade,
-  provider text not null check (provider in ('claude', 'gemini', 'openai', 'openrouter', 'vercel', 'opencode-go', 'courtlistener')),
+  provider text not null check (provider in ('claude', 'gemini', 'openai', 'openrouter', 'orcarouter', 'vercel', 'opencode-go', 'courtlistener')),
   encrypted_key text not null,
   iv text not null,
   auth_tag text not null,

--- a/backend/src/lib/__tests__/llmModels.test.ts
+++ b/backend/src/lib/__tests__/llmModels.test.ts
@@ -15,6 +15,7 @@ import {
     providerForModel,
     resolveModel,
     openRouterModelId,
+    orcaRouterModelId,
     vercelModelId,
     openCodeGoModelId,
     isOpenCodeGoChatCompletionsModel,
@@ -69,6 +70,12 @@ describe("providerForModel", () => {
         expect(providerForModel("vercel/anthropic/claude-sonnet-4.5")).toBe(
             "vercel",
         );
+    });
+
+    it("maps namespaced OrcaRouter ids to the orcarouter provider", () => {
+        expect(
+            providerForModel("orcarouter/deepseek/deepseek-v4-flash"),
+        ).toBe("orcarouter");
     });
 
     it("maps namespaced OpenCode Go ids to the opencode-go provider", () => {
@@ -159,6 +166,18 @@ describe("resolveModel", () => {
         );
     });
 
+    it("accepts namespaced OrcaRouter model ids", () => {
+        expect(
+            resolveModel(
+                "orcarouter/deepseek/deepseek-v4-flash-free",
+                DEFAULT_MAIN_MODEL,
+            ),
+        ).toBe("orcarouter/deepseek/deepseek-v4-flash-free");
+        expect(resolveModel("orcarouter/invalid", DEFAULT_MAIN_MODEL)).toBe(
+            DEFAULT_MAIN_MODEL,
+        );
+    });
+
     it("accepts namespaced Vercel AI Gateway model ids", () => {
         expect(resolveModel("vercel/openai/gpt-5.4", DEFAULT_MAIN_MODEL)).toBe(
             "vercel/openai/gpt-5.4",
@@ -225,6 +244,14 @@ describe("openRouterModelId", () => {
         expect(openRouterModelId("openrouter/openrouter/auto")).toBe(
             "openrouter/auto",
         );
+    });
+});
+
+describe("orcaRouterModelId", () => {
+    it("removes only the internal provider namespace", () => {
+        expect(
+            orcaRouterModelId("orcarouter/deepseek/deepseek-v4-flash-free"),
+        ).toBe("deepseek/deepseek-v4-flash-free");
     });
 });
 

--- a/backend/src/lib/__tests__/openrouter.test.ts
+++ b/backend/src/lib/__tests__/openrouter.test.ts
@@ -428,6 +428,60 @@ describe("OpenRouter LLM adapter", () => {
     });
 });
 
+describe("OrcaRouter LLM adapter", () => {
+    afterEach(() => {
+        vi.unstubAllGlobals();
+        vi.clearAllMocks();
+        delete process.env.ORCAROUTER_BASE_URL;
+        delete process.env.ORCAROUTER_API_KEY;
+    });
+
+    it("uses the saved key, endpoint, and unprefixed model ID", async () => {
+        const fetchMock = vi.fn().mockResolvedValue(
+            new Response(
+                JSON.stringify({
+                    choices: [{ message: { content: "An Orca title" } }],
+                }),
+                {
+                    status: 200,
+                    headers: { "Content-Type": "application/json" },
+                },
+            ),
+        );
+        vi.stubGlobal("fetch", fetchMock);
+
+        const result = await completeWithProvider({
+            model: "orcarouter/deepseek/deepseek-v4-flash-free",
+            user: "Title this",
+            apiKeys: { orcarouter: "orca-user-key" },
+        });
+
+        expect(result).toBe("An Orca title");
+        const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+        expect(url).toBe("https://api.orcarouter.ai/v1/chat/completions");
+        expect(new Headers(init.headers).get("authorization")).toBe(
+            "Bearer orca-user-key",
+        );
+        // OpenRouter-only attribution headers must not leak to other routers.
+        expect(init.headers).not.toHaveProperty("X-Title");
+        expect(JSON.parse(String(init.body))).toMatchObject({
+            model: "deepseek/deepseek-v4-flash-free",
+        });
+    });
+
+    it("names OrcaRouter when no key is configured", async () => {
+        delete process.env.ORCAROUTER_API_KEY;
+        await expect(
+            completeWithProvider({
+                model: "orcarouter/deepseek/deepseek-v4-flash-free",
+                user: "Title this",
+            }),
+        ).rejects.toThrow(
+            "OrcaRouter API key is not configured. Set ORCAROUTER_API_KEY",
+        );
+    });
+});
+
 describe("Vercel AI Gateway LLM adapter", () => {
     afterEach(() => {
         vi.unstubAllGlobals();

--- a/backend/src/lib/__tests__/routerModels.test.ts
+++ b/backend/src/lib/__tests__/routerModels.test.ts
@@ -187,6 +187,9 @@ describe("router slugs", () => {
         expect(routerForModelId("openrouter/openai/gpt-5.4")).toBe(
             "openrouter",
         );
+        expect(routerForModelId("orcarouter/deepseek/deepseek-v4-flash")).toBe(
+            "orcarouter",
+        );
         expect(routerForModelId("vercel/openai/gpt-5.4")).toBe("vercel");
         expect(routerForModelId("opencode-go/glm-5")).toBe("opencode-go");
         expect(routerForModelId("gemini-3-flash-preview")).toBeNull();

--- a/backend/src/lib/__tests__/userApiKeys.test.ts
+++ b/backend/src/lib/__tests__/userApiKeys.test.ts
@@ -22,6 +22,7 @@ describe("normalizeApiKeyProvider", () => {
 
     it("returns the supported router providers", () => {
         expect(normalizeApiKeyProvider("openrouter")).toBe("openrouter");
+        expect(normalizeApiKeyProvider("orcarouter")).toBe("orcarouter");
         expect(normalizeApiKeyProvider("vercel")).toBe("vercel");
         expect(normalizeApiKeyProvider("opencode-go")).toBe("opencode-go");
     });
@@ -41,6 +42,7 @@ describe("hasEnvApiKey", () => {
         "OPENAI_API_KEY",
         "GEMINI_API_KEY",
         "OPENROUTER_API_KEY",
+        "ORCAROUTER_API_KEY",
         "AI_GATEWAY_API_KEY",
         "VERCEL_AI_GATEWAY_API_KEY",
         "OPENCODE_API_KEY",
@@ -85,6 +87,16 @@ describe("hasEnvApiKey", () => {
     it("accepts VERCEL_AI_GATEWAY_API_KEY as a compatibility alias", () => {
         process.env.VERCEL_AI_GATEWAY_API_KEY = "vercel-key-test";
         expect(hasEnvApiKey("vercel")).toBe(true);
+    });
+
+    it("returns true for OpenRouter when OPENROUTER_API_KEY is set", () => {
+        process.env.OPENROUTER_API_KEY = "or-key-test";
+        expect(hasEnvApiKey("openrouter")).toBe(true);
+    });
+
+    it("returns true for OrcaRouter when ORCAROUTER_API_KEY is set", () => {
+        process.env.ORCAROUTER_API_KEY = "orca-key-test";
+        expect(hasEnvApiKey("orcarouter")).toBe(true);
     });
 
     it("returns true for OpenCode Go when OPENCODE_API_KEY is set", () => {

--- a/backend/src/lib/llm/models.ts
+++ b/backend/src/lib/llm/models.ts
@@ -140,6 +140,7 @@ const ALL_MODELS = new Set<string>([
 export function providerForModel(model: string): Provider {
     if (model.startsWith("ollama")) return "ollama";
     if (model.startsWith("openrouter/")) return "openrouter";
+    if (model.startsWith("orcarouter/")) return "orcarouter";
     if (model.startsWith("vercel/")) return "vercel";
     if (model.startsWith("opencode-go/")) return "opencode-go";
     if (model.startsWith("claude")) return "claude";
@@ -165,9 +166,11 @@ export function resolveModel(
         canonical &&
         (ALL_MODELS.has(canonical) ||
             canonical.startsWith("ollama/") ||
-            /^(?:openrouter|vercel)\/[^\s/]+\/[^\s]+$/.test(canonical) ||
+            /^(?:openrouter|orcarouter|vercel)\/[^\s/]+\/[^\s]+$/.test(
+                canonical,
+            ) ||
             // OpenCode Go's catalog ids are single-segment ("glm-5"), not the
-            // vendor/model pairs OpenRouter and Vercel publish.
+            // vendor/model pairs OpenRouter, OrcaRouter and Vercel publish.
             /^opencode-go\/[^\s]+$/.test(canonical))
     )
         return canonical;
@@ -176,6 +179,10 @@ export function resolveModel(
 
 export function openRouterModelId(model: string): string {
     return model.replace(/^openrouter\//, "");
+}
+
+export function orcaRouterModelId(model: string): string {
+    return model.replace(/^orcarouter\//, "");
 }
 
 export function vercelModelId(model: string): string {

--- a/backend/src/lib/llm/providers.ts
+++ b/backend/src/lib/llm/providers.ts
@@ -10,6 +10,7 @@ import {
   normalizeReasoningLevelForModel,
   openCodeGoModelId,
   openRouterModelId,
+  orcaRouterModelId,
   providerForModel,
   vercelModelId,
 } from "./models";
@@ -25,6 +26,9 @@ import { REASONING_LEVELS } from "./types";
 const OPENROUTER_BASE_URL =
   process.env.OPENROUTER_BASE_URL?.trim().replace(/\/+$/, "") ||
   "https://openrouter.ai/api/v1";
+const ORCAROUTER_BASE_URL =
+  process.env.ORCAROUTER_BASE_URL?.trim().replace(/\/+$/, "") ||
+  "https://api.orcarouter.ai/v1";
 const OPENCODE_GO_BASE_URL =
   process.env.OPENCODE_GO_BASE_URL?.trim().replace(/\/+$/, "") ||
   "https://opencode.ai/zen/go/v1";
@@ -41,17 +45,19 @@ type CompleteProviderParams = {
 
 type RouterProvider = Extract<
   Provider,
-  "openrouter" | "vercel" | "opencode-go"
+  "openrouter" | "orcarouter" | "vercel" | "opencode-go"
 >;
 
 const ROUTER_LABELS: Record<RouterProvider, string> = {
   openrouter: "OpenRouter",
+  orcarouter: "OrcaRouter",
   vercel: "Vercel AI Gateway",
   "opencode-go": "OpenCode Go",
 };
 
 const ROUTER_KEY_ENV_HINTS: Record<RouterProvider, string> = {
   openrouter: "OPENROUTER_API_KEY",
+  orcarouter: "ORCAROUTER_API_KEY",
   vercel: "AI_GATEWAY_API_KEY",
   "opencode-go": "OPENCODE_API_KEY",
 };
@@ -79,6 +85,7 @@ function routerEnvironmentKey(provider: RouterProvider): string | undefined {
     );
   }
   if (provider === "opencode-go") return process.env.OPENCODE_API_KEY?.trim();
+  if (provider === "orcarouter") return process.env.ORCAROUTER_API_KEY?.trim();
   return process.env.OPENROUTER_API_KEY?.trim();
 }
 
@@ -88,6 +95,7 @@ function routerUserKey(
 ): string | null | undefined {
   if (provider === "vercel") return apiKeys?.vercel;
   if (provider === "opencode-go") return apiKeys?.["opencode-go"];
+  if (provider === "orcarouter") return apiKeys?.orcarouter;
   return apiKeys?.openrouter;
 }
 
@@ -151,6 +159,23 @@ async function createRouterAdapter(
       label: ROUTER_LABELS[provider],
       model: openrouter.chat(openRouterModelId(model)),
       modelId: model,
+    };
+  }
+
+  if (provider === "orcarouter") {
+    const { createOpenAICompatible } = await import("@ai-sdk/openai-compatible");
+    const orcarouter = createOpenAICompatible({
+      name: "orcarouter",
+      apiKey: key,
+      baseURL: ORCAROUTER_BASE_URL,
+      fetch: aiSdkFetch,
+    });
+    return {
+      provider,
+      label: ROUTER_LABELS[provider],
+      model: orcarouter(orcaRouterModelId(model)),
+      modelId: model,
+      supportsReasoning: false,
     };
   }
 
@@ -247,7 +272,7 @@ async function createProviderAdapter(
     };
   }
 
-  if (provider === "openrouter" || provider === "vercel") {
+  if (provider === "openrouter" || provider === "vercel" || provider === "orcarouter") {
     return createRouterAdapter(provider, model, apiKeys);
   }
 

--- a/backend/src/lib/llm/types.ts
+++ b/backend/src/lib/llm/types.ts
@@ -7,6 +7,7 @@ export type Provider =
     | "gemini"
     | "openai"
     | "openrouter"
+    | "orcarouter"
     | "vercel"
     | "opencode-go"
     | "ollama";
@@ -59,6 +60,7 @@ export type UserApiKeys = {
     gemini?: string | null;
     openai?: string | null;
     openrouter?: string | null;
+    orcarouter?: string | null;
     vercel?: string | null;
     "opencode-go"?: string | null;
     courtlistener?: string | null;

--- a/backend/src/lib/modelSelection.ts
+++ b/backend/src/lib/modelSelection.ts
@@ -201,6 +201,7 @@ export function titleModelForChat(
         case "openai":
             return OPENAI_LOW_MODELS[0];
         case "openrouter":
+        case "orcarouter":
         case "vercel":
         case "opencode-go":
         case "ollama":

--- a/backend/src/lib/routerModels.ts
+++ b/backend/src/lib/routerModels.ts
@@ -4,7 +4,7 @@ import { resolveModel } from "./llm/models";
 
 type Db = ReturnType<typeof createServerSupabase>;
 
-export type RouterSlug = "openrouter" | "vercel" | "opencode-go";
+export type RouterSlug = "openrouter" | "orcarouter" | "vercel" | "opencode-go";
 
 /**
  * Every router, in the order the settings UI lists them. A router's slug is
@@ -13,6 +13,7 @@ export type RouterSlug = "openrouter" | "vercel" | "opencode-go";
  */
 export const ROUTER_SLUGS: readonly RouterSlug[] = [
     "openrouter",
+    "orcarouter",
     "vercel",
     "opencode-go",
 ];
@@ -42,6 +43,7 @@ export function isRouterModelSelected(
 /** Router labels as the settings UI names them, for user-facing messages. */
 const ROUTER_LABELS: Record<RouterSlug, string> = {
     openrouter: "OpenRouter",
+    orcarouter: "OrcaRouter",
     vercel: "Vercel AI Gateway",
     "opencode-go": "OpenCode Go",
 };

--- a/backend/src/lib/userApiKeys.ts
+++ b/backend/src/lib/userApiKeys.ts
@@ -8,6 +8,7 @@ export type ApiKeyProvider =
     | "gemini"
     | "openai"
     | "openrouter"
+    | "orcarouter"
     | "vercel"
     | "opencode-go"
     | "courtlistener";
@@ -28,6 +29,7 @@ const PROVIDERS: ApiKeyProvider[] = [
     "gemini",
     "openai",
     "openrouter",
+    "orcarouter",
     "vercel",
     "opencode-go",
     "courtlistener",
@@ -47,6 +49,8 @@ function envApiKey(provider: ApiKeyProvider): string | null {
             return process.env.OPENAI_API_KEY?.trim() || null;
         case "openrouter":
             return process.env.OPENROUTER_API_KEY?.trim() || null;
+        case "orcarouter":
+            return process.env.ORCAROUTER_API_KEY?.trim() || null;
         case "vercel":
             return (
                 process.env.AI_GATEWAY_API_KEY?.trim() ||
@@ -127,6 +131,7 @@ export async function getUserApiKeyStatus(
         gemini: false,
         openai: false,
         openrouter: false,
+        orcarouter: false,
         vercel: false,
         "opencode-go": false,
         courtlistener: false,
@@ -135,6 +140,7 @@ export async function getUserApiKeyStatus(
             gemini: null,
             openai: null,
             openrouter: null,
+            orcarouter: null,
             vercel: null,
             "opencode-go": null,
             courtlistener: null,
@@ -174,6 +180,7 @@ export async function getUserApiKeys(
         gemini: envApiKey("gemini"),
         openai: envApiKey("openai"),
         openrouter: envApiKey("openrouter"),
+        orcarouter: envApiKey("orcarouter"),
         vercel: envApiKey("vercel"),
         "opencode-go": envApiKey("opencode-go"),
         courtlistener: envApiKey("courtlistener"),

--- a/backend/src/routes/__tests__/models.test.ts
+++ b/backend/src/routes/__tests__/models.test.ts
@@ -239,6 +239,114 @@ describe("GET /models/vercel", () => {
     });
 });
 
+describe("GET /models/orcarouter", () => {
+    beforeEach(() => {
+        getUserApiKeys.mockResolvedValue({ orcarouter: "orca-user-key" });
+    });
+
+    afterEach(() => {
+        vi.unstubAllGlobals();
+        vi.clearAllMocks();
+        delete process.env.ORCAROUTER_BASE_URL;
+    });
+
+    it("requires a configured OrcaRouter key", async () => {
+        getUserApiKeys.mockResolvedValue({});
+        const fetchMock = vi.fn();
+        vi.stubGlobal("fetch", fetchMock);
+
+        const response = await request(app).get("/models/orcarouter");
+
+        expect(response.status).toBe(422);
+        expect(response.body.code).toBe("missing_api_key");
+        expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it("returns the authenticated OrcaRouter catalog in selector shape", async () => {
+        const fetchMock = vi.fn().mockResolvedValue(
+            new Response(
+                JSON.stringify({
+                    data: [
+                        {
+                            id: "deepseek/deepseek-v4-flash-free",
+                            name: "DeepSeek V4 Flash Free",
+                        },
+                        {
+                            id: "anthropic/claude-sonnet-4.5",
+                            name: "Claude Sonnet 4.5",
+                            pricing: {
+                                prompt: "0.000003",
+                                completion: "0.000015",
+                            },
+                        },
+                        { id: null, name: "Invalid" },
+                    ],
+                }),
+                {
+                    status: 200,
+                    headers: { "Content-Type": "application/json" },
+                },
+            ),
+        );
+        vi.stubGlobal("fetch", fetchMock);
+
+        const response = await request(app).get("/models/orcarouter");
+
+        expect(response.status).toBe(200);
+        expect(response.body.models).toEqual([
+            { id: "deepseek/deepseek-v4-flash-free", label: "DeepSeek V4 Flash Free" },
+            {
+                id: "anthropic/claude-sonnet-4.5",
+                label: "Claude Sonnet 4.5",
+                pricing: { input: "0.000003", output: "0.000015" },
+            },
+        ]);
+        expect(fetchMock).toHaveBeenCalledWith(
+            "https://api.orcarouter.ai/v1/models",
+            { headers: { Authorization: "Bearer orca-user-key" } },
+        );
+        // The user's key must never reach the browser.
+        expect(JSON.stringify(response.body)).not.toContain("orca-user-key");
+    });
+
+    it("honors ORCAROUTER_BASE_URL like the chat adapter", async () => {
+        process.env.ORCAROUTER_BASE_URL = "http://localhost:4444/api/v1/";
+        const fetchMock = vi
+            .fn()
+            .mockResolvedValue(
+                new Response(JSON.stringify({ data: [] }), { status: 200 }),
+            );
+        vi.stubGlobal("fetch", fetchMock);
+
+        const response = await request(app).get("/models/orcarouter");
+
+        expect(response.status).toBe(200);
+        expect(fetchMock.mock.calls[0]?.[0]).toBe(
+            "http://localhost:4444/api/v1/models",
+        );
+    });
+
+    it("reports an upstream failure as a bad gateway", async () => {
+        const consoleError = vi
+            .spyOn(console, "error")
+            .mockImplementation(() => {});
+        vi.stubGlobal(
+            "fetch",
+            vi.fn().mockResolvedValue(new Response("nope", { status: 401 })),
+        );
+
+        const response = await request(app).get("/models/orcarouter");
+
+        expect(response.status).toBe(502);
+        expect(response.body).toEqual({
+            code: INTERNAL_ERROR_CODE,
+            detail: INTERNAL_ERROR_MESSAGE,
+        });
+        expect(response.text).not.toContain("nope");
+        consoleError.mockRestore();
+    });
+});
+
 describe("GET /models/opencode-go", () => {
     beforeEach(() => {
         getUserApiKeys.mockResolvedValue({ "opencode-go": "oc-user-key" });

--- a/backend/src/routes/__tests__/userRouterModels.test.ts
+++ b/backend/src/routes/__tests__/userRouterModels.test.ts
@@ -116,6 +116,7 @@ const API_KEY_STATUS = {
     gemini: false,
     openai: false,
     openrouter: true,
+    orcarouter: true,
     vercel: true,
     "opencode-go": true,
     courtlistener: false,
@@ -124,6 +125,7 @@ const API_KEY_STATUS = {
         gemini: null,
         openai: null,
         openrouter: "user",
+        orcarouter: "user",
         vercel: "user",
         "opencode-go": "user",
         courtlistener: null,
@@ -135,6 +137,7 @@ beforeEach(() => {
     getUserApiKeyStatus.mockResolvedValue(API_KEY_STATUS);
     getAllUserRouterModels.mockResolvedValue({
         openrouter: [],
+        orcarouter: [],
         vercel: [],
         "opencode-go": [],
     });
@@ -169,6 +172,25 @@ describe("PATCH /user/profile router model selections", () => {
             "user-1",
             "vercel",
             ["vercel/v0-1.5-md"],
+            expect.anything(),
+        );
+    });
+
+    it("accepts OrcaRouter vendor/model catalog ids", async () => {
+        const response = await request(app)
+            .patch("/user/profile")
+            .send({
+                orcaRouterModels: [
+                    "orcarouter/deepseek/deepseek-v4-flash",
+                    "anthropic/claude-sonnet-4.5",
+                ],
+            });
+
+        expect(response.status).toBe(200);
+        expect(replaceUserRouterModels).toHaveBeenCalledWith(
+            "user-1",
+            "orcarouter",
+            ["deepseek/deepseek-v4-flash", "anthropic/claude-sonnet-4.5"],
             expect.anything(),
         );
     });

--- a/backend/src/routes/models.ts
+++ b/backend/src/routes/models.ts
@@ -126,6 +126,75 @@ modelsRouter.get("/openrouter", requireAuth, async (_req, res) => {
     }
 });
 
+// OrcaRouter's authenticated catalog, limited to text models that support
+// tool calling because Mike supplies tools on interactive chat requests.
+modelsRouter.get("/orcarouter", requireAuth, async (_req, res) => {
+    const userId = res.locals.userId as string;
+    try {
+        const apiKeys = await getUserApiKeys(userId, createServerSupabase());
+        const key = apiKeys.orcarouter?.trim();
+        if (!key) {
+            return void res.status(422).json({
+                code: "missing_api_key",
+                detail: "An OrcaRouter API key is required to list models.",
+            });
+        }
+
+        // Honor the same base-URL override as the chat adapter so a proxy or
+        // test double sees the catalog request too (read per request, like
+        // the Vercel route below, so tests and re-configuration work).
+        const baseUrl = (
+            process.env.ORCAROUTER_BASE_URL?.trim() ||
+            "https://api.orcarouter.ai/v1"
+        ).replace(/\/+$/, "");
+        const response = await fetch(`${baseUrl}/models`, {
+            headers: { Authorization: `Bearer ${key}` },
+        });
+        if (!response.ok) {
+            const detail = await response.text().catch(() => "");
+            sendInternalError(
+                res,
+                new Error(
+                    `OrcaRouter model catalog request failed (${response.status})${detail ? `: ${detail}` : ""}`,
+                ),
+                502,
+            );
+            return;
+        }
+
+        const payload = (await response.json()) as {
+            data?: Array<{
+                id?: unknown;
+                name?: unknown;
+                pricing?: {
+                    prompt?: unknown;
+                    completion?: unknown;
+                };
+            }>;
+        };
+        const models = (payload.data ?? []).flatMap((model) => {
+            if (typeof model.id !== "string" || !model.id.trim()) return [];
+            const pricing = catalogPricing(
+                model.pricing?.prompt,
+                model.pricing?.completion,
+            );
+            return [
+                {
+                    id: model.id.trim(),
+                    label:
+                        typeof model.name === "string" && model.name.trim()
+                            ? model.name.trim()
+                            : model.id.trim(),
+                    ...(pricing ? { pricing } : {}),
+                },
+            ];
+        });
+        res.json({ models });
+    } catch (error) {
+        sendInternalError(res, error);
+    }
+});
+
 // Vercel AI Gateway's public catalog, limited to text models that support tool
 // calling because Mike supplies tools on interactive chat requests. A key must
 // still be configured before the catalog is exposed in the user's settings.

--- a/backend/src/routes/tabular.ts
+++ b/backend/src/routes/tabular.ts
@@ -504,6 +504,7 @@ function providerLabel(provider: Provider): string {
     if (provider === "claude") return "Anthropic";
     if (provider === "openai") return "OpenAI";
     if (provider === "openrouter") return "OpenRouter";
+    if (provider === "orcarouter") return "OrcaRouter";
     if (provider === "vercel") return "Vercel AI Gateway";
     if (provider === "opencode-go") return "OpenCode Go";
     if (provider === "ollama") return "Local (Ollama)";

--- a/backend/src/routes/user.ts
+++ b/backend/src/routes/user.ts
@@ -468,6 +468,7 @@ const CATALOG_MODEL_ID_RE = /^[^\s/]+\/[^\s]+$/;
  */
 const ROUTER_MODEL_ID_RE: Record<RouterSlug, RegExp> = {
     openrouter: CATALOG_MODEL_ID_RE,
+    orcarouter: CATALOG_MODEL_ID_RE,
     vercel: CATALOG_MODEL_ID_RE,
     "opencode-go": /^[^\s]+$/,
 };
@@ -478,6 +479,7 @@ const ROUTER_MODEL_ID_RE: Record<RouterSlug, RegExp> = {
  */
 export const ROUTER_PROFILE_FIELDS: Record<RouterSlug, string> = {
     openrouter: "openRouterModels",
+    orcarouter: "orcaRouterModels",
     vercel: "vercelModels",
     "opencode-go": "openCodeGoModels",
 };

--- a/frontend/src/app/(pages)/settings/byok/page.tsx
+++ b/frontend/src/app/(pages)/settings/byok/page.tsx
@@ -27,6 +27,11 @@ const MODEL_API_KEY_FIELDS = [
         placeholder: "sk-or-...",
     },
     {
+        provider: "orcarouter",
+        label: "OrcaRouter API Key",
+        placeholder: "sk-orca-...",
+    },
+    {
         provider: "vercel",
         label: "Vercel AI Gateway API Key",
         placeholder: "vck_...",

--- a/frontend/src/app/(pages)/settings/models/page.tsx
+++ b/frontend/src/app/(pages)/settings/models/page.tsx
@@ -20,6 +20,7 @@ import {
     canonicalModelId,
     openCodeGoModelOptions,
     openRouterModelOptions,
+    orcaRouterModelOptions,
     vercelModelOptions,
     type ModelOption,
 } from "@/app/components/assistant/ModelToggle";
@@ -46,9 +47,11 @@ export default function ModelPreferencesPage() {
     >({});
     const savedTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
     const openRouterSelection = profile?.openRouterModels ?? [];
+    const orcaRouterSelection = profile?.orcaRouterModels ?? [];
     const vercelSelection = profile?.vercelModels ?? [];
     const selectedOpenRouterOptions =
         openRouterModelOptions(openRouterSelection);
+    const selectedOrcaRouterOptions = orcaRouterModelOptions(orcaRouterSelection);
     const selectedVercelOptions = vercelModelOptions(vercelSelection);
     const selectedOpenCodeGoOptions = openCodeGoModelOptions(
         profile?.openCodeGoModels ?? [],
@@ -108,6 +111,7 @@ export default function ModelPreferencesPage() {
                             options={[
                                 ...SETTINGS_MODELS,
                                 ...selectedOpenRouterOptions,
+                                ...selectedOrcaRouterOptions,
                                 ...selectedVercelOptions,
                                 ...selectedOpenCodeGoOptions,
                                 ...ollamaModels,
@@ -136,6 +140,7 @@ export default function ModelPreferencesPage() {
                             options={[
                                 ...MODELS,
                                 ...selectedOpenRouterOptions,
+                                ...selectedOrcaRouterOptions,
                                 ...selectedVercelOptions,
                                 ...selectedOpenCodeGoOptions,
                                 ...ollamaModels,

--- a/frontend/src/app/components/assistant/ChatInput.tsx
+++ b/frontend/src/app/components/assistant/ChatInput.tsx
@@ -137,6 +137,7 @@ export const ChatInput = forwardRef<ChatInputHandle, Props>(function ChatInput(
             profile && !apiKeysDegraded
                 ? {
                   openRouterModels: profile.openRouterModels,
+                  orcaRouterModels: profile.orcaRouterModels,
                   vercelModels: profile.vercelModels,
                   openCodeGoModels: profile.openCodeGoModels,
                   }

--- a/frontend/src/app/components/assistant/ModelToggle.tsx
+++ b/frontend/src/app/components/assistant/ModelToggle.tsx
@@ -80,7 +80,7 @@ const MODEL_NAME_ACRONYMS: Record<string, string> = {
 
 export function modelDisplayName(modelId: string): string {
   const normalized = modelId
-    .replace(/^(?:openrouter|vercel|opencode-go|ollama)\//, "")
+    .replace(/^(?:openrouter|orcarouter|vercel|opencode-go|ollama)\//, "")
     .split("/")
     .at(-1)!
     .replace(/(\d)-(\d)/g, "$1.$2");
@@ -110,7 +110,7 @@ export function modelDisplayName(modelId: string): string {
  * Router slugs, which double as model-id prefixes and API-key provider names.
  * Kept in sync with backend/src/lib/routerModels.ts ROUTER_SLUGS.
  */
-export const ROUTER_SLUGS = ["openrouter", "vercel", "opencode-go"] as const;
+export const ROUTER_SLUGS = ["openrouter", "orcarouter", "vercel", "opencode-go"] as const;
 export type RouterSlug = (typeof ROUTER_SLUGS)[number];
 
 const ROUTER_VENDOR_GROUPS: Record<string, string> = {
@@ -178,6 +178,7 @@ interface Props {
    *  trigger instead of flashing "No Models" on every page load. */
   apiKeysLoading?: boolean;
   openRouterModels?: string[];
+  orcaRouterModels?: string[];
   vercelModels?: string[];
   openCodeGoModels?: string[];
   compact?: boolean;
@@ -211,6 +212,15 @@ export function openRouterModelOptions(models: string[]): ModelOption[] {
   }));
 }
 
+export function orcaRouterModelOptions(models: string[]): ModelOption[] {
+  return models.map((model) => ({
+    id: `orcarouter/${model}`,
+    label: modelDisplayName(model),
+    group: underlyingProviderGroup(model, "orcarouter"),
+    source: "OrcaRouter",
+  }));
+}
+
 export function vercelModelOptions(models: string[]): ModelOption[] {
   return models.map((model) => ({
     id: `vercel/${model}`,
@@ -235,6 +245,7 @@ export function ModelToggle({
   apiKeys,
   apiKeysLoading = false,
   openRouterModels = [],
+  orcaRouterModels = [],
   vercelModels = [],
   openCodeGoModels = [],
   compact = false,
@@ -247,6 +258,7 @@ export function ModelToggle({
   const models = [
     ...MODELS,
     ...openRouterModelOptions(openRouterModels),
+    ...orcaRouterModelOptions(orcaRouterModels),
     ...vercelModelOptions(vercelModels),
     ...openCodeGoModelOptions(openCodeGoModels),
     ...ollamaModels.map((model) => ({
@@ -282,6 +294,7 @@ export function ModelToggle({
       (availableModels.length > 0 ? "Select model" : "No Models"));
   const emptyReason = noModelsReason(apiKeys, {
     openrouter: openRouterModels,
+    orcarouter: orcaRouterModels,
     vercel: vercelModels,
     "opencode-go": openCodeGoModels,
   });

--- a/frontend/src/app/components/settings/RouterSettingsSection.test.tsx
+++ b/frontend/src/app/components/settings/RouterSettingsSection.test.tsx
@@ -18,6 +18,7 @@ const {
 vi.mock("@/app/lib/mikeApi", () => ({
     getOpenRouterModels,
     getVercelModels: vi.fn().mockResolvedValue([]),
+    getOrcaRouterModels: vi.fn().mockResolvedValue([]),
     getOpenCodeGoModels,
 }));
 
@@ -26,6 +27,7 @@ vi.mock("@/app/contexts/UserProfileContext", () => ({
         profile: {
             apiKeys: {
                 openrouter: { configured: true, source: "user" },
+                orcarouter: { configured: false, source: null },
                 vercel: { configured: false, source: null },
                 "opencode-go": {
                     configured: openCodeGoConfigured.value,
@@ -33,10 +35,12 @@ vi.mock("@/app/contexts/UserProfileContext", () => ({
                 },
             },
             openRouterModels: ["anthropic/claude-sonnet-4.5"],
+            orcaRouterModels: [],
             vercelModels: [],
             openCodeGoModels: [],
         },
         updateOpenRouterModels,
+        updateOrcaRouterModels: vi.fn(),
         updateVercelModels: vi.fn(),
         updateOpenCodeGoModels,
     }),

--- a/frontend/src/app/components/settings/RouterSettingsSection.tsx
+++ b/frontend/src/app/components/settings/RouterSettingsSection.tsx
@@ -13,6 +13,7 @@ import { useUserProfile } from "@/app/contexts/UserProfileContext";
 import {
     getOpenCodeGoModels,
     getOpenRouterModels,
+    getOrcaRouterModels,
     getVercelModels,
     type RouterCatalogModel,
 } from "@/app/lib/mikeApi";
@@ -64,6 +65,11 @@ const ROUTER_MODEL_ID: Record<
         pattern: CATALOG_MODEL_ID_RE,
         shape: "vendor/model",
         example: "anthropic/claude-sonnet-5",
+    },
+    orcarouter: {
+        pattern: CATALOG_MODEL_ID_RE,
+        shape: "vendor/model",
+        example: "deepseek/deepseek-v4-flash",
     },
     vercel: {
         pattern: CATALOG_MODEL_ID_RE,
@@ -120,16 +126,24 @@ export function RouterSettingsSection() {
     const {
         profile,
         updateOpenRouterModels,
+        updateOrcaRouterModels,
         updateVercelModels,
         updateOpenCodeGoModels,
     } = useUserProfile();
     const openRouterConfigured =
         profile?.apiKeys.openrouter.configured === true;
+    const orcaRouterConfigured =
+        profile?.apiKeys.orcarouter.configured === true;
     const vercelConfigured = profile?.apiKeys.vercel.configured === true;
     const openCodeGoConfigured =
         profile?.apiKeys["opencode-go"].configured === true;
 
-    if (!openRouterConfigured && !vercelConfigured && !openCodeGoConfigured) {
+    if (
+        !openRouterConfigured &&
+        !orcaRouterConfigured &&
+        !vercelConfigured &&
+        !openCodeGoConfigured
+    ) {
         return null;
     }
 
@@ -150,6 +164,15 @@ export function RouterSettingsSection() {
                         selection={profile?.openRouterModels ?? []}
                         loadCatalog={getOpenRouterModels}
                         onSave={updateOpenRouterModels}
+                    />
+                )}
+                {orcaRouterConfigured && (
+                    <RouterModelsSetting
+                        provider="orcarouter"
+                        label="OrcaRouter"
+                        selection={profile?.orcaRouterModels ?? []}
+                        loadCatalog={getOrcaRouterModels}
+                        onSave={updateOrcaRouterModels}
                     />
                 )}
                 {vercelConfigured && (

--- a/frontend/src/app/components/tabular/NewTRModal.tsx
+++ b/frontend/src/app/components/tabular/NewTRModal.tsx
@@ -133,11 +133,12 @@ export function NewTRModal({
     useEffect(() => {
         if (!open || !profile?.tabularModel) return;
         const defaultModel = profile.tabularModel;
-        const router = (["openrouter", "vercel", "opencode-go"] as const).find(
-            (slug) => defaultModel.startsWith(`${slug}/`),
-        );
+        const router = (
+            ["openrouter", "orcarouter", "vercel", "opencode-go"] as const
+        ).find((slug) => defaultModel.startsWith(`${slug}/`));
         const selectedByRouter: Record<RouterSlug, string[]> = {
             openrouter: profile.openRouterModels,
+            orcarouter: profile.orcaRouterModels,
             vercel: profile.vercelModels,
             "opencode-go": profile.openCodeGoModels,
         };

--- a/frontend/src/app/components/workflows/UseWorkflowModal.tsx
+++ b/frontend/src/app/components/workflows/UseWorkflowModal.tsx
@@ -124,11 +124,12 @@ export function UseWorkflowModal({ workflow, onClose, skipSelect = false }: Prop
             return;
         }
         const defaultModel = profile.tabularModel;
-        const router = (["openrouter", "vercel", "opencode-go"] as const).find(
-            (slug) => defaultModel.startsWith(`${slug}/`),
-        );
+        const router = (
+            ["openrouter", "orcarouter", "vercel", "opencode-go"] as const
+        ).find((slug) => defaultModel.startsWith(`${slug}/`));
         const routerSelections: Record<RouterSlug, string[]> = {
             openrouter: profile.openRouterModels,
+            orcarouter: profile.orcaRouterModels,
             vercel: profile.vercelModels,
             "opencode-go": profile.openCodeGoModels,
         };

--- a/frontend/src/app/contexts/UserProfileContext.tsx
+++ b/frontend/src/app/contexts/UserProfileContext.tsx
@@ -56,6 +56,7 @@ interface UserProfile {
     legalResearchUs: boolean;
     quickActionsVisible: boolean;
     openRouterModels: string[];
+    orcaRouterModels: string[];
     vercelModels: string[];
     openCodeGoModels: string[];
     darkMode: boolean;
@@ -98,6 +99,7 @@ interface UserProfileContextType {
     updateLegalResearchUs: (enabled: boolean) => Promise<boolean>;
     updateQuickActionsVisible: (visible: boolean) => Promise<boolean>;
     updateOpenRouterModels: (models: string[]) => Promise<boolean>;
+    updateOrcaRouterModels: (models: string[]) => Promise<boolean>;
     updateVercelModels: (models: string[]) => Promise<boolean>;
     updateOpenCodeGoModels: (models: string[]) => Promise<boolean>;
     updateDarkMode: (enabled: boolean) => Promise<void>;
@@ -118,6 +120,7 @@ const API_KEY_PROVIDERS: ApiKeyProvider[] = [
     "gemini",
     "openai",
     "openrouter",
+    "orcarouter",
     "vercel",
     "opencode-go",
     "courtlistener",
@@ -129,6 +132,7 @@ function emptyApiKeys(): ApiKeyState {
         gemini: { configured: false, source: null },
         openai: { configured: false, source: null },
         openrouter: { configured: false, source: null },
+        orcarouter: { configured: false, source: null },
         vercel: { configured: false, source: null },
         "opencode-go": { configured: false, source: null },
         courtlistener: { configured: false, source: null },
@@ -164,6 +168,9 @@ function toProfile(data: ApiUserProfile): UserProfile {
         mfaOnLogin: profile.mfaOnLogin === true,
         openRouterModels: Array.isArray(profile.openRouterModels)
             ? profile.openRouterModels
+            : [],
+        orcaRouterModels: Array.isArray(profile.orcaRouterModels)
+            ? profile.orcaRouterModels
             : [],
         vercelModels: Array.isArray(profile.vercelModels)
             ? profile.vercelModels
@@ -228,6 +235,7 @@ export function UserProfileProvider({ children }: { children: ReactNode }) {
                 legalResearchUs: true,
                 quickActionsVisible: true,
                 openRouterModels: [],
+                orcaRouterModels: [],
                 vercelModels: [],
                 openCodeGoModels: [],
                 darkMode: false,
@@ -499,6 +507,22 @@ export function UserProfileProvider({ children }: { children: ReactNode }) {
         [user],
     );
 
+    const updateOrcaRouterModels = useCallback(
+        async (orcaRouterModels: string[]): Promise<boolean> => {
+            if (!user) return false;
+            try {
+                const updated = await updateUserProfile({ orcaRouterModels });
+                setProfile((prev) =>
+                    prev ? { ...prev, ...toProfile(updated) } : null,
+                );
+                return true;
+            } catch {
+                return false;
+            }
+        },
+        [user],
+    );
+
     const updateVercelModels = useCallback(
         async (vercelModels: string[]): Promise<boolean> => {
             if (!user) return false;
@@ -620,6 +644,7 @@ export function UserProfileProvider({ children }: { children: ReactNode }) {
                 updateLegalResearchUs,
                 updateQuickActionsVisible,
                 updateOpenRouterModels,
+                updateOrcaRouterModels,
                 updateVercelModels,
                 updateOpenCodeGoModels,
                 updateDarkMode,

--- a/frontend/src/app/hooks/useSelectedModel.test.ts
+++ b/frontend/src/app/hooks/useSelectedModel.test.ts
@@ -9,6 +9,7 @@ const keys: ApiKeyState = {
     gemini: { configured: false, source: null },
     openai: { configured: true, source: "user" },
     openrouter: { configured: true, source: "user" },
+    orcarouter: { configured: false, source: null },
     vercel: { configured: false, source: null },
     "opencode-go": { configured: false, source: null },
     courtlistener: { configured: false, source: null },
@@ -16,6 +17,7 @@ const keys: ApiKeyState = {
 
 const routerSelections = {
     openRouterModels: ["openai/gpt-5.4"],
+    orcaRouterModels: [],
     vercelModels: [],
     openCodeGoModels: [],
 };

--- a/frontend/src/app/hooks/useSelectedModel.ts
+++ b/frontend/src/app/hooks/useSelectedModel.ts
@@ -30,6 +30,7 @@ export interface SelectedModelSources {
     lastSelectedModel?: string | null;
     routerSelections?: {
         openRouterModels: string[];
+        orcaRouterModels: string[];
         vercelModels: string[];
         openCodeGoModels: string[];
     } | null;
@@ -51,6 +52,7 @@ function usableStoredModel(
     if (router && sources.routerSelections) {
         const selections: Record<RouterSlug, string[]> = {
             openrouter: sources.routerSelections.openRouterModels,
+            orcarouter: sources.routerSelections.orcaRouterModels,
             vercel: sources.routerSelections.vercelModels,
             "opencode-go": sources.routerSelections.openCodeGoModels,
         };
@@ -72,6 +74,7 @@ export function useSelectedModel(
     const manuallySelected = useRef(false);
     const previousSelectionKey = useRef(sources.selectionKey);
     const openRouterModels = sources.routerSelections?.openRouterModels;
+    const orcaRouterModels = sources.routerSelections?.orcaRouterModels;
     const vercelModels = sources.routerSelections?.vercelModels;
     const openCodeGoModels = sources.routerSelections?.openCodeGoModels;
     const hasRouterSelections = sources.routerSelections != null;
@@ -83,6 +86,7 @@ export function useSelectedModel(
             routerSelections: hasRouterSelections
                 ? {
                       openRouterModels: openRouterModels ?? [],
+                      orcaRouterModels: orcaRouterModels ?? [],
                       vercelModels: vercelModels ?? [],
                       openCodeGoModels: openCodeGoModels ?? [],
                   }
@@ -95,6 +99,7 @@ export function useSelectedModel(
             sources.lastSelectedModel,
             hasRouterSelections,
             openRouterModels,
+            orcaRouterModels,
             vercelModels,
             openCodeGoModels,
             sources.apiKeys,

--- a/frontend/src/app/lib/mikeApi.ts
+++ b/frontend/src/app/lib/mikeApi.ts
@@ -415,6 +415,7 @@ export interface UserProfile {
     quickActionsVisible: boolean;
     darkMode: boolean;
     openRouterModels: string[];
+    orcaRouterModels: string[];
     vercelModels: string[];
     openCodeGoModels: string[];
     apiKeyStatus: ApiKeyStatus;
@@ -528,6 +529,7 @@ export async function updateUserProfile(payload: {
     quickActionsVisible?: boolean;
     darkMode?: boolean;
     openRouterModels?: string[];
+    orcaRouterModels?: string[];
     vercelModels?: string[];
     openCodeGoModels?: string[];
 }): Promise<UserProfile> {
@@ -569,6 +571,7 @@ export type ApiKeyProvider =
     | "gemini"
     | "openai"
     | "openrouter"
+    | "orcarouter"
     | "vercel"
     | "opencode-go"
     | "courtlistener";
@@ -616,6 +619,13 @@ export async function getOllamaModels(): Promise<OllamaModelOption[]> {
 export async function getOpenRouterModels(): Promise<RouterCatalogModel[]> {
     const { models } = await apiRequest<{ models: RouterCatalogModel[] }>(
         "/models/openrouter",
+    );
+    return models;
+}
+
+export async function getOrcaRouterModels(): Promise<RouterCatalogModel[]> {
+    const { models } = await apiRequest<{ models: RouterCatalogModel[] }>(
+        "/models/orcarouter",
     );
     return models;
 }

--- a/frontend/src/app/lib/modelAvailability.ts
+++ b/frontend/src/app/lib/modelAvailability.ts
@@ -9,6 +9,7 @@ export type ModelProvider =
     | "gemini"
     | "openai"
     | "openrouter"
+    | "orcarouter"
     | "vercel"
     | "opencode-go"
     | "ollama";
@@ -16,6 +17,7 @@ export type ModelProvider =
 export function getModelProvider(modelId: string): ModelProvider | null {
     if (modelId.startsWith("ollama/")) return "ollama"; // dynamic, not in the static list
     if (modelId.startsWith("openrouter/")) return "openrouter";
+    if (modelId.startsWith("orcarouter/")) return "orcarouter";
     if (modelId.startsWith("vercel/")) return "vercel";
     if (modelId.startsWith("opencode-go/")) return "opencode-go";
     const model = SETTINGS_MODELS.find((m) => m.id === modelId);
@@ -44,6 +46,7 @@ export function providerLabel(provider: ModelProvider): string {
     if (provider === "claude") return "Anthropic (Claude)";
     if (provider === "openai") return "OpenAI";
     if (provider === "openrouter") return "OpenRouter";
+    if (provider === "orcarouter") return "OrcaRouter";
     if (provider === "vercel") return "Vercel AI Gateway";
     if (provider === "opencode-go") return "OpenCode Go";
     if (provider === "ollama") return "Local (Ollama)";
@@ -56,6 +59,7 @@ export function modelGroupToProvider(
     if (group === "Anthropic") return "claude";
     if (group === "OpenAI") return "openai";
     if (group === "OpenRouter") return "openrouter";
+    if (group === "OrcaRouter") return "orcarouter";
     if (group === "Vercel AI Gateway") return "vercel";
     if (group === "OpenCode Go") return "opencode-go";
     if (group === "Local") return "ollama";

--- a/frontend/src/shared/ui/ModelToggleUI.tsx
+++ b/frontend/src/shared/ui/ModelToggleUI.tsx
@@ -60,7 +60,7 @@ const GPT_56_REASONING_LEVELS: readonly ReasoningLevel[] = REASONING_LEVELS;
 export function reasoningLevelsForModel(
   modelId: string,
 ): readonly ReasoningLevel[] {
-  const catalogId = modelId.replace(/^(?:openrouter|vercel)\//, "");
+  const catalogId = modelId.replace(/^(?:openrouter|orcarouter|vercel)\//, "");
   if (/(?:^|\/)gpt-5\.6(?:-|$)/.test(catalogId)) {
     return GPT_56_REASONING_LEVELS;
   }

--- a/word-addin/src/taskpane/api/client.ts
+++ b/word-addin/src/taskpane/api/client.ts
@@ -182,6 +182,7 @@ interface UserProfile {
   mfaOnLogin: boolean;
   legalResearchUs: boolean;
   openRouterModels: string[];
+  orcaRouterModels: string[];
   vercelModels: string[];
   openCodeGoModels: string[];
   apiKeyStatus: ApiKeyStatus;
@@ -218,6 +219,7 @@ export interface ApiKeyStatus {
   gemini: boolean;
   openai: boolean;
   openrouter: boolean;
+  orcarouter: boolean;
   vercel: boolean;
   "opencode-go": boolean;
   courtlistener: boolean;
@@ -227,6 +229,7 @@ export interface ApiKeyStatus {
       | "gemini"
       | "openai"
       | "openrouter"
+      | "orcarouter"
       | "vercel"
       | "opencode-go"
       | "courtlistener",

--- a/word-addin/src/taskpane/components/assistant/ChatInput.tsx
+++ b/word-addin/src/taskpane/components/assistant/ChatInput.tsx
@@ -105,6 +105,7 @@ export const ChatInput = forwardRef<ChatInputHandle, ChatInputProps>(
     const [keyStatus, setKeyStatus] = useState<ApiKeyStatus | null>(null);
     const [keyStatusLoading, setKeyStatusLoading] = useState(true);
     const [openRouterModels, setOpenRouterModels] = useState<string[]>([]);
+    const [orcaRouterModels, setOrcaRouterModels] = useState<string[]>([]);
     const [vercelModels, setVercelModels] = useState<string[]>([]);
     const [openCodeGoModels, setOpenCodeGoModels] = useState<string[]>([]);
     const [profileLastSelectedModel, setProfileLastSelectedModel] = useState<
@@ -116,7 +117,12 @@ export const ChatInput = forwardRef<ChatInputHandle, ChatInputProps>(
       chatModel,
       lastSelectedModel: lastSelectedModel ?? profileLastSelectedModel,
       routerSelections: profileLoaded
-        ? { openRouterModels, vercelModels, openCodeGoModels }
+        ? {
+            openRouterModels,
+            orcaRouterModels,
+            vercelModels,
+            openCodeGoModels,
+          }
         : null,
       apiKeyStatus: keyStatus,
     });
@@ -237,6 +243,7 @@ export const ChatInput = forwardRef<ChatInputHandle, ChatInputProps>(
         setKeyStatus(status);
         if (profile) {
           setOpenRouterModels(profile.openRouterModels ?? []);
+          setOrcaRouterModels(profile.orcaRouterModels ?? []);
           setVercelModels(profile.vercelModels ?? []);
           setOpenCodeGoModels(profile.openCodeGoModels ?? []);
           setProfileLastSelectedModel(profile.lastSelectedChatModel ?? null);
@@ -570,6 +577,7 @@ export const ChatInput = forwardRef<ChatInputHandle, ChatInputProps>(
                     keyStatus={keyStatus}
                     keyStatusLoading={keyStatusLoading}
                     openRouterModels={openRouterModels}
+                    orcaRouterModels={orcaRouterModels}
                     vercelModels={vercelModels}
                     openCodeGoModels={openCodeGoModels}
                     compact={compactControls}
@@ -586,6 +594,8 @@ export const ChatInput = forwardRef<ChatInputHandle, ChatInputProps>(
                       const routerHasNoModels =
                         (keyStatus?.openrouter &&
                           openRouterModels.length === 0) ||
+                        (keyStatus?.orcarouter &&
+                          orcaRouterModels.length === 0) ||
                         (keyStatus?.vercel && vercelModels.length === 0) ||
                         (keyStatus?.["opencode-go"] &&
                           openCodeGoModels.length === 0);

--- a/word-addin/src/taskpane/components/assistant/ModelToggle.tsx
+++ b/word-addin/src/taskpane/components/assistant/ModelToggle.tsx
@@ -11,6 +11,7 @@ import {
   modelDisplayName,
   openCodeGoModelOptions,
   openRouterModelOptions,
+  orcaRouterModelOptions,
   vercelModelOptions,
   STATIC_MODELS,
   type ModelOption,
@@ -22,6 +23,7 @@ export function ModelToggle({
   keyStatus,
   keyStatusLoading = false,
   openRouterModels,
+  orcaRouterModels,
   vercelModels,
   openCodeGoModels,
   compact = false,
@@ -36,6 +38,7 @@ export function ModelToggle({
    *  disabled trigger instead of flashing "No Models". */
   keyStatusLoading?: boolean;
   openRouterModels: string[];
+  orcaRouterModels: string[];
   vercelModels: string[];
   openCodeGoModels: string[];
   compact?: boolean;
@@ -59,6 +62,7 @@ export function ModelToggle({
 
   const models = useMemo(() => {
     const openRouterOptions = openRouterModelOptions(openRouterModels);
+    const orcaRouterOptions = orcaRouterModelOptions(orcaRouterModels);
     const vercelOptions = vercelModelOptions(vercelModels);
     const openCodeGoOptions = openCodeGoModelOptions(openCodeGoModels);
     const localOptions = ollamaModels.map((model) => ({
@@ -69,6 +73,7 @@ export function ModelToggle({
     return [
       ...STATIC_MODELS,
       ...openRouterOptions,
+      ...orcaRouterOptions,
       ...vercelOptions,
       ...openCodeGoOptions,
       ...localOptions,
@@ -80,6 +85,7 @@ export function ModelToggle({
     keyStatus,
     ollamaModels,
     openRouterModels,
+    orcaRouterModels,
     vercelModels,
     openCodeGoModels,
   ]);

--- a/word-addin/src/taskpane/hooks/useSelectedModel.ts
+++ b/word-addin/src/taskpane/hooks/useSelectedModel.ts
@@ -13,6 +13,7 @@ interface SelectedModelSources {
   lastSelectedModel?: string | null;
   routerSelections?: {
     openRouterModels: string[];
+    orcaRouterModels: string[];
     vercelModels: string[];
     openCodeGoModels: string[];
   } | null;
@@ -31,6 +32,7 @@ function usableStoredModel(
   if (router && sources.routerSelections) {
     const selections = {
       openrouter: sources.routerSelections.openRouterModels,
+      orcarouter: sources.routerSelections.orcaRouterModels,
       vercel: sources.routerSelections.vercelModels,
       "opencode-go": sources.routerSelections.openCodeGoModels,
     };
@@ -52,6 +54,7 @@ export function useSelectedModel(
   const manualSelection = useRef(false);
   const previousSessionKey = useRef(sources.sessionKey);
   const openRouterModels = sources.routerSelections?.openRouterModels;
+  const orcaRouterModels = sources.routerSelections?.orcaRouterModels;
   const vercelModels = sources.routerSelections?.vercelModels;
   const openCodeGoModels = sources.routerSelections?.openCodeGoModels;
 
@@ -80,6 +83,7 @@ export function useSelectedModel(
     sources.lastSelectedModel,
     sources.apiKeyStatus,
     openRouterModels,
+    orcaRouterModels,
     vercelModels,
     openCodeGoModels,
   ]); // eslint-disable-line react-hooks/exhaustive-deps

--- a/word-addin/src/taskpane/lib/modelCatalog.ts
+++ b/word-addin/src/taskpane/lib/modelCatalog.ts
@@ -11,7 +11,7 @@ import type { ApiKeyStatus } from "../api/client";
 export type ModelGroup = string;
 
 /** Kept in sync with frontend ModelToggle.tsx ROUTER_SLUGS. */
-export const ROUTER_SLUGS = ["openrouter", "vercel", "opencode-go"] as const;
+export const ROUTER_SLUGS = ["openrouter", "orcarouter", "vercel", "opencode-go"] as const;
 
 export interface ModelOption {
   id: string;
@@ -70,7 +70,7 @@ const MODEL_NAME_ACRONYMS: Record<string, string> = {
 
 export function modelDisplayName(modelId: string): string {
   const normalized = modelId
-    .replace(/^(?:openrouter|vercel|opencode-go|ollama)\//, "")
+    .replace(/^(?:openrouter|orcarouter|vercel|opencode-go|ollama)\//, "")
     .split("/")
     .at(-1)!
     .replace(/(\d)-(\d)/g, "$1.$2");
@@ -107,6 +107,15 @@ export function openRouterModelOptions(models: string[]): ModelOption[] {
     label: modelDisplayName(model),
     group: underlyingProviderGroup(model, "openrouter"),
     source: "OpenRouter",
+  }));
+}
+
+export function orcaRouterModelOptions(models: string[]): ModelOption[] {
+  return models.map((model) => ({
+    id: `orcarouter/${model}`,
+    label: modelDisplayName(model),
+    group: underlyingProviderGroup(model, "orcarouter"),
+    source: "OrcaRouter",
   }));
 }
 
@@ -197,6 +206,7 @@ export function isModelAvailable(
   // for requests the backend would happily accept.
   if (!status) return true;
   if (modelId.startsWith("openrouter/")) return !!status.openrouter;
+  if (modelId.startsWith("orcarouter/")) return !!status.orcarouter;
   if (modelId.startsWith("vercel/")) return !!status.vercel;
   if (modelId.startsWith("opencode-go/")) return !!status["opencode-go"];
   const model = STATIC_MODELS.find((item) => item.id === modelId);
@@ -210,6 +220,9 @@ export function missingModelProvider(modelId: string): string {
   const group = STATIC_MODELS.find((item) => item.id === modelId)?.group;
   if (modelId.startsWith("openrouter/") || group === "OpenRouter") {
     return "OpenRouter";
+  }
+  if (modelId.startsWith("orcarouter/") || group === "OrcaRouter") {
+    return "OrcaRouter";
   }
   if (modelId.startsWith("vercel/") || group === "Vercel AI Gateway") {
     return "Vercel AI Gateway";


### PR DESCRIPTION
## Summary

Mike is an open-source legal AI platform for document review, drafting, and
legal research. It already lets self-hosters bring their own keys for a
handful of model routers — OpenRouter, Vercel AI Gateway, and OpenCode Go —
and pick catalog models in **Settings → Bring Your Own Keys → Routers**. This
PR adds [OrcaRouter](https://www.orcarouter.ai) as a first-class router next
to them.

## Changes

- New `orcarouter` router slug alongside `openrouter`, `vercel`, and
  `opencode-go`: model ids are namespaced `orcarouter/<vendor>/<model>`, and
  the user's saved selection is gated through the same
  `user_router_models` machinery.
- **Settings → Bring Your Own Keys** now accepts an OrcaRouter API key
  (`sk-orca-...`); the Routers section lists OrcaRouter's authenticated
  catalog once a key is configured, mirroring the OpenRouter entry.
- The backend resolves `orcarouter/` models through an OpenAI-compatible
  adapter pointed at `https://api.orcarouter.ai/v1`, with an
  `ORCAROUTER_API_KEY` env option and `ORCAROUTER_BASE_URL` override for
  proxies, exactly like the other routers.
- A migration (`20260829_01_add_orcarouter_user_api_key_provider.sql`)
  widens the `user_api_keys.provider` check to include `orcarouter`;
  `backend/schema.sql` is updated to match.
- The Word add-in mirrors the new router in its hand-maintained catalog so
  add-in users see the same models.
- Adapter, catalog-route, and router-selection tests cover the new provider.

## Why

Mike already treats OpenRouter and the other gateways as named routers rather
than anonymous custom base URLs. OrcaRouter exposes the same provider/model
namespace shape (e.g. `anthropic/claude-sonnet-5`, `deepseek/deepseek-v4-flash`)
behind an OpenAI-compatible endpoint, so it fits the existing router model
without a new concept. It also combines adaptive routing, automatic failover,
zero-markup inference, observability, guardrails, and agent-tool governance
behind the same endpoint. Adding OrcaRouter as a first-class provider means
Mike's users can use that stack directly, without treating it as a hand-typed
custom base URL. It also runs gateway-level, zero-trust security for AI agents
on the same endpoint — screening every prompt/response and governing every tool
call on a default-deny basis, with no application code changes.

## Testing

- `npm run build --prefix backend` (tsc) passes; backend unit/integration
  suites pass (843 passed, 25 skipped; the pre-existing `health.test.ts`
  failures are unrelated to this change).
- `npm test --prefix frontend` passes for the router/settings suites.
- Live check: `completeWithProvider({ model: "orcarouter/deepseek/deepseek-v4-flash-free", ... })`
  against the real OrcaRouter endpoint returns a 200 with a normal
  completion.

I'm an engineer on the OrcaRouter team. Discord: discord.gg/YEubt8enRA · X:
https://x.com/OrcaRouter
