### PR TITLE
docs+test: surface and pin OPENAI_BASE_URL gateway routing for OpenAI models

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -84,6 +84,13 @@ MIKE_WORKFLOWS_GITHUB_TOKEN=
 GEMINI_API_KEY=your-gemini-key
 ANTHROPIC_API_KEY=your-anthropic-key
 OPENAI_API_KEY=your-openai-key
+# Optional: route OpenAI-model requests through an OpenAI-protocol gateway
+# instead of api.openai.com — e.g. Azure OpenAI's v1 endpoint
+# (https://<resource>.openai.azure.com/openai/v1) or a LiteLLM proxy. Read by
+# the @ai-sdk/openai provider; pinned by a regression test. The gateway must
+# support the Responses API and serve deployments named after the model ids
+# Mike ships (gpt-5.4, gpt-5.6-terra, ...).
+OPENAI_BASE_URL=
 # Optional router keys. Users can also save any of these in Settings.
 OPENROUTER_API_KEY=
 AI_GATEWAY_API_KEY=

--- a/backend/src/lib/__tests__/llmProviders.test.ts
+++ b/backend/src/lib/__tests__/llmProviders.test.ts
@@ -1,5 +1,57 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { fallbackReasoningLevelFromProviderError } from "../llm/providers";
+
+// A minimal OpenAI Responses-API payload, enough for generateText to parse.
+function responsesApiPayload(text: string) {
+  return {
+    id: "resp_test_1",
+    object: "response",
+    created_at: Math.floor(Date.now() / 1000),
+    status: "completed",
+    error: null,
+    incomplete_details: null,
+    instructions: null,
+    max_output_tokens: null,
+    model: "gpt-5.4",
+    output: [
+      {
+        type: "message",
+        id: "msg_test_1",
+        status: "completed",
+        role: "assistant",
+        content: [{ type: "output_text", text, annotations: [] }],
+      },
+    ],
+    parallel_tool_calls: true,
+    previous_response_id: null,
+    reasoning: { effort: null, summary: null },
+    store: true,
+    temperature: null,
+    text: { format: { type: "text" } },
+    tool_choice: "auto",
+    tools: [],
+    top_p: null,
+    truncation: "disabled",
+    usage: {
+      input_tokens: 10,
+      input_tokens_details: { cached_tokens: 0 },
+      output_tokens: 9,
+      output_tokens_details: { reasoning_tokens: 0 },
+      total_tokens: 19,
+    },
+    user: null,
+    metadata: {},
+  };
+}
+
+const mocks = vi.hoisted(() => ({
+  aiSdkFetch: vi.fn(),
+}));
+
+vi.mock("../llm/aiSdk", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../llm/aiSdk")>()),
+  aiSdkFetch: mocks.aiSdkFetch,
+}));
 
 describe("fallbackReasoningLevelFromProviderError", () => {
   it("selects the nearest level advertised by a provider", () => {
@@ -19,5 +71,48 @@ describe("fallbackReasoningLevelFromProviderError", () => {
         "high",
       ),
     ).toBeUndefined();
+  });
+});
+
+// Mike relies on @ai-sdk/openai reading OPENAI_BASE_URL when no explicit
+// baseURL is configured — that is what lets a deployment point OpenAI models
+// at an Azure OpenAI v1 endpoint or a LiteLLM proxy with configuration alone
+// (documented in backend/.env.example). The SDK's env fallback is not part of
+// Mike's own code, so these tests pin it against SDK upgrades. The capture
+// point is aiSdkFetch, the fetch implementation every provider adapter hands
+// to its SDK, so the assertion covers the full request path.
+describe("OPENAI_BASE_URL gateway routing", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    mocks.aiSdkFetch.mockReset();
+  });
+
+  async function completeThroughCapturedFetch() {
+    mocks.aiSdkFetch.mockImplementation(
+      async () =>
+        new Response(JSON.stringify(responsesApiPayload("routed hello")), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+    );
+    vi.stubEnv("OPENAI_API_KEY", "test-key");
+    const { completeWithProvider } = await import("../llm/providers");
+    const text = await completeWithProvider({
+      model: "gpt-5.4",
+      user: "hello",
+    });
+    return { text, url: String(mocks.aiSdkFetch.mock.calls.at(-1)?.[0]) };
+  }
+
+  it("sends OpenAI-model requests to api.openai.com by default", async () => {
+    const { url } = await completeThroughCapturedFetch();
+    expect(url).toBe("https://api.openai.com/v1/responses");
+  });
+
+  it("routes OpenAI-model requests through OPENAI_BASE_URL when set", async () => {
+    vi.stubEnv("OPENAI_BASE_URL", "http://gateway.test/v1");
+    const { text, url } = await completeThroughCapturedFetch();
+    expect(url).toBe("http://gateway.test/v1/responses");
+    expect(text).toBe("routed hello");
   });
 });


