### PR TITLE
fix: correct blob mock so mikeApi tests pass on Node 22 and 24

### DIFF
--- a/frontend/vitest.setup.ts
+++ b/frontend/vitest.setup.ts
@@ -1,1 +1,13 @@
 import "@testing-library/jest-dom/vitest";
+import { Blob as NodeBlob } from "node:buffer";
+
+// Vitest's jsdom environment always overrides `globalThis.Blob` with jsdom's
+// own Blob implementation, which never implemented `.text()`/`.arrayBuffer()`/
+// `.stream()` (it only has `slice`, `size`, `type`). On Node 24 (unlike
+// Node 22), the built-in `Response.prototype.blob()` resolves its `Blob`
+// constructor dynamically from `globalThis` at call time, so blobs returned
+// from a real `Response` end up jsdom-shaped and missing those methods.
+// Restoring the real Node `Blob` here (independent of the global, via
+// `node:buffer`) keeps `response.blob()` usable the same way on every
+// supported Node version. See #361.
+globalThis.Blob = NodeBlob as unknown as typeof Blob;


### PR DESCRIPTION
## Summary

Fixes 4 tests in `frontend/src/app/lib/mikeApi.test.ts` that fail locally on Node 24 with `TypeError: blob.text is not a function`, while passing in CI (Node 22).

## Root cause

The tests already construct real `Response` objects (`new Response(...)`), so the request/response mocking itself was not the problem. The actual cause is in the shared Vitest jsdom test environment setup:

- Vitest's built-in jsdom environment always overrides `globalThis.Blob` with jsdom's own `Blob` implementation, which has never implemented `.text()`, `.arrayBuffer()`, or `.stream()` — only `slice`, `size`, and `type`.
- Node's built-in `Response.prototype.blob()` resolves its `Blob` constructor dynamically from `globalThis` at call time. On Node 24 this means `response.blob()` returns a jsdom-shaped blob missing those methods; on Node 22 it apparently does not exhibit this behavior, so the same tests pass there.
- Since the repo's own `package.json` pins `engines.node: ">=22"` with no upper bound, Node 24 is a legitimately supported local dev version, so this was a real (if narrow) bug, not just an unsupported-toolchain situation.

## Fix

Restore the real Node `Blob` (imported directly from `node:buffer`, independent of the `globalThis` override jsdom performs) in `frontend/vitest.setup.ts`, which runs before every test file. This makes `response.blob()` behave identically on Node 22 and Node 24, and does not touch any production code path.

## Changes

- `frontend/vitest.setup.ts`: restore `globalThis.Blob` to the native `node:buffer` `Blob` after jsdom's environment setup overrides it, with a comment explaining why.

## Test plan

- [x] `cd frontend && npx vitest run src/app/lib/mikeApi.test.ts` — 178/178 pass (previously 174/178, with the 4 tests named in #361 failing).
- [x] `cd frontend && npx vitest run` (full frontend suite) — 98 files / 641 tests, all pass — confirming no regression from the global `Blob` change on other tests that rely on `File`/`Blob`/`FormData` (upload flows, clipboard export, etc).
- [x] `cd frontend && npx tsc --noEmit` — clean.
- [x] `cd frontend && npx eslint vitest.setup.ts` — clean.
- [ ] `npm run build --prefix frontend` was not run in this environment: this worktree's `node_modules` is a symlink to a sibling worktree (to avoid an `npm install` under a non-pinned local Node version per repo policy), and Turbopack refuses to build through a symlink that points outside its detected project root. Confirmed this Turbopack error is pre-existing and unrelated to this change by reproducing it identically with the fix stashed out. `tsc --noEmit` covers the type-checking this build step would otherwise gate.

Closes #361