### PR DESCRIPTION
**Explainer:** https://claude.ai/code/artifact/f2fe3dbf-150e-437a-abc5-bd7ef527bf66

## Summary

Mike can already serve its OpenAI models from an Azure OpenAI endpoint or a LiteLLM-style proxy with **zero code changes** — `@ai-sdk/openai` falls back to the `OPENAI_BASE_URL` environment variable whenever `createOpenAI()` is called without an explicit `baseURL`, which is exactly how `backend/src/lib/llm/providers.ts` calls it. Nothing in the repository documents this, and nothing protects it: the capability lives entirely in a dependency's fallback path. This PR makes it discoverable (`.env.example`) and pins it with an end-to-end regression test. **No runtime code changes.**

Context: a community request for "more pluggable backends so that the Azure backend could be an option on base" — the Azure fork it mentions exists to solve a problem base Mike already solves invisibly.

**Relationship to #447.** Contributor PR #447 (*feat: add generic OpenAI-compatible gateway provider*, LN-Zap) is open and touches the same area. The two are complementary rather than competing: **#402 is the minimal docs + test pin for the routing that ships today**, and **#447 is the larger provider addition**. This branch is deliberately *not* rebased onto or merged with #447, and its test asserts current `main` behaviour. If #447 lands first, `llmProviders.test.ts` is the single place to re-point; if #402 lands first, #447 inherits a regression net for the fallback it builds on. A maintainer should decide the order — nothing here blocks either.

## What changed

- `backend/.env.example` — documents `OPENAI_BASE_URL` next to `OPENAI_API_KEY`, including the two real constraints (gateway must support the Responses API; deployments must be named after model ids in Mike's catalog).
- `backend/src/lib/__tests__/llmProviders.test.ts` — two new tests pin the routing end to end by capturing requests at `aiSdkFetch` (the fetch implementation every provider adapter hands to its SDK): the default resolves to `https://api.openai.com/v1/responses`, and with `OPENAI_BASE_URL=http://gateway.test/v1` the same call lands on `http://gateway.test/v1/responses` and the completion parses.
- `backend/src/lib/llm/providers.ts` is **unchanged**. That absence is the feature — see Tradeoffs.

## Why

Behavior that is undocumented might as well not exist — the community's lagging Azure fork is the proof. And behavior that lives in a dependency's fallback (`loadSetting(..., environmentVariableName: "OPENAI_BASE_URL")` inside `@ai-sdk/openai`) is one SDK upgrade away from silently disappearing — with a valid key in place, it would not even error; requests would simply start going to `api.openai.com` again. Documentation makes it usable; the test makes it safe to rely on.

## Reproduce the base case on main

1. `git checkout main && npm ci --prefix backend && npm run build --prefix backend`
2. `grep -rn OPENAI_BASE_URL backend/src backend/.env.example docs/` → **zero hits**: nothing tells an operator this variable exists.
3. Yet routing already honors it:
   ```bash
   OPENAI_BASE_URL=http://localhost:9/v1 OPENAI_API_KEY=sk-x node -e \
     "require('./backend/dist/lib/llm/providers.js').completeWithProvider({model:'gpt-5.4',user:'hi'}).catch(e=>console.log(e.message))"
   ```
   The failure is `ECONNREFUSED 127.0.0.1:9` — the request went to the override, not to api.openai.com. Working, invisible, unpinned.
4. `npm test --prefix backend -- src/lib/__tests__/llmProviders.test.ts` on main → 2 tests. Neither of them says anything about where a request is sent.

## Verify on this branch

1. Same setup on this branch.
2. `backend/.env.example` now documents the variable and its constraints.
3. `npm test --prefix backend -- src/lib/__tests__/llmProviders.test.ts` → **4 tests pass**, including both routing pins. Delete the SDK's env fallback (or stub `OPENAI_BASE_URL` handling out) and the test fails — that's the regression net.
4. Optional live check: run any OpenAI-protocol stub locally and repeat the step-3 command from the base case with the stub's URL; the completion round-trips (see Demo).

## Tradeoffs & design decisions

- **Deliberately no runtime code.** An earlier draft passed `baseURL` explicitly in `providers.ts`; live A/B testing showed it was a functional no-op because the SDK already reads the variable, so it was dropped. If a future `@ai-sdk/openai` removes the fallback, the pinned test fails and the fix is a one-line explicit `baseURL` in `createOpenAI()`.
- **Responses API required.** The adapter calls `openai.responses(model)`, so chat-completions-only gateways won't work via this variable. Those are already served by the `OLLAMA_BASE_URL` + `ollama/<tag>` path (openai-compatible adapter), at the cost of "Local (Ollama)" labeling.
- **Deployment naming constraint.** Model validation still runs against Mike's catalog, so Azure deployments must be named after Mike's model ids (`gpt-5.4`, `gpt-5.6-terra`, …). Accepting arbitrary deployment names would need catalog/validation work (a provider-registry discussion, out of scope here).
- **Not stacked on #447.** Keeping this independent means it can merge in either order; the cost is that if #447 lands first, this test needs re-pointing at the new provider path rather than the SDK fallback.
- **The constraints are documented, not enforced.** An operator who names an Azure deployment outside Mike's catalog gets a generic model-validation rejection, not a message about naming.
- UI provider labels are untouched — requests routed through a gateway still display as "OpenAI".

## Testing performed

Local, 2026-09-14, on the rebased tip `b6952fed` (rebased onto `origin/main` `aba3cfca`, one commit replayed, no conflicts):

- `npm test --prefix backend -- src/lib/__tests__/llmProviders.test.ts` → 1 file, **4 passed**
- `npm test --prefix backend` → **129 files passed, 6 skipped; 1591 tests passed, 39 skipped**
- `npm run build --prefix backend` → tsc clean
- `git diff --check` → clean

Post-rebase check: `main`'s `providers.ts` still calls `createOpenAI()` with only `apiKey` and `fetch` — no explicit `baseURL` — so the test's assertions match main's behaviour as-is and needed no adaptation.

GitHub CI on `b6952fed`, 2026-09-14: **14 / 14 checks green** — Backend build and tests, Frontend build and tests, Playwright, Supabase stack integration tests, Fresh install vs upgraded deployment (schema drift), CodeQL / Analyze, gitleaks (full history), dependency-audit (root / backend / frontend / word-addin), Eval harness, CLA.

Earlier live A/B against a local OpenAI-protocol stub: with the variable set, Mike's compiled provider layer hit the stub and returned its completion on this branch **and on unmodified main** — which is precisely why this ships as docs + test rather than code.

## Demo

![OPENAI_BASE_URL demo](https://raw.githubusercontent.com/amal66/mike/assets/pluggable-backends-demo-2026-08-29/pr-openai-baseurl-demo.gif)

*Recorded 2026-08-29. A local OpenAI-protocol stub stands in for a corporate gateway; Mike's real compiled provider layer sends `POST /v1/responses` to it and round-trips the completion. Not re-recorded for the 2026-09-14 rebase — the diff is docs + test only and no runtime path changed.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NSG87RB94ikHfQyjT6TP1E
