### PR TITLE
fix: review fixes for organization access (#426)

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -13,6 +13,23 @@ permissions:
   contents: read
 
 jobs:
+  # The gate's own regression suite. It asserts the FAIL-CLOSED contract —
+  # every bug this script has had was a path where "we could not check"
+  # printed the same "passed" as "we checked and it is clean" — and it runs
+  # against stub servers, so it needs no network and no install. Kept as its
+  # own job rather than a step in the matrix below so it runs once, and so a
+  # broken gate is legible as a broken gate rather than as four failing
+  # workspace audits.
+  audit-gate-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: 22
+      - name: Audit gate self-tests
+        run: node --test scripts/audit-gate.test.mjs
+
   # Blocking for EVERY tree in the matrix below: high/critical advisories
   # fail the build unless their GHSA id is documented (with a reason) in
   # scripts/audit-allowlist.json — see scripts/audit-gate.mjs. Auditing

--- a/backend/migrations/20260904_01_organization_access.sql
+++ b/backend/migrations/20260904_01_organization_access.sql
@@ -708,10 +708,12 @@ AS $function$
       and (p_type is null or w.type = p_type)
   ),
   org_shared as (
-    -- Same org-membership arm as get_workflows_overview, including the
-    -- workflow_shares NOT EXISTS dedup, so a row visible via both routes
-    -- contributes its options exactly once. Tagged 'shared' to match the
-    -- overview's scope bucketing.
+    -- Same org-membership arm as get_workflows_overview. The `shared` arm
+    -- above takes only org_id IS NULL workflows and this one only org_id IS
+    -- NOT NULL, so the two are disjoint by construction and a row visible via
+    -- both routes still contributes its options exactly once -- no dedup
+    -- predicate is needed. Tagged 'shared' to match the overview's scope
+    -- bucketing.
     select w.practice, w.language, w.jurisdictions, 'shared'::text as source
     from public.workflows w
     where w.org_id is not null
@@ -1373,10 +1375,16 @@ AS $function$
     )
     when p_workflow_user_id::text = p_user_id then 'owner'
     else (
+      -- BOTH sides lowered. get_workflows_overview lists a share with
+      -- lower() on both, so a legacy mixed-case row listed for its recipient
+      -- and then 404'd the moment they opened it (and re-sharing produced a
+      -- second row rather than updating the first). The 02 migration
+      -- normalizes the stored values and adds a lowercase CHECK; this stays
+      -- symmetrical with the overview regardless.
       select s.role from public.workflow_shares s
       where s.workflow_id = p_workflow_id
         and coalesce(p_user_email, '') <> ''
-        and s.shared_with_email = lower(p_user_email)
+        and lower(s.shared_with_email) = lower(p_user_email)
       limit 1
     )
   end;
@@ -1770,6 +1778,23 @@ END $do$;
 CREATE INDEX IF NOT EXISTS idx_workflows_org ON public.workflows (org_id);
 DROP TRIGGER IF EXISTS workflows_cleanup_direct_grants ON public.workflows;
 CREATE TRIGGER workflows_cleanup_direct_grants AFTER INSERT OR UPDATE OF org_id ON public.workflows FOR EACH ROW EXECUTE FUNCTION public.cleanup_inherited_direct_grants();
+
+-- Every new table is service-role only, like every other table in this
+-- schema: the API is the only thing that reads them, and RLS ENABLE with no
+-- policy is not by itself a grant boundary — `anon` and `authenticated`
+-- inherit table privileges from PUBLIC unless they are revoked. schema.sql
+-- revokes all eight for fresh installs; without these lines an UPGRADED
+-- deployment ends up with a different, weaker posture than a fresh one for
+-- precisely the tables that decide who can see a firm's matters.
+-- Idempotent: revoking a privilege that is not held is a no-op.
+REVOKE ALL ON public.organizations FROM anon, authenticated;
+REVOKE ALL ON public.org_members FROM anon, authenticated;
+REVOKE ALL ON public.org_invitations FROM anon, authenticated;
+REVOKE ALL ON public.project_access_grants FROM anon, authenticated;
+REVOKE ALL ON public.project_org_access_overrides FROM anon, authenticated;
+REVOKE ALL ON public.chat_access_grants FROM anon, authenticated;
+REVOKE ALL ON public.tabular_review_access_grants FROM anon, authenticated;
+REVOKE ALL ON public.workflow_org_access_overrides FROM anon, authenticated;
 
 notify pgrst, 'reload schema';
 

--- a/backend/migrations/20260904_02_migrate_legacy_sharing.sql
+++ b/backend/migrations/20260904_02_migrate_legacy_sharing.sql
@@ -10,6 +10,29 @@
 
 begin;
 
+-- Archive for direct review shares the new model has nowhere to put. See the
+-- header comment on this table in schema.sql, and the review backfill below,
+-- for why they are neither converted nor discarded.
+create table if not exists public.tabular_review_legacy_shares (
+  id uuid primary key default gen_random_uuid(),
+  tabular_review_id uuid not null
+    references public.tabular_reviews(id) on delete cascade,
+  project_id uuid,
+  email text not null,
+  archived_at timestamptz not null default now(),
+  unique(tabular_review_id, email),
+  constraint tabular_review_legacy_shares_email_lowercase
+    check (email = lower(email))
+);
+
+create index if not exists idx_tabular_review_legacy_shares_review
+  on public.tabular_review_legacy_shares(tabular_review_id);
+
+alter table public.tabular_review_legacy_shares enable row level security;
+revoke all on public.tabular_review_legacy_shares from anon, authenticated;
+grant select, insert, update, delete
+  on public.tabular_review_legacy_shares to service_role;
+
 do $migration$
 begin
   if exists (
@@ -19,6 +42,15 @@ begin
       and table_name = 'projects'
       and column_name = 'shared_with'
   ) then
+    -- The creator is EXCLUDED. A legacy shared_with array could contain the
+    -- project owner's own address (their own invitation, echoed back), and
+    -- turning that into an editor grant on their own project produces a state
+    -- the API itself refuses to create: the project reads as "Shared with 1
+    -- user" and the owner appears as a guest on their own matter.
+    --
+    -- position('@' ...) is measured on the TRIMMED value, which is the value
+    -- actually inserted, and must be > 1: '@x.com' has an @ at position 1 and
+    -- no local part.
     execute $sql$
       insert into public.project_access_grants (
         project_id, email, role, created_by
@@ -29,6 +61,8 @@ begin
         'editor',
         project.user_id
       from public.projects project
+      left join public.user_profiles creator
+        on creator.user_id = project.user_id
       cross join lateral jsonb_array_elements_text(
         case
           when jsonb_typeof(project.shared_with) = 'array'
@@ -37,7 +71,9 @@ begin
         end
       ) recipient(email)
       where trim(recipient.email) <> ''
-        and position('@' in recipient.email) > 0
+        and position('@' in trim(recipient.email)) > 1
+        and lower(trim(recipient.email))
+          is distinct from lower(trim(coalesce(creator.email, '')))
       on conflict (project_id, email) do nothing
     $sql$;
   end if;
@@ -49,6 +85,8 @@ begin
       and table_name = 'tabular_reviews'
       and column_name = 'shared_with'
   ) then
+    -- Standalone reviews: the share becomes a real grant, same creator
+    -- exclusion and same trimmed '@' test as the project backfill above.
     execute $sql$
       insert into public.tabular_review_access_grants (
         tabular_review_id, email, role, created_by
@@ -59,6 +97,8 @@ begin
         'editor',
         review.user_id
       from public.tabular_reviews review
+      left join public.user_profiles creator
+        on creator.user_id = review.user_id
       cross join lateral jsonb_array_elements_text(
         case
           when jsonb_typeof(review.shared_with) = 'array'
@@ -68,7 +108,50 @@ begin
       ) recipient(email)
       where review.project_id is null
         and trim(recipient.email) <> ''
-        and position('@' in recipient.email) > 0
+        and position('@' in trim(recipient.email)) > 1
+        and lower(trim(recipient.email))
+          is distinct from lower(trim(coalesce(creator.email, '')))
+      on conflict (tabular_review_id, email) do nothing
+    $sql$;
+  end if;
+
+  if exists (
+    select 1
+    from information_schema.columns
+    where table_schema = 'public'
+      and table_name = 'tabular_reviews'
+      and column_name = 'shared_with'
+  ) then
+    -- Project-contained reviews: NOT convertible. A contained review inherits
+    -- access from its project, and validate_direct_access_scope refuses a
+    -- review-level grant on one, so there is no row shape that preserves
+    -- "this person may see this review and nothing else in the matter".
+    --
+    -- Promoting these to project-level viewer grants was REJECTED: a share on
+    -- one review is not consent to see the whole matter, and widening access
+    -- silently during a migration is worse than losing it. Dropping the
+    -- column with the recipients unrecorded was rejected too -- main honoured
+    -- these shares, so people lose access at upgrade and nobody can say who
+    -- they were. Archive the triples; an operator re-grants deliberately.
+    execute $sql$
+      insert into public.tabular_review_legacy_shares (
+        tabular_review_id, project_id, email
+      )
+      select distinct
+        review.id,
+        review.project_id,
+        lower(trim(recipient.email))
+      from public.tabular_reviews review
+      cross join lateral jsonb_array_elements_text(
+        case
+          when jsonb_typeof(review.shared_with) = 'array'
+            then review.shared_with
+          else '[]'::jsonb
+        end
+      ) recipient(email)
+      where review.project_id is not null
+        and trim(recipient.email) <> ''
+        and position('@' in trim(recipient.email)) > 1
       on conflict (tabular_review_id, email) do nothing
     $sql$;
   end if;
@@ -87,6 +170,52 @@ begin
   end if;
 end;
 $migration$;
+
+-- Canonicalize workflow share recipients, the way the four sibling grant
+-- tables already store them.
+--
+-- workflow_access_role and lib/access.ts look a recipient up by their
+-- normalized (lowercased) address, while get_workflows_overview lowers both
+-- sides -- so a legacy mixed-case row LISTED for its recipient and then 404'd
+-- when they opened it, and re-sharing inserted a second row instead of
+-- updating the first (the unique constraint is on the raw value).
+--
+-- Collapse first, keeping the strongest role, because the unique constraint
+-- on (workflow_id, shared_with_email) cannot separate 'A@x.com' from
+-- 'a@x.com' once both are lowered. Ordering by role strength means a
+-- recipient never LOSES access to a workflow they could already edit.
+with ranked as (
+  select
+    id,
+    row_number() over (
+      partition by workflow_id, lower(trim(shared_with_email))
+      order by
+        case role when 'owner' then 0 when 'editor' then 1 else 2 end,
+        created_at asc,
+        id asc
+    ) as dup_rank
+  from public.workflow_shares
+)
+delete from public.workflow_shares s
+using ranked
+where ranked.id = s.id
+  and ranked.dup_rank > 1;
+
+update public.workflow_shares
+set shared_with_email = lower(trim(shared_with_email))
+where shared_with_email is distinct from lower(trim(shared_with_email));
+
+do $do$ begin
+  if not exists (
+    select 1 from pg_constraint
+    where conname = 'workflow_shares_email_lowercase'
+      and conrelid = 'public.workflow_shares'::regclass
+  ) then
+    alter table public.workflow_shares
+      add constraint workflow_shares_email_lowercase
+      check (shared_with_email = lower(shared_with_email));
+  end if;
+end $do$;
 
 drop index if exists public.projects_shared_with_idx;
 alter table public.projects drop column if exists shared_with;

--- a/backend/migrations/20260904_02_migrate_legacy_sharing.sql
+++ b/backend/migrations/20260904_02_migrate_legacy_sharing.sql
@@ -15,8 +15,14 @@ begin;
 -- for why they are neither converted nor discarded.
 create table if not exists public.tabular_review_legacy_shares (
   id uuid primary key default gen_random_uuid(),
-  tabular_review_id uuid not null
-    references public.tabular_reviews(id) on delete cascade,
+  -- NO foreign key, deliberately, and for the same reason project_id has
+  -- none: this is a historical record of who lost access at upgrade, and it
+  -- has to outlive the rows it describes. An ON DELETE CASCADE here meant
+  -- deleting the review -- or the project, which cascades to its reviews --
+  -- silently destroyed the only record of the recipients an operator was
+  -- supposed to re-grant, which is exactly the outcome the table exists to
+  -- prevent.
+  tabular_review_id uuid not null,
   project_id uuid,
   email text not null,
   archived_at timestamptz not null default now(),
@@ -24,6 +30,12 @@ create table if not exists public.tabular_review_legacy_shares (
   constraint tabular_review_legacy_shares_email_lowercase
     check (email = lower(email))
 );
+
+-- Replay-safe: `create table if not exists` above leaves an EXISTING table
+-- untouched, so a deployment that applied the first cut of this migration
+-- still carries the cascade. Drop it explicitly.
+alter table public.tabular_review_legacy_shares
+  drop constraint if exists tabular_review_legacy_shares_tabular_review_id_fkey;
 
 create index if not exists idx_tabular_review_legacy_shares_review
   on public.tabular_review_legacy_shares(tabular_review_id);
@@ -63,6 +75,14 @@ begin
       from public.projects project
       left join public.user_profiles creator
         on creator.user_id = project.user_id
+      -- user_profiles is populated by a trigger and can be missing (a row
+      -- deleted by hand, an account created before the trigger existed). With
+      -- only that join, coalesce(creator.email,'') was '' for such a creator,
+      -- the exclusion never matched, and they were handed an EDITOR grant on
+      -- their own project -- the exact state this exclusion exists to
+      -- prevent. auth.users is the authoritative address.
+      left join auth.users creator_auth
+        on creator_auth.id = project.user_id
       cross join lateral jsonb_array_elements_text(
         case
           when jsonb_typeof(project.shared_with) = 'array'
@@ -73,7 +93,8 @@ begin
       where trim(recipient.email) <> ''
         and position('@' in trim(recipient.email)) > 1
         and lower(trim(recipient.email))
-          is distinct from lower(trim(coalesce(creator.email, '')))
+          is distinct from lower(trim(coalesce(
+            creator.email, creator_auth.email, '')))
       on conflict (project_id, email) do nothing
     $sql$;
   end if;
@@ -99,6 +120,8 @@ begin
       from public.tabular_reviews review
       left join public.user_profiles creator
         on creator.user_id = review.user_id
+      left join auth.users creator_auth
+        on creator_auth.id = review.user_id
       cross join lateral jsonb_array_elements_text(
         case
           when jsonb_typeof(review.shared_with) = 'array'
@@ -110,7 +133,8 @@ begin
         and trim(recipient.email) <> ''
         and position('@' in trim(recipient.email)) > 1
         and lower(trim(recipient.email))
-          is distinct from lower(trim(coalesce(creator.email, '')))
+          is distinct from lower(trim(coalesce(
+            creator.email, creator_auth.email, '')))
       on conflict (tabular_review_id, email) do nothing
     $sql$;
   end if;
@@ -142,6 +166,10 @@ begin
         review.project_id,
         lower(trim(recipient.email))
       from public.tabular_reviews review
+      left join public.user_profiles creator
+        on creator.user_id = review.user_id
+      left join auth.users creator_auth
+        on creator_auth.id = review.user_id
       cross join lateral jsonb_array_elements_text(
         case
           when jsonb_typeof(review.shared_with) = 'array'
@@ -152,6 +180,13 @@ begin
       where review.project_id is not null
         and trim(recipient.email) <> ''
         and position('@' in trim(recipient.email)) > 1
+        -- Same creator exclusion as the two backfills above. Without it the
+        -- archive lists the review's own creator as somebody who lost
+        -- access, and an operator "restoring" it grants the owner a guest
+        -- role on their own review.
+        and lower(trim(recipient.email))
+          is distinct from lower(trim(coalesce(
+            creator.email, creator_auth.email, '')))
       on conflict (tabular_review_id, email) do nothing
     $sql$;
   end if;

--- a/backend/schema.sql
+++ b/backend/schema.sql
@@ -536,8 +536,10 @@ create table if not exists public.projects (
   -- user_id is provenance ("who made this"), not the access rule — that flows
   -- from project_access_grants and org membership (lib/access.ts).
   user_id uuid references auth.users(id) on delete set null,
-  -- Multi-tenant: nullable so system/global rows stay valid; user_id remains
-  -- the hard cascade anchor (org_id uses SET NULL, not CASCADE).
+  -- Multi-tenant: nullable so system/global rows stay valid. The FK is
+  -- RESTRICT, so an organization holding projects cannot be deleted at all --
+  -- the API answers 409 (lib/orgs.ts deleteOrg) rather than letting the
+  -- database strand a firm's matters.
   org_id uuid references public.organizations(id) on delete restrict,
   name text not null,
   cm_number text,
@@ -1001,7 +1003,13 @@ create table if not exists public.workflow_shares (
     check (role in ('owner', 'editor', 'viewer')),
   created_at timestamptz not null default now(),
   constraint workflow_shares_workflow_email_unique
-    unique(workflow_id, shared_with_email)
+    unique(workflow_id, shared_with_email),
+  -- Canonical case, like every sibling grant table (project_access_grants,
+  -- chat_access_grants, tabular_review_access_grants, org_invitations).
+  -- Without it the unique constraint above treats A@x.com and a@x.com as two
+  -- different recipients while the access lookups treat them as one.
+  constraint workflow_shares_email_lowercase
+    check (shared_with_email = lower(shared_with_email))
 );
 
 create index if not exists workflow_shares_workflow_id_idx
@@ -1060,10 +1068,16 @@ as $$
     )
     when p_workflow_user_id::text = p_user_id then 'owner'
     else (
+      -- BOTH sides lowered. get_workflows_overview lists a share with
+      -- lower() on both, so a legacy mixed-case row listed for its recipient
+      -- and then 404'd the moment they opened it (and re-sharing produced a
+      -- second row rather than updating the first). The 02 migration
+      -- normalizes the stored values and adds a lowercase CHECK; this stays
+      -- symmetrical with the overview regardless.
       select s.role from public.workflow_shares s
       where s.workflow_id = p_workflow_id
         and coalesce(p_user_email, '') <> ''
-        and s.shared_with_email = lower(p_user_email)
+        and lower(s.shared_with_email) = lower(p_user_email)
       limit 1
     )
   end;
@@ -2098,6 +2112,40 @@ create index if not exists idx_tabular_review_access_grants_review
 
 alter table public.tabular_review_access_grants enable row level security;
 
+-- Archive of direct review shares that the organization model has nowhere to
+-- put. On main, a tabular review inside a project could ALSO carry its own
+-- shared_with list, and access.ts honoured it. In this model a
+-- project-contained review inherits access exclusively from its project --
+-- validate_direct_access_scope refuses a review-level grant on one -- so the
+-- 20260904_02 data migration cannot convert those recipients into grants.
+--
+-- Promoting them to project viewer grants was considered and REJECTED: a
+-- share on one review is not consent to see the whole matter, and silently
+-- widening access is a worse failure than losing it. Silently DESTROYING the
+-- shares is not acceptable either, so the migration copies the discarded
+-- (review, project, email) triples here. An operator can read this table and
+-- re-grant access at project level deliberately, per recipient, with the
+-- context to judge it. Fresh installs create it empty.
+create table if not exists public.tabular_review_legacy_shares (
+  id uuid primary key default gen_random_uuid(),
+  tabular_review_id uuid not null
+    references public.tabular_reviews(id) on delete cascade,
+  -- The project the review sat in when the share was archived. Deliberately
+  -- not a foreign key: this is a historical record, and it must survive the
+  -- project being reorganized or deleted.
+  project_id uuid,
+  email text not null,
+  archived_at timestamptz not null default now(),
+  unique(tabular_review_id, email),
+  constraint tabular_review_legacy_shares_email_lowercase
+    check (email = lower(email))
+);
+
+create index if not exists idx_tabular_review_legacy_shares_review
+  on public.tabular_review_legacy_shares(tabular_review_id);
+
+alter table public.tabular_review_legacy_shares enable row level security;
+
 create or replace function public.review_access_role(
   p_review_id uuid,
   p_review_user_id uuid,
@@ -2865,10 +2913,12 @@ as $$
       and (p_type is null or w.type = p_type)
   ),
   org_shared as (
-    -- Same org-membership arm as get_workflows_overview, including the
-    -- workflow_shares NOT EXISTS dedup, so a row visible via both routes
-    -- contributes its options exactly once. Tagged 'shared' to match the
-    -- overview's scope bucketing.
+    -- Same org-membership arm as get_workflows_overview. The `shared` arm
+    -- above takes only org_id IS NULL workflows and this one only org_id IS
+    -- NOT NULL, so the two are disjoint by construction and a row visible via
+    -- both routes still contributes its options exactly once -- no dedup
+    -- predicate is needed. Tagged 'shared' to match the overview's scope
+    -- bucketing.
     select w.practice, w.language, w.jurisdictions, 'shared'::text as source
     from public.workflows w
     where w.org_id is not null
@@ -4785,6 +4835,7 @@ revoke all on public.word_chat_messages from anon, authenticated;
 revoke all on public.word_document_edits from anon, authenticated;
 revoke all on public.tabular_reviews from anon, authenticated;
 revoke all on public.tabular_review_access_grants from anon, authenticated;
+revoke all on public.tabular_review_legacy_shares from anon, authenticated;
 revoke all on public.tabular_cells from anon, authenticated;
 revoke all on public.tabular_review_rows from anon, authenticated;
 revoke all on public.tabular_review_row_sources from anon, authenticated;

--- a/backend/schema.sql
+++ b/backend/schema.sql
@@ -2128,11 +2128,13 @@ alter table public.tabular_review_access_grants enable row level security;
 -- context to judge it. Fresh installs create it empty.
 create table if not exists public.tabular_review_legacy_shares (
   id uuid primary key default gen_random_uuid(),
-  tabular_review_id uuid not null
-    references public.tabular_reviews(id) on delete cascade,
-  -- The project the review sat in when the share was archived. Deliberately
-  -- not a foreign key: this is a historical record, and it must survive the
-  -- project being reorganized or deleted.
+  -- NEITHER id is a foreign key. This is a historical record of who lost
+  -- access at upgrade, and it must survive the rows it describes: an ON
+  -- DELETE CASCADE to tabular_reviews meant deleting the review -- or the
+  -- project, which cascades to its reviews -- destroyed the only record of
+  -- the recipients an operator was supposed to re-grant.
+  tabular_review_id uuid not null,
+  -- The project the review sat in when the share was archived.
   project_id uuid,
   email text not null,
   archived_at timestamptz not null default now(),

--- a/backend/src/__tests__/integration/chat.routes.test.ts
+++ b/backend/src/__tests__/integration/chat.routes.test.ts
@@ -1483,6 +1483,48 @@ describe("chat writes are gated on content.edit (org RBAC)", () => {
         expect(res.body).toHaveProperty("detail");
     });
 
+    // A Viewer can open the project, so answering "Project not found" told
+    // them their matter had vanished. The refusal has to say it is one.
+    it("403s a project Viewer creating a chat in that project", async () => {
+        mockedCreate.mockImplementation(
+            () =>
+                makeRbacDb(null, "colleague-1", {
+                    grantRole: "viewer",
+                    project: { org_id: null },
+                    chat: { org_id: null },
+                }) as never,
+        );
+
+        const res = await request(app)
+            .post("/chat/create")
+            .set("Authorization", "Bearer test")
+            .send({ project_id: "proj-1" });
+
+        expect(res.status).toBe(403);
+        expect(res.body.detail).toBe(
+            "You do not have permission to write in this project.",
+        );
+    });
+
+    it("keeps 404 when the project is invisible to the caller", async () => {
+        mockedCreate.mockImplementation(
+            () =>
+                makeRbacDb(null, "colleague-1", {
+                    grantRole: null,
+                    project: { org_id: null },
+                    chat: { org_id: null },
+                }) as never,
+        );
+
+        const res = await request(app)
+            .post("/chat/create")
+            .set("Authorization", "Bearer test")
+            .send({ project_id: "proj-1" });
+
+        expect(res.status).toBe(404);
+        expect(res.body.detail).toBe("Project not found");
+    });
+
     it("does not elevate a project chat's creator above project access", async () => {
         mockedCreate.mockImplementation(() => makeRbacDb(null, "u1") as never);
 
@@ -1518,6 +1560,27 @@ describe("chat writes are gated on content.edit (org RBAC)", () => {
 
         expect(res.status).toBe(200);
         expect(res.body.title).toBe("Generated Title");
+    });
+
+    // The update's error used to be ignored, so a failed write still
+    // answered 200 with the new title: the sidebar renamed the chat and the
+    // next reload silently put the old name back.
+    it("reports a failed title write instead of answering 200", async () => {
+        await seedResolvableModel();
+        mockedCreate.mockImplementation(
+            () =>
+                makeRbacDb("admin", "colleague-1", {
+                    chatWriteError: "title update failed",
+                }) as never,
+        );
+
+        const res = await request(app)
+            .post("/chat/chat-1/generate-title")
+            .set("Authorization", "Bearer test")
+            .send({ message: "hello there" });
+
+        expect(res.status).toBe(500);
+        expect(res.body.detail).toBe("Something went wrong. Please try again.");
     });
 
     it("still lets a project viewer GET the chat (reads stay project.view)", async () => {
@@ -1736,6 +1799,42 @@ describe("chat grants, deletion and roster", () => {
         expect(res.status).toBe(400);
         expect(res.body.detail).toBe(
             "future@example.com does not belong to a Mike user.",
+        );
+    });
+
+    // The creator's email now comes from one filtered row instead of a scan
+    // of every profile in the deployment; this pins that the row it reads is
+    // still the right one, since the "creator already has access" refusal is
+    // the only thing that email decides.
+    it("400s when a grant targets the chat creator's own email", async () => {
+        mockedCreate.mockImplementation(
+            () =>
+                makeRbacDb(null, "colleague-1", {
+                    chat: { project_id: null, org_id: null },
+                    chatGrantRole: "owner",
+                    profiles: [
+                        {
+                            user_id: "decoy",
+                            email: "decoy@example.com",
+                            display_name: "Decoy",
+                        },
+                        {
+                            user_id: "colleague-1",
+                            email: "colleague@example.com",
+                            display_name: "Creator",
+                        },
+                    ],
+                }) as never,
+        );
+
+        const res = await request(app)
+            .post("/chat/chat-1/access")
+            .set("Authorization", "Bearer test")
+            .send({ email: "Colleague@Example.com", role: "viewer" });
+
+        expect(res.status).toBe(400);
+        expect(res.body.detail).toBe(
+            "The chat creator already has owner access",
         );
     });
 

--- a/backend/src/__tests__/integration/chat.routes.test.ts
+++ b/backend/src/__tests__/integration/chat.routes.test.ts
@@ -1838,6 +1838,122 @@ describe("chat grants, deletion and roster", () => {
         );
     });
 
+    it("500s when the creator's profile read fails, without writing a grant", async () => {
+        // A FAILED READ IS NOT "the creator has no email". Swallowing the
+        // error sent `creatorEmail: null` into upsertContentGrant — and that
+        // email is the only thing standing between the creator and a guest
+        // grant on their own chat. So a transient database fault quietly
+        // created exactly the row the check exists to prevent.
+        const grantWrites: string[] = [];
+        mockedCreate.mockImplementation(() => {
+            const db = makeRbacDb(null, "colleague-1", {
+                chat: { project_id: null, org_id: null },
+                chatGrantRole: "owner",
+                profiles: [
+                    {
+                        user_id: "colleague-1",
+                        email: "colleague@example.com",
+                        display_name: "Creator",
+                    },
+                ],
+            });
+            const originalFrom = db.from;
+            db.from = vi.fn((table: string) => {
+                if (table === "user_profiles") {
+                    // ONLY the creator lookup fails — it is the read keyed by
+                    // `user_id`. Every other profile read (the one that
+                    // resolves the RECIPIENT's account) still works, so the
+                    // request cannot fall into a 500 for some other reason.
+                    const profiles = [
+                        {
+                            user_id: "colleague-1",
+                            email: "colleague@example.com",
+                            display_name: "Creator",
+                        },
+                        {
+                            user_id: "mate",
+                            email: "mate@example.com",
+                            display_name: "Mate",
+                        },
+                    ];
+                    const filters: Record<string, unknown> = {};
+                    const q: Record<string, unknown> = {};
+                    for (const method of ["select", "is", "order", "limit"])
+                        q[method] = () => q;
+                    q.eq = (column: string, value: unknown) => {
+                        filters[column] = value;
+                        return q;
+                    };
+                    q.in = (column: string, values: unknown[]) => {
+                        filters[column] = values;
+                        return q;
+                    };
+                    const settle = () =>
+                        "user_id" in filters
+                            ? {
+                                  data: null,
+                                  error: { message: "connection reset" },
+                              }
+                            : {
+                                  data: profiles.filter((row) =>
+                                      Object.entries(filters).every(
+                                          ([column, value]) =>
+                                              Array.isArray(value)
+                                                  ? value.includes(
+                                                        row[
+                                                            column as keyof typeof row
+                                                        ],
+                                                    )
+                                                  : row[
+                                                        column as keyof typeof row
+                                                    ] === value,
+                                      ),
+                                  ),
+                                  error: null,
+                              };
+                    q.maybeSingle = () => {
+                        const { data, error } = settle();
+                        return Promise.resolve({
+                            data: data?.[0] ?? null,
+                            error,
+                        });
+                    };
+                    q.single = q.maybeSingle;
+                    q.then = (resolve: (v: unknown) => unknown) =>
+                        Promise.resolve(settle()).then(resolve);
+                    return q;
+                }
+                const query = originalFrom(table) as Record<string, unknown>;
+                if (table === "chat_access_grants")
+                    for (const method of ["upsert", "insert"] as const) {
+                        const original = query[method] as (
+                            ...args: unknown[]
+                        ) => unknown;
+                        query[method] = (...args: unknown[]) => {
+                            grantWrites.push(method);
+                            return original(...args);
+                        };
+                    }
+                return query;
+            }) as never;
+            return db as never;
+        });
+
+        const res = await request(app)
+            .post("/chat/chat-1/access")
+            .set("Authorization", "Bearer test")
+            .send({ email: "mate@example.com", role: "viewer" });
+
+        expect.soft(res.status).toBe(500);
+        expect.soft(res.body.detail).toBe(
+            "Something went wrong. Please try again.",
+        );
+        // The internal message never reaches the client...
+        expect.soft(JSON.stringify(res.body)).not.toContain("connection reset");
+        // ...and nothing was written.
+        expect.soft(grantWrites).toEqual([]);
+    });
+
     it("403s a directly granted member trying to manage grants", async () => {
         mockedCreate.mockImplementation(
             () =>

--- a/backend/src/__tests__/integration/documents.routes.test.ts
+++ b/backend/src/__tests__/integration/documents.routes.test.ts
@@ -1,0 +1,198 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import request from "supertest";
+
+// ---------------------------------------------------------------------------
+// DELETE /single-documents/:documentId — the container's rule, not `user_id`.
+//
+// This route used to scope its lookup with `.eq("user_id", userId)`, which
+// answered "Document not found" for anything the caller had not personally
+// uploaded. Two consequences:
+//
+//   * an organization admin could not remove a colleague's document from a
+//     matter the firm owns, and
+//   * once account deletion started blanking documents.user_id instead of
+//     destroying organization content, NOBODY could remove a departed
+//     colleague's document — the row was stranded in a project the
+//     organization is supposed to control.
+//
+// It now resolves the document through ensureDocAccess and applies the same
+// creator-scoped rule as DELETE .../versions/:versionId.
+// ---------------------------------------------------------------------------
+
+const { ensureDocAccess } = vi.hoisted(() => ({ ensureDocAccess: vi.fn() }));
+
+type QueryResult = { data: unknown; error: unknown };
+let tables: Record<string, QueryResult>;
+const deletes: string[] = [];
+
+function makeQuery(table: string) {
+    const q: Record<string, unknown> = {};
+    for (const m of [
+        "select",
+        "update",
+        "upsert",
+        "insert",
+        "eq",
+        "in",
+        "is",
+        "or",
+        "not",
+        "order",
+        "limit",
+    ])
+        q[m] = vi.fn(() => q);
+    q.delete = vi.fn(() => {
+        deletes.push(table);
+        return q;
+    });
+    const result = () => tables[table] ?? { data: null, error: null };
+    q.single = vi.fn(() => Promise.resolve(result()));
+    q.maybeSingle = vi.fn(() => Promise.resolve(result()));
+    q.then = (resolve: (v: unknown) => unknown) =>
+        Promise.resolve(result()).then(resolve);
+    return q;
+}
+
+vi.mock("../../lib/supabase", () => ({
+    createServerSupabase: vi.fn(() => ({
+        from: vi.fn((table: string) => makeQuery(table)),
+        rpc: vi.fn(async () => ({ data: null, error: null })),
+        auth: {
+            getUser: async () => ({ data: { user: { id: "u1" } }, error: null }),
+        },
+    })),
+}));
+
+vi.mock("../../middleware/auth", () => ({
+    requireAuth: (
+        _req: unknown,
+        res: { locals: Record<string, unknown> },
+        next: () => void,
+    ) => {
+        res.locals.userId = "u1";
+        res.locals.userEmail = "u1@test.local";
+        next();
+    },
+    requireMfaIfEnrolled: (_req: unknown, _res: unknown, next: () => void) =>
+        next(),
+}));
+
+// Only the verdict is stubbed; creatorScopedAllowed stays real, because the
+// rule under test IS that helper's "the creator is gone, so the container's
+// Owners inherit" branch.
+vi.mock("../../lib/access", async (importOriginal) => ({
+    ...(await importOriginal<typeof import("../../lib/access")>()),
+    ensureDocAccess: (...args: unknown[]) => ensureDocAccess(...args),
+}));
+
+vi.mock("../../lib/dbq/enqueue", () => ({
+    enqueueStorageCleanup: vi.fn(async () => {}),
+    enqueueDbJob: vi.fn(async () => ({ ok: true })),
+}));
+
+import { app } from "../../app";
+
+const AUTH = ["Authorization", "Bearer test"] as const;
+const DOC = "11111111-1111-4111-8111-111111111111";
+
+const access = (projectRole: string, isCreator: boolean) => ({
+    ok: true,
+    isCreator,
+    orgRole: "admin",
+    projectRole,
+});
+
+describe("DELETE /single-documents/:documentId", () => {
+    beforeEach(() => {
+        deletes.length = 0;
+        tables = {
+            documents: {
+                data: {
+                    id: DOC,
+                    user_id: "u2",
+                    project_id: "p1",
+                    org_id: "o1",
+                    workflow_id: null,
+                },
+                error: null,
+            },
+            document_versions: { data: [], error: null },
+        };
+        ensureDocAccess.mockResolvedValue(access("owner", false));
+    });
+
+    it("deletes a detached document nobody else could reach", async () => {
+        // user_id NULL: the uploader's account is gone, so "only the creator
+        // may delete" would mean nobody ever can.
+        tables.documents = {
+            data: {
+                id: DOC,
+                user_id: null,
+                project_id: "p1",
+                org_id: "o1",
+                workflow_id: null,
+            },
+            error: null,
+        };
+
+        const res = await request(app)
+            .delete(`/single-documents/${DOC}`)
+            .set(...AUTH);
+
+        expect(res.status).toBe(204);
+        expect(deletes).toContain("documents");
+    });
+
+    it("deletes the caller's own document", async () => {
+        ensureDocAccess.mockResolvedValue(access("owner", true));
+
+        const res = await request(app)
+            .delete(`/single-documents/${DOC}`)
+            .set(...AUTH);
+
+        expect(res.status).toBe(204);
+    });
+
+    it("refuses a live colleague's document with 403, not a fake 404", async () => {
+        const res = await request(app)
+            .delete(`/single-documents/${DOC}`)
+            .set(...AUTH);
+
+        expect(res.status).toBe(403);
+        expect(res.body.detail).toBe(
+            "You do not have permission to delete this document.",
+        );
+        expect(deletes).not.toContain("documents");
+    });
+
+    it("keeps 404 for a document the caller cannot see at all", async () => {
+        ensureDocAccess.mockResolvedValue({ ok: false });
+
+        const res = await request(app)
+            .delete(`/single-documents/${DOC}`)
+            .set(...AUTH);
+
+        expect(res.status).toBe(404);
+        expect(deletes).not.toContain("documents");
+    });
+
+    it("lets a workflow asset be removed by anyone who may edit the workflow", async () => {
+        tables.documents = {
+            data: {
+                id: DOC,
+                user_id: "u2",
+                project_id: null,
+                org_id: "o1",
+                workflow_id: "w1",
+            },
+            error: null,
+        };
+        ensureDocAccess.mockResolvedValue(access("editor", false));
+
+        const res = await request(app)
+            .delete(`/single-documents/${DOC}`)
+            .set(...AUTH);
+
+        expect(res.status).toBe(204);
+    });
+});

--- a/backend/src/__tests__/integration/documents.routes.test.ts
+++ b/backend/src/__tests__/integration/documents.routes.test.ts
@@ -21,35 +21,87 @@ import request from "supertest";
 
 const { ensureDocAccess } = vi.hoisted(() => ({ ensureDocAccess: vi.fn() }));
 
-type QueryResult = { data: unknown; error: unknown };
-let tables: Record<string, QueryResult>;
+type Row = Record<string, unknown>;
+
+// FILTER-AWARE, deliberately. The previous stub answered per TABLE and threw
+// every `.eq()` away, so a route that scoped its lookup with
+// `.eq("user_id", userId)` and a route that did not returned the same row —
+// which is precisely the difference these tests exist to see. Honouring
+// eq/in/is is what makes "an org admin may delete a colleague's document"
+// and "the creator scope is gone" observable at all.
+let rows: Record<string, Row[]>;
+let errors: Record<string, { message: string } | undefined>;
+/** Tables a delete was issued against, in order. */
 const deletes: string[] = [];
+/** Update payloads, so a soft-delete can be asserted on. */
+const updates: { table: string; payload: Row }[] = [];
 
 function makeQuery(table: string) {
+    const filters: {
+        kind: "eq" | "in" | "is";
+        column: string;
+        value: unknown;
+    }[] = [];
+    let op: "select" | "delete" | "update" = "select";
+    let payload: Row = {};
+
     const q: Record<string, unknown> = {};
-    for (const m of [
-        "select",
-        "update",
-        "upsert",
-        "insert",
-        "eq",
-        "in",
-        "is",
-        "or",
-        "not",
-        "order",
-        "limit",
-    ])
+    for (const m of ["select", "upsert", "insert", "or", "not", "order", "limit"])
         q[m] = vi.fn(() => q);
-    q.delete = vi.fn(() => {
-        deletes.push(table);
+    for (const kind of ["eq", "in", "is"] as const)
+        q[kind] = vi.fn((column: string, value: unknown) => {
+            filters.push({ kind, column, value });
+            return q;
+        });
+    q.update = vi.fn((value: Row) => {
+        op = "update";
+        payload = value;
         return q;
     });
-    const result = () => tables[table] ?? { data: null, error: null };
-    q.single = vi.fn(() => Promise.resolve(result()));
-    q.maybeSingle = vi.fn(() => Promise.resolve(result()));
+    q.delete = vi.fn(() => {
+        op = "delete";
+        return q;
+    });
+
+    const matches = () =>
+        (rows[table] ?? []).filter((row) =>
+            filters.every((filter) => {
+                if (filter.kind === "in")
+                    return (filter.value as unknown[]).includes(
+                        row[filter.column],
+                    );
+                // A missing column and an explicit null mean the same thing
+                // here, exactly as they do in the column itself.
+                return (row[filter.column] ?? null) === (filter.value ?? null);
+            }),
+        );
+
+    const settle = () => {
+        const error = errors[table];
+        if (error) return { data: null, error };
+        const hits = matches();
+        if (op === "delete") {
+            deletes.push(table);
+            rows[table] = (rows[table] ?? []).filter(
+                (row) => !hits.includes(row),
+            );
+            return { data: hits, error: null };
+        }
+        if (op === "update") {
+            updates.push({ table, payload });
+            for (const row of hits) Object.assign(row, payload);
+            return { data: hits, error: null };
+        }
+        return { data: hits, error: null };
+    };
+
+    q.single = vi.fn(async () => {
+        const { data, error } = settle();
+        return { data: (data as Row[] | null)?.[0] ?? null, error };
+    });
+    q.maybeSingle = q.single;
     q.then = (resolve: (v: unknown) => unknown) =>
-        Promise.resolve(result()).then(resolve);
+        Promise.resolve(settle()).then(resolve);
     return q;
 }
 
@@ -105,18 +157,19 @@ const access = (projectRole: string, isCreator: boolean) => ({
 describe("DELETE /single-documents/:documentId", () => {
     beforeEach(() => {
         deletes.length = 0;
-        tables = {
-            documents: {
-                data: {
+        updates.length = 0;
+        errors = {};
+        rows = {
+            documents: [
+                {
                     id: DOC,
                     user_id: "u2",
                     project_id: "p1",
                     org_id: "o1",
                     workflow_id: null,
                 },
-                error: null,
-            },
-            document_versions: { data: [], error: null },
+            ],
+            document_versions: [],
         };
         ensureDocAccess.mockResolvedValue(access("owner", false));
     });
@@ -124,16 +177,15 @@ describe("DELETE /single-documents/:documentId", () => {
     it("deletes a detached document nobody else could reach", async () => {
         // user_id NULL: the uploader's account is gone, so "only the creator
         // may delete" would mean nobody ever can.
-        tables.documents = {
-            data: {
+        rows.documents = [
+            {
                 id: DOC,
                 user_id: null,
                 project_id: "p1",
                 org_id: "o1",
                 workflow_id: null,
             },
-            error: null,
-        };
+        ];
 
         const res = await request(app)
             .delete(`/single-documents/${DOC}`)
@@ -176,17 +228,60 @@ describe("DELETE /single-documents/:documentId", () => {
         expect(deletes).not.toContain("documents");
     });
 
+    it("lets an organization admin delete a departed colleague's document", async () => {
+        // The stub now honours `.eq()`, so a `.eq("user_id", userId)` scope on
+        // the lookup would hand this route a null row and a 404 — which is
+        // exactly what it used to do. Account deletion blanks
+        // documents.user_id rather than destroying organization content, so
+        // under the old scope NOBODY could remove this row: it sat stranded
+        // in a matter the firm is supposed to control.
+        rows.documents = [
+            {
+                id: DOC,
+                user_id: null,
+                project_id: "p1",
+                org_id: "o1",
+                workflow_id: null,
+            },
+        ];
+        ensureDocAccess.mockResolvedValue(access("owner", false));
+
+        const res = await request(app)
+            .delete(`/single-documents/${DOC}`)
+            .set(...AUTH);
+
+        expect(res.status).toBe(204);
+        // The row is really gone, not merely "no error".
+        expect(rows.documents).toEqual([]);
+    });
+
+    it("refuses a non-creator editor deleting a live colleague's document", async () => {
+        // Widening the lookup past `user_id` must not widen the RULE: the
+        // creator-scoped check still applies, and an Editor who did not
+        // upload this file may not delete it.
+        ensureDocAccess.mockResolvedValue(access("editor", false));
+
+        const res = await request(app)
+            .delete(`/single-documents/${DOC}`)
+            .set(...AUTH);
+
+        expect(res.status).toBe(403);
+        expect(res.body.detail).toBe(
+            "You do not have permission to delete this document.",
+        );
+        expect(rows.documents).toHaveLength(1);
+    });
+
     it("lets a workflow asset be removed by anyone who may edit the workflow", async () => {
-        tables.documents = {
-            data: {
+        rows.documents = [
+            {
                 id: DOC,
                 user_id: "u2",
                 project_id: null,
                 org_id: "o1",
                 workflow_id: "w1",
             },
-            error: null,
-        };
+        ];
         ensureDocAccess.mockResolvedValue(access("editor", false));
 
         const res = await request(app)
@@ -194,5 +289,102 @@ describe("DELETE /single-documents/:documentId", () => {
             .set(...AUTH);
 
         expect(res.status).toBe(204);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// DELETE /single-documents/:documentId/versions/:versionId
+//
+// The same split as the whole-document DELETE: no verdict at all is a 404,
+// and a caller who can OPEN the document but may not delete this version is
+// refused by name. Collapsing both into 404 told a Viewer their version had
+// vanished — and then the document list re-rendered it.
+// ---------------------------------------------------------------------------
+
+const V1 = "22222222-2222-4222-8222-222222222221";
+const V2 = "22222222-2222-4222-8222-222222222222";
+
+describe("DELETE /single-documents/:documentId/versions/:versionId", () => {
+    beforeEach(() => {
+        deletes.length = 0;
+        updates.length = 0;
+        errors = {};
+        rows = {
+            documents: [
+                {
+                    id: DOC,
+                    user_id: "u2",
+                    project_id: "p1",
+                    org_id: "o1",
+                    workflow_id: null,
+                    current_version_id: V2,
+                },
+            ],
+            document_versions: [
+                {
+                    id: V1,
+                    document_id: DOC,
+                    storage_path: null,
+                    pdf_storage_path: null,
+                    version_number: 1,
+                    created_at: "2026-09-01T00:00:00Z",
+                    deleted_at: null,
+                },
+                {
+                    id: V2,
+                    document_id: DOC,
+                    storage_path: null,
+                    pdf_storage_path: null,
+                    version_number: 2,
+                    created_at: "2026-09-02T00:00:00Z",
+                    deleted_at: null,
+                },
+            ],
+        };
+        ensureDocAccess.mockResolvedValue(access("editor", false));
+    });
+
+    it("refuses a non-creator editor with 403 and a reason", async () => {
+        const res = await request(app)
+            .delete(`/single-documents/${DOC}/versions/${V2}`)
+            .set(...AUTH);
+
+        expect(res.status).toBe(403);
+        expect(res.body.detail).toBe(
+            "You do not have permission to delete this version.",
+        );
+        // Nothing was soft-deleted and current_version_id did not move.
+        expect(updates).toEqual([]);
+        expect(rows.documents[0].current_version_id).toBe(V2);
+    });
+
+    it("keeps 404 for a caller with no verdict at all", async () => {
+        // A non-member must not learn that the document exists.
+        ensureDocAccess.mockResolvedValue({ ok: false });
+
+        const res = await request(app)
+            .delete(`/single-documents/${DOC}/versions/${V2}`)
+            .set(...AUTH);
+
+        expect(res.status).toBe(404);
+        expect(res.body.detail).toBe("Document not found");
+        expect(updates).toEqual([]);
+    });
+
+    it("lets the version's creator through the gate", async () => {
+        ensureDocAccess.mockResolvedValue(access("editor", true));
+        rows.documents[0].user_id = "u1";
+
+        const res = await request(app)
+            .delete(`/single-documents/${DOC}/versions/${V2}`)
+            .set(...AUTH);
+
+        expect(res.status).toBe(200);
+        expect(res.body.deleted_version_id).toBe(V2);
+        // The current version fell back to the newest survivor.
+        expect(res.body.current_version_id).toBe(V1);
+        expect(
+            updates.some((update) => update.table === "document_versions"),
+        ).toBe(true);
     });
 });

--- a/backend/src/__tests__/integration/projects.directorySearch.routes.test.ts
+++ b/backend/src/__tests__/integration/projects.directorySearch.routes.test.ts
@@ -1,0 +1,301 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import request from "supertest";
+
+// ---------------------------------------------------------------------------
+// GET /projects?view=directory-search — the document picker's own access
+// branches.
+//
+// This route resolves the same project three different ways (created by me,
+// granted to me, in one of my orgs) and the shared per-table stub used by
+// projects.routes.test.ts cannot tell those reads apart. So this file drives
+// a FILTER-AWARE db instead, and records the filters each read was issued
+// with — the shape of the override query is itself one of the things under
+// test, not just its answer.
+// ---------------------------------------------------------------------------
+
+function mockSupabase() {
+    return {
+        from: vi.fn(() => {
+            const q: Record<string, unknown> = {};
+            for (const method of [
+                "select",
+                "update",
+                "delete",
+                "upsert",
+                "insert",
+                "eq",
+                "neq",
+                "in",
+                "is",
+                "or",
+                "not",
+                "ilike",
+                "order",
+                "limit",
+                "range",
+            ])
+                q[method] = vi.fn(() => q);
+            q.single = vi.fn(() => Promise.resolve({ data: null, error: null }));
+            q.maybeSingle = q.single;
+            q.then = (resolve: (v: unknown) => unknown) =>
+                Promise.resolve({ data: [], error: null }).then(resolve);
+            return q;
+        }),
+        rpc: vi.fn(() => Promise.resolve({ data: [], error: null })),
+        auth: {
+            getUser: () =>
+                Promise.resolve({ data: { user: { id: "u1" } }, error: null }),
+        },
+    };
+}
+
+vi.mock("../../lib/supabase", () => ({
+    createServerSupabase: vi.fn(() => mockSupabase()),
+}));
+
+vi.mock("../../middleware/auth", () => ({
+    requireAuth: (
+        _req: unknown,
+        res: { locals: Record<string, unknown> },
+        next: () => void,
+    ) => {
+        res.locals.userId = "u1";
+        res.locals.userEmail = "u1@test.local";
+        next();
+    },
+    requireMfaIfEnrolled: (_req: unknown, _res: unknown, next: () => void) =>
+        next(),
+}));
+
+// Every export of lib/access must survive — the other routers mounted by the
+// app import from it at load time.
+vi.mock("../../lib/access", async (importOriginal) => ({
+    ...(await importOriginal<typeof import("../../lib/access")>()),
+    checkProjectAccess: vi.fn(async () => ({ ok: false })),
+    ensureDocAccess: vi.fn(async () => ({ ok: true, isOwner: true })),
+    ensureReviewAccess: vi.fn(async () => ({ ok: true, isOwner: true })),
+    filterAccessibleDocumentIds: vi.fn(async (ids: string[]) => ids),
+    listAccessibleProjectIds: vi.fn(async () => []),
+    getOrgRole: vi.fn(async () => null),
+    resolveContentOrgId: vi.fn(async () => null),
+}));
+
+vi.mock("../../lib/userDataCleanup", () => ({
+    deleteProjectsByIds: vi.fn(async () => 0),
+    deleteAllUserChats: vi.fn(async () => {}),
+    deleteAllUserTabularReviews: vi.fn(async () => {}),
+    deleteUserAccountData: vi.fn(async () => {}),
+    deleteUserProjects: vi.fn(async () => 0),
+    listOrgsBlockingAccountDeletion: vi.fn(async () => []),
+}));
+
+vi.mock("../../lib/documentVersions", () => ({
+    attachActiveVersionPaths: vi.fn(async () => {}),
+    attachLatestVersionNumbers: vi.fn(async () => {}),
+    contentSha256: vi.fn(() => "0".repeat(64)),
+    loadActiveVersion: vi.fn(async () => null),
+}));
+
+import { app } from "../../app";
+import { createServerSupabase } from "../../lib/supabase";
+
+const AUTH = ["Authorization", "Bearer test"] as const;
+
+type Project = Record<string, unknown>;
+
+/**
+ * A db that answers per (table, filters) and records what it was asked.
+ * `reads` holds one entry per query with its filters in the order they were
+ * applied, which is how the override-query shape is asserted.
+ */
+function directorySearchDb(options: {
+    /** Rows the `projects` read scoped by `eq:user_id` returns. */
+    created?: Project[];
+    /** Rows the `projects` read scoped by `in:org_id` returns. */
+    orgProjects?: Project[];
+    memberships?: { org_id: string; role: string }[];
+    denies?: string[];
+}) {
+    const created = options.created ?? [];
+    const orgProjects = options.orgProjects ?? [];
+    const memberships = options.memberships ?? [];
+    const denied = new Set(options.denies ?? []);
+    const reads: { table: string; filters: string[] }[] = [];
+
+    const build = (
+        table: string,
+        resolve: (filters: Record<string, unknown>) => unknown[],
+    ) => {
+        const filters: Record<string, unknown> = {};
+        const record = { table, filters: [] as string[] };
+        reads.push(record);
+        const b: Record<string, unknown> = {};
+        for (const method of ["select", "order", "limit", "range", "ilike"])
+            b[method] = () => b;
+        b.is = () => b;
+        b.eq = (column: string, value: unknown) => {
+            filters[`eq:${column}`] = value;
+            record.filters.push(`eq:${column}`);
+            return b;
+        };
+        b.in = (column: string, value: unknown) => {
+            filters[`in:${column}`] = value;
+            record.filters.push(`in:${column}`);
+            return b;
+        };
+        b.single = () =>
+            Promise.resolve({ data: resolve(filters)[0] ?? null, error: null });
+        b.maybeSingle = b.single;
+        b.then = (onResolve: (v: unknown) => unknown) =>
+            Promise.resolve({ data: resolve(filters), error: null }).then(
+                onResolve,
+            );
+        return b;
+    };
+
+    const db = {
+        from: (table: string) => {
+            if (table === "projects")
+                return build(table, (filters) => {
+                    if (filters["in:org_id"]) return orgProjects;
+                    if (filters["in:id"]) return [];
+                    return created;
+                });
+            if (table === "project_org_access_overrides")
+                return build(table, (filters) => {
+                    const orgIds =
+                        (filters["in:org_id"] as string[] | undefined) ?? [];
+                    return orgProjects
+                        .filter(
+                            (project) =>
+                                denied.has(project.id as string) &&
+                                orgIds.includes(project.org_id as string),
+                        )
+                        .map((project) => ({ project_id: project.id }));
+                });
+            if (table === "org_members") return build(table, () => memberships);
+            return build(table, () => []);
+        },
+        rpc: () => Promise.resolve({ data: [], error: null }),
+        auth: {
+            getUser: () =>
+                Promise.resolve({
+                    data: { user: { id: "u1" } },
+                    error: null,
+                }),
+        },
+    };
+    return { db, reads };
+}
+
+function useDb(handle: { db: unknown }) {
+    vi.mocked(createServerSupabase).mockImplementationOnce(
+        () => handle.db as ReturnType<typeof createServerSupabase>,
+    );
+}
+
+const search = () =>
+    request(app).get("/projects?view=directory-search&search=Matter").set(...AUTH);
+
+// The caller created this org matter and then left the firm. The
+// projects.user_id row survives their departure; their access does not.
+const CREATED_ORG_PROJECT = {
+    id: "p-firm",
+    name: "Matter Firm",
+    cm_number: "2026-0001",
+    org_id: "o1",
+    user_id: "u1",
+    updated_at: "2026-09-01T00:00:00Z",
+};
+
+describe("GET /projects?view=directory-search", () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it("hides an org project whose creator has left the organization", async () => {
+        // "I created it" is not a verdict on its own. checkProjectAccess —
+        // which every other read path uses — answers "no access" for a
+        // non-member, so the picker was the one surface still offering a
+        // matter that 404s the moment it is opened.
+        const handle = directorySearchDb({
+            created: [CREATED_ORG_PROJECT],
+            memberships: [],
+        });
+        useDb(handle);
+
+        const res = await search();
+
+        expect(res.status).toBe(200);
+        expect(res.body).toEqual([]);
+    });
+
+    it("keeps that project while its creator is still a member", async () => {
+        // The control. The org branch re-admits it, so leaving the org is
+        // what removes it — not the change itself.
+        const handle = directorySearchDb({
+            created: [CREATED_ORG_PROJECT],
+            orgProjects: [CREATED_ORG_PROJECT],
+            memberships: [{ org_id: "o1", role: "member" }],
+        });
+        useDb(handle);
+
+        const res = await search();
+
+        expect(res.status).toBe(200);
+        expect(res.body.map((project: { id: string }) => project.id)).toEqual([
+            "p-firm",
+        ]);
+    });
+
+    it("keeps a personal project the caller created, org membership or not", async () => {
+        const handle = directorySearchDb({
+            created: [
+                {
+                    id: "p-personal",
+                    name: "Matter Personal",
+                    org_id: null,
+                    user_id: "u1",
+                    updated_at: "2026-09-01T00:00:00Z",
+                },
+            ],
+            memberships: [],
+        });
+        useDb(handle);
+
+        const res = await search();
+
+        expect(res.status).toBe(200);
+        expect(res.body.map((project: { id: string }) => project.id)).toEqual([
+            "p-personal",
+        ]);
+    });
+
+    it("asks for the deny overrides by org, never by a list of project ids", async () => {
+        // The candidate-id list grows with the firm's matters and is spliced
+        // verbatim into the PostgREST query string, so a large tenant sent a
+        // URL past the server's request-line limit; the read then failed and
+        // the picker — which fails closed — went blank. org_id is bounded by
+        // the caller's memberships instead.
+        const handle = directorySearchDb({
+            created: [],
+            orgProjects: [CREATED_ORG_PROJECT],
+            memberships: [{ org_id: "o1", role: "member" }],
+        });
+        useDb(handle);
+
+        const res = await search();
+
+        expect(res.status).toBe(200);
+        const overrideReads = handle.reads.filter(
+            (read) => read.table === "project_org_access_overrides",
+        );
+        expect(overrideReads).toHaveLength(1);
+        expect(overrideReads[0].filters).toEqual([
+            "in:org_id",
+            "eq:user_id",
+            "eq:role",
+        ]);
+        expect(overrideReads[0].filters).not.toContain("in:project_id");
+    });
+});

--- a/backend/src/__tests__/integration/projects.routes.test.ts
+++ b/backend/src/__tests__/integration/projects.routes.test.ts
@@ -373,6 +373,144 @@ describe("projects.routes", () => {
 
       expect(res.status).toBe(404);
     });
+
+    // ── directory search vs. the deny override ─────────────────────────
+    // The picker's org branch used to be plain membership: `projects` where
+    // org_id IN (my orgs), with no per-project verdict. Every other path
+    // resolves through checkProjectAccess / project_access_role, which
+    // refuse on a deny — so the picker was handing a walled-off member the
+    // matter's name, cm_number and its document filenames.
+    //
+    // The shared stub answers per TABLE, and this route reads the same
+    // `projects` table three different ways, so these two tests use a
+    // filter-aware db instead.
+    function directorySearchDb(options: {
+      personal?: Record<string, unknown>[];
+      orgProjects?: Record<string, unknown>[];
+      memberships?: { org_id: string; role: string }[];
+      denies?: string[];
+    }) {
+      const personal = options.personal ?? [];
+      const orgProjects = options.orgProjects ?? [];
+      const memberships = options.memberships ?? [];
+      const denied = new Set(options.denies ?? []);
+
+      const build = (resolve: (f: Record<string, unknown>) => unknown[]) => {
+        const filters: Record<string, unknown> = {};
+        const b: Record<string, unknown> = {};
+        for (const method of ["select", "order", "limit", "range", "ilike"])
+          b[method] = () => b;
+        b.is = () => b;
+        b.eq = (column: string, value: unknown) => {
+          filters[`eq:${column}`] = value;
+          return b;
+        };
+        b.in = (column: string, value: unknown) => {
+          filters[`in:${column}`] = value;
+          return b;
+        };
+        b.single = () =>
+          Promise.resolve({ data: resolve(filters)[0] ?? null, error: null });
+        b.maybeSingle = b.single;
+        b.then = (onResolve: (v: unknown) => unknown) =>
+          Promise.resolve({ data: resolve(filters), error: null }).then(
+            onResolve,
+          );
+        return b;
+      };
+
+      return {
+        from: (table: string) => {
+          if (table === "projects")
+            return build((filters) => {
+              if (filters["in:org_id"]) return orgProjects;
+              if (filters["in:id"]) return [];
+              return personal;
+            });
+          if (table === "project_org_access_overrides")
+            return build((filters) =>
+              (
+                (filters["in:project_id"] as string[] | undefined) ?? []
+              )
+                .filter((id) => denied.has(id))
+                .map((id) => ({ project_id: id })),
+            );
+          if (table === "org_members") return build(() => memberships);
+          return build(() => []);
+        },
+        rpc: () => Promise.resolve({ data: [], error: null }),
+        auth: {
+          getUser: () =>
+            Promise.resolve({ data: { user: { id: "u1" } }, error: null }),
+        },
+      };
+    }
+
+    const WALLED = {
+      id: "p-walled",
+      name: "Matter P",
+      cm_number: "2026-0042",
+      org_id: "o1",
+      user_id: "u2",
+      updated_at: "2026-09-01T00:00:00Z",
+    };
+
+    it("hides an org project the caller is denied on", async () => {
+      vi.mocked(createServerSupabase).mockImplementationOnce(
+        () =>
+          directorySearchDb({
+            memberships: [{ org_id: "o1", role: "member" }],
+            orgProjects: [WALLED],
+            denies: ["p-walled"],
+          }) as unknown as ReturnType<typeof createServerSupabase>,
+      );
+
+      const res = await request(app)
+        .get("/projects?view=directory-search&search=Matter")
+        .set(...AUTH);
+
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual([]);
+    });
+
+    it("still returns the org project when no deny override exists", async () => {
+      vi.mocked(createServerSupabase).mockImplementationOnce(
+        () =>
+          directorySearchDb({
+            memberships: [{ org_id: "o1", role: "member" }],
+            orgProjects: [WALLED],
+          }) as unknown as ReturnType<typeof createServerSupabase>,
+      );
+
+      const res = await request(app)
+        .get("/projects?view=directory-search&search=Matter")
+        .set(...AUTH);
+
+      expect(res.status).toBe(200);
+      expect(res.body.map((project: { id: string }) => project.id)).toEqual([
+        "p-walled",
+      ]);
+    });
+
+    it("keeps an org admin's view of a project carrying a stale deny row", async () => {
+      vi.mocked(createServerSupabase).mockImplementationOnce(
+        () =>
+          directorySearchDb({
+            memberships: [{ org_id: "o1", role: "admin" }],
+            orgProjects: [WALLED],
+            denies: ["p-walled"],
+          }) as unknown as ReturnType<typeof createServerSupabase>,
+      );
+
+      const res = await request(app)
+        .get("/projects?view=directory-search&search=Matter")
+        .set(...AUTH);
+
+      expect(res.status).toBe(200);
+      expect(res.body.map((project: { id: string }) => project.id)).toEqual([
+        "p-walled",
+      ]);
+    });
     });
 
     // ── GET /projects/ids (select-all-matching support) ──────────────────
@@ -618,7 +756,12 @@ describe("projects.routes", () => {
           conflict_resolution: "rename",
         });
 
-      expect(res.status).toBe(404);
+      // 403, not 404: the viewer can see this project, so claiming it does
+      // not exist is a lie the UI then repeats to them.
+      expect(res.status).toBe(403);
+      expect(res.body.detail).toBe(
+        "You do not have permission to organize documents in this project.",
+      );
       expect(captured.name).toBeUndefined();
     });
 
@@ -1029,12 +1172,62 @@ describe("projects.routes", () => {
             expect(res.status).toBe(204);
         });
 
-        it("blocks a viewer (404)", async () => {
+        it("blocks a viewer with a refusal, not a fake 404", async () => {
             checkProjectAccess.mockResolvedValue(roleAccess("viewer"));
             const res = await request(app)
                 .delete("/projects/p1/folders/f1")
                 .set(...AUTH);
+            expect(res.status).toBe(403);
+            expect(res.body.detail).toBe(
+                "You do not have permission to organize documents in this project.",
+            );
+        });
+
+        it("still answers 404 when the project is invisible", async () => {
+            checkProjectAccess.mockResolvedValue({ ok: false });
+            const res = await request(app)
+                .delete("/projects/p1/folders/f1")
+                .set(...AUTH);
             expect(res.status).toBe(404);
+            expect(res.body.detail).toBe("Project not found");
+        });
+    });
+
+    // ── POST /projects/:projectId/folders (404 vs 403) ───────────────────
+    // "Project not found" for a viewer who is looking straight at the
+    // project is the bug: a refusal has to say it is a refusal.
+    describe("POST /projects/:projectId/folders", () => {
+        it("refuses a viewer with 403 and an intentional message", async () => {
+            checkProjectAccess.mockResolvedValue({
+                ok: true,
+                isCreator: false,
+                orgRole: "member",
+                projectRole: "viewer",
+                project: { id: "p1", user_id: "u2", org_id: "o1" },
+            });
+
+            const res = await request(app)
+                .post("/projects/p1/folders")
+                .set(...AUTH)
+                .send({ name: "Closing" });
+
+            expect(res.status).toBe(403);
+            expect(res.body.detail).toBe(
+                "You do not have permission to organize documents in this project.",
+            );
+            expect(supabaseState.inserts).toEqual([]);
+        });
+
+        it("keeps 404 for a project the caller cannot see at all", async () => {
+            checkProjectAccess.mockResolvedValue({ ok: false });
+
+            const res = await request(app)
+                .post("/projects/p1/folders")
+                .set(...AUTH)
+                .send({ name: "Closing" });
+
+            expect(res.status).toBe(404);
+            expect(res.body.detail).toBe("Project not found");
         });
     });
 

--- a/backend/src/__tests__/integration/projects.routes.test.ts
+++ b/backend/src/__tests__/integration/projects.routes.test.ts
@@ -428,13 +428,19 @@ describe("projects.routes", () => {
               return personal;
             });
           if (table === "project_org_access_overrides")
-            return build((filters) =>
-              (
-                (filters["in:project_id"] as string[] | undefined) ?? []
-              )
-                .filter((id) => denied.has(id))
-                .map((id) => ({ project_id: id })),
-            );
+            // The deny read is scoped by the caller's memberships (org_id),
+            // their user_id and role — never by every org project's id.
+            return build((filters) => {
+              const orgIds = (filters["in:org_id"] as string[] | undefined) ?? [];
+              if (filters["in:project_id"]) return [];
+              return orgProjects
+                .filter(
+                  (project) =>
+                    denied.has(project.id as string) &&
+                    orgIds.includes(project.org_id as string),
+                )
+                .map((project) => ({ project_id: project.id }));
+            });
           if (table === "org_members") return build(() => memberships);
           return build(() => []);
         },

--- a/backend/src/__tests__/integration/tabular.routes.test.ts
+++ b/backend/src/__tests__/integration/tabular.routes.test.ts
@@ -184,6 +184,7 @@ vi.mock("../../lib/documentVersions", () => ({
 }));
 
 import { app } from "../../app";
+import { REVIEW_EDIT_FORBIDDEN } from "../../routes/tabular";
 
 const AUTH = ["Authorization", "Bearer test"] as const;
 
@@ -1417,6 +1418,123 @@ describe("tabular.routes", () => {
             expect(res.body.detail).toBe("Review not found");
         });
 
+        // ── the write gate ────────────────────────────────────────────────
+        // GENERATION IS A WRITE: it claims the review's generation lease,
+        // spends the caller's model credit, persists a cell per column per
+        // row and stamps an audit event in the caller's name. `access.ok`
+        // alone let a review VIEWER do all of that.
+        it("refuses a viewer with 403, not 404, and starts nothing", async () => {
+            supabaseState.tables.tabular_reviews = {
+                data: {
+                    id: "r1",
+                    user_id: "other",
+                    project_id: "p1",
+                    columns_config: [{ index: 0, name: "Col", prompt: "p" }],
+                },
+                error: null,
+            };
+            ensureReviewAccess.mockResolvedValue({
+                ok: true,
+                isCreator: false,
+                orgRole: "member",
+                projectRole: "viewer",
+            });
+
+            const res = await request(app)
+                .post("/tabular-review/r1/generate")
+                .set(...AUTH)
+                .send({ expected_updated_at: new Date().toISOString() });
+
+            // 403 with a reason, because the viewer CAN see this review —
+            // telling them it does not exist is a lie the UI then repeats.
+            expect(res.status).toBe(403);
+            expect(res.body.detail).toBe(REVIEW_EDIT_FORBIDDEN);
+            // And no side effects: no generation lease, no cells, no audit.
+            expect(supabaseState.rpcCalls).toEqual([]);
+            expect(supabaseState.inserts).toEqual([]);
+            expect(supabaseState.updates).toEqual([]);
+        });
+
+        it("lets an editor past the gate", async () => {
+            // Empty columns_config, so the next guard in prepareTabularGenerate
+            // answers — which is how the test proves the WRITE gate was
+            // passed without entering the streaming loop.
+            supabaseState.tables.tabular_reviews = {
+                data: {
+                    id: "r1",
+                    user_id: "other",
+                    project_id: "p1",
+                    columns_config: [],
+                },
+                error: null,
+            };
+            ensureReviewAccess.mockResolvedValue({
+                ok: true,
+                isCreator: false,
+                orgRole: "member",
+                projectRole: "editor",
+            });
+
+            const res = await request(app)
+                .post("/tabular-review/r1/generate")
+                .set(...AUTH);
+
+            expect(res.status).toBe(400);
+            expect(res.body.detail).toBe("No columns configured");
+        });
+
+        it("still answers 404 to a caller with no verdict at all", async () => {
+            // The split must keep the 404 for a non-member: 403 would confirm
+            // the review exists to somebody who cannot see it.
+            supabaseState.tables.tabular_reviews = {
+                data: {
+                    id: "r1",
+                    user_id: "other",
+                    project_id: "p1",
+                    columns_config: [{ index: 0, name: "Col", prompt: "p" }],
+                },
+                error: null,
+            };
+            ensureReviewAccess.mockResolvedValue({ ok: false });
+
+            const res = await request(app)
+                .post("/tabular-review/r1/generate")
+                .set(...AUTH);
+
+            expect(res.status).toBe(404);
+            expect(res.body.detail).toBe("Review not found");
+        });
+
+        it("refuses a viewer on the reconnect stream as well", async () => {
+            // The reconnect stream resumes a run this caller was entitled to
+            // START, and a viewer never was. Leaving it open would have made
+            // the POST gate cosmetic: the same generation channel, one URL
+            // away.
+            supabaseState.tables.tabular_reviews = {
+                data: {
+                    id: "r1",
+                    user_id: "other",
+                    project_id: "p1",
+                    columns_config: [{ index: 0, name: "Col", prompt: "p" }],
+                },
+                error: null,
+            };
+            ensureReviewAccess.mockResolvedValue({
+                ok: true,
+                isCreator: false,
+                orgRole: "member",
+                projectRole: "viewer",
+            });
+
+            const res = await request(app)
+                .get("/tabular-review/r1/generate/stream")
+                .set(...AUTH);
+
+            expect(res.status).toBe(403);
+            expect(res.body.detail).toBe(REVIEW_EDIT_FORBIDDEN);
+            expect(supabaseState.rpcCalls).toEqual([]);
+        });
+
         it("blocks a run when the review has no selected model", async () => {
             supabaseState.tables.tabular_reviews = {
                 data: {
@@ -1635,6 +1753,31 @@ describe("tabular.routes", () => {
 
             expect(res.status).toBe(404);
             expect(res.body.detail).toBe("Review not found");
+        });
+
+        it("refuses a viewer with 403 rather than claiming the review is gone", async () => {
+            // Review chat writes: it persists messages and can reshape the
+            // review. A viewer used to be told "Review not found" for a
+            // review sitting open on their screen.
+            supabaseState.tables.tabular_reviews = {
+                data: { id: "r1", user_id: "other", project_id: "p1" },
+                error: null,
+            };
+            ensureReviewAccess.mockResolvedValue({
+                ok: true,
+                isCreator: false,
+                orgRole: "member",
+                projectRole: "viewer",
+            });
+
+            const res = await request(app)
+                .post("/tabular-review/r1/chat")
+                .set(...AUTH)
+                .send({ messages: [{ role: "user", content: "hello" }] });
+
+            expect(res.status).toBe(403);
+            expect(res.body.detail).toBe(REVIEW_EDIT_FORBIDDEN);
+            expect(supabaseState.inserts).toEqual([]);
         });
 
         it("returns 422 missing_api_key before streaming when the key is absent", async () => {

--- a/backend/src/__tests__/integration/uploadSessions.routes.test.ts
+++ b/backend/src/__tests__/integration/uploadSessions.routes.test.ts
@@ -5,6 +5,9 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 const mocks = vi.hoisted(() => ({
   rpc: vi.fn(),
   getSignedUploadUrl: vi.fn(),
+  ensureDocAccess: vi.fn(),
+  /** The row the `documents` read answers with. */
+  documentRow: { data: null as unknown, error: null as unknown },
 }));
 
 vi.mock("../../middleware/auth", () => ({
@@ -20,7 +23,28 @@ vi.mock("../../middleware/auth", () => ({
 }));
 
 vi.mock("../../lib/supabase", () => ({
-  createServerSupabase: () => ({ rpc: mocks.rpc }),
+  createServerSupabase: () => ({
+    rpc: mocks.rpc,
+    // Enough of a builder for the destination checks: they read one row and
+    // then hand the verdict to lib/access.
+    from: () => {
+      const query: Record<string, unknown> = {};
+      for (const method of ["select", "eq", "in", "is", "order", "limit"])
+        query[method] = () => query;
+      query.maybeSingle = async () => mocks.documentRow;
+      query.single = query.maybeSingle;
+      query.then = (resolve: (value: unknown) => unknown) =>
+        Promise.resolve({ data: [], error: null }).then(resolve);
+      return query;
+    },
+  }),
+}));
+
+// Only the verdict is stubbed. creatorScopedAllowed and `can` stay real,
+// because the rule under test is how those two combine.
+vi.mock("../../lib/access", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../lib/access")>()),
+  ensureDocAccess: (...args: unknown[]) => mocks.ensureDocAccess(...args),
 }));
 
 vi.mock("../../lib/storage", () => ({
@@ -164,5 +188,128 @@ describe("upload session routes", () => {
 
     expect(response.status).toBe(404);
     expect(mocks.rpc).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// validateDestinationAccess — the version-upload destination.
+//
+// This branch collapsed "you cannot see this document" and "you may see it
+// but not write to it" into the same 404, so a Viewer who tried to add a
+// version was told their document had disappeared — while it went on
+// rendering in the list behind the dialog. The project branch above already
+// splits the two; this one now does too.
+// ---------------------------------------------------------------------------
+
+const DOCUMENT_ID = "33333333-3333-4333-8333-333333333333";
+const VERSION_ID = "44444444-4444-4444-8444-444444444444";
+
+function versionManifest(
+  purpose: "document_version_create" | "document_version_replace",
+) {
+  return {
+    purpose,
+    destination:
+      purpose === "document_version_replace"
+        ? { document_id: DOCUMENT_ID, version_id: VERSION_ID }
+        : { document_id: DOCUMENT_ID },
+    files: [
+      {
+        client_id: "client-0",
+        filename: "contract.pdf",
+        size_bytes: 1234,
+      },
+    ],
+  };
+}
+
+describe("upload session destination access", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.rpc.mockResolvedValue({ error: null });
+    mocks.getSignedUploadUrl.mockResolvedValue("https://upload.example/signed");
+    mocks.documentRow = {
+      data: {
+        id: DOCUMENT_ID,
+        // A colleague's document in a shared matter.
+        user_id: "22222222-2222-4222-8222-222222222222",
+        project_id: "p1",
+        org_id: "o1",
+        workflow_id: null,
+      },
+      error: null,
+    };
+  });
+
+  it("refuses a viewer by name instead of hiding the document", async () => {
+    mocks.ensureDocAccess.mockResolvedValue({
+      ok: true,
+      isCreator: false,
+      orgRole: "member",
+      projectRole: "viewer",
+    });
+
+    const response = await request(app)
+      .post("/upload-sessions")
+      .send(versionManifest("document_version_create"));
+
+    expect(response.status).toBe(403);
+    expect(response.body.detail).toBe(
+      "You do not have permission to edit content in this project.",
+    );
+    // No session was reserved and no upload URL was minted.
+    expect(mocks.rpc).not.toHaveBeenCalled();
+    expect(mocks.getSignedUploadUrl).not.toHaveBeenCalled();
+  });
+
+  it("keeps 404 for a caller with no verdict at all", async () => {
+    // A non-member must not be able to tell an existing document from a
+    // missing one, so this half of the split stays a 404.
+    mocks.ensureDocAccess.mockResolvedValue({ ok: false });
+
+    const response = await request(app)
+      .post("/upload-sessions")
+      .send(versionManifest("document_version_create"));
+
+    expect(response.status).toBe(404);
+    expect(response.body.detail).toBe("Document not found");
+    expect(mocks.rpc).not.toHaveBeenCalled();
+  });
+
+  it("names the narrower rule when an editor may write but not replace", async () => {
+    // Replacing a version is creator-scoped; editing content is not. Two
+    // different refusals, so they say two different things.
+    mocks.ensureDocAccess.mockResolvedValue({
+      ok: true,
+      isCreator: false,
+      orgRole: "member",
+      projectRole: "editor",
+    });
+
+    const response = await request(app)
+      .post("/upload-sessions")
+      .send(versionManifest("document_version_replace"));
+
+    expect(response.status).toBe(403);
+    expect(response.body.detail).toBe(
+      "You do not have permission to replace this version.",
+    );
+    expect(mocks.rpc).not.toHaveBeenCalled();
+  });
+
+  it("lets an editor open a version-create session", async () => {
+    mocks.ensureDocAccess.mockResolvedValue({
+      ok: true,
+      isCreator: false,
+      orgRole: "member",
+      projectRole: "editor",
+    });
+
+    const response = await request(app)
+      .post("/upload-sessions")
+      .send(versionManifest("document_version_create"));
+
+    expect(response.status).toBe(201);
+    expect(mocks.rpc).toHaveBeenCalledOnce();
   });
 });

--- a/backend/src/__tests__/integration/user.routes.test.ts
+++ b/backend/src/__tests__/integration/user.routes.test.ts
@@ -20,6 +20,7 @@ const {
     deleteAllUserTabularReviews,
     deleteUserAccountData,
     deleteUserProjects,
+    listOrgsBlockingAccountDeletion,
     buildUserAccountExport,
     buildUserChatsExport,
     buildUserTabularReviewsExport,
@@ -37,6 +38,7 @@ const {
     deleteAllUserTabularReviews: vi.fn(),
     deleteUserAccountData: vi.fn(),
     deleteUserProjects: vi.fn(),
+    listOrgsBlockingAccountDeletion: vi.fn(),
     buildUserAccountExport: vi.fn(),
     buildUserChatsExport: vi.fn(),
     buildUserTabularReviewsExport: vi.fn(),
@@ -200,6 +202,8 @@ vi.mock("../../lib/userDataCleanup", () => ({
     deleteUserAccountData: (...args: unknown[]) =>
         deleteUserAccountData(...args),
     deleteUserProjects: (...args: unknown[]) => deleteUserProjects(...args),
+    listOrgsBlockingAccountDeletion: (...args: unknown[]) =>
+        listOrgsBlockingAccountDeletion(...args),
 }));
 
 vi.mock("../../lib/userDataExport", () => ({
@@ -279,6 +283,7 @@ describe("user.routes", () => {
         deleteAllUserTabularReviews.mockResolvedValue(undefined);
         deleteUserAccountData.mockResolvedValue(undefined);
         deleteUserProjects.mockResolvedValue(undefined);
+        listOrgsBlockingAccountDeletion.mockResolvedValue([]);
         buildUserAccountExport.mockResolvedValue({ account: "data" });
         buildUserChatsExport.mockResolvedValue({ chats: "data" });
         buildUserTabularReviewsExport.mockResolvedValue({ reviews: "data" });
@@ -1071,6 +1076,54 @@ describe("user.routes", () => {
             // Sessions are revoked immediately all the same: the account is
             // unusable from the moment this returns.
             expect(adminSignOut).toHaveBeenCalledWith("test-token", "global");
+        });
+
+        // SOLE-ADMIN REFUSAL. Deleting this account would either hand the
+        // organization to an arbitrary successor or strand it with no members
+        // at all, so the product refuses and names the organizations.
+        it("DELETE /user/account returns 409 for the sole admin of a live org", async () => {
+            listOrgsBlockingAccountDeletion.mockResolvedValue([
+                { org_id: "o1", name: "Org A", reason: "members" },
+                { org_id: "o2", name: "Org B", reason: "content" },
+            ]);
+
+            const res = await request(app)
+                .delete("/user/account")
+                .set(...AUTH);
+
+            expect(res.status).toBe(409);
+            expect(res.body.code).toBe("org_successor_required");
+            expect(res.body.detail).toBe(
+                "You are the only admin of Org A, Org B. Make another member an admin, or delete the organization, before deleting your account.",
+            );
+            expect(res.body.organizations).toEqual([
+                { org_id: "o1", name: "Org A", reason: "members" },
+                { org_id: "o2", name: "Org B", reason: "content" },
+            ]);
+            // Nothing was scheduled, nothing was revoked, nothing was
+            // destroyed — the user is still signed in and can appoint an
+            // admin. The old behaviour answered 204, revoked the session and
+            // then failed the job forever.
+            expect(supabaseState.inserts.db_jobs ?? []).toHaveLength(0);
+            expect(adminSignOut).not.toHaveBeenCalled();
+            expect(deleteUserAccountData).not.toHaveBeenCalled();
+        });
+
+        it("DELETE /user/account refuses the inline path for a sole admin too", async () => {
+            // The no-runner fallback runs the cascade synchronously, so the
+            // check must gate it as well.
+            dbJobsEnabled.mockReturnValue(false);
+            listOrgsBlockingAccountDeletion.mockResolvedValue([
+                { org_id: "o1", name: "Org A", reason: "members" },
+            ]);
+
+            const res = await request(app)
+                .delete("/user/account")
+                .set(...AUTH);
+
+            expect(res.status).toBe(409);
+            expect(deleteUserAccountData).not.toHaveBeenCalled();
+            expect(adminDeleteUser).not.toHaveBeenCalled();
         });
 
         it("DELETE /user/account runs inline when no runner will drain the queue", async () => {

--- a/backend/src/__tests__/integration/user.routes.test.ts
+++ b/backend/src/__tests__/integration/user.routes.test.ts
@@ -1094,7 +1094,7 @@ describe("user.routes", () => {
             expect(res.status).toBe(409);
             expect(res.body.code).toBe("org_successor_required");
             expect(res.body.detail).toBe(
-                "You are the only admin of Org A, Org B. Make another member an admin, or delete the organization, before deleting your account.",
+                "You are the only admin of Org A. Make another member an admin, or delete the organization, before deleting your account. You are the only admin of Org B, which still owns content. Delete or move the organization's projects, workflows, documents and reviews, or delete the organization, before deleting your account.",
             );
             expect(res.body.organizations).toEqual([
                 { org_id: "o1", name: "Org A", reason: "members" },

--- a/backend/src/__tests__/integration/workflows.routes.test.ts
+++ b/backend/src/__tests__/integration/workflows.routes.test.ts
@@ -628,6 +628,134 @@ describe("workflows.routes", () => {
 
       expect(res.status).toBe(204);
     });
+
+    // Revoking used to fire the delete and ignore its result: a failed
+    // delete and an unknown share id both answered 204, so the client
+    // dropped the row from the list while the person kept access.
+    describe("DELETE /workflows/:workflowId/shares/:shareId", () => {
+      beforeEach(() => {
+        supabaseState.tables.workflows = {
+          data: { id: "w-personal", user_id: "u1", org_id: null },
+          error: null,
+        };
+      });
+
+      it("returns 204 when a row was actually removed", async () => {
+        supabaseState.tables.workflow_shares = {
+          data: [{ id: "s1" }],
+          error: null,
+        };
+
+        const res = await request(app)
+          .delete("/workflows/w-personal/shares/s1")
+          .set(...AUTH);
+
+        expect(res.status).toBe(204);
+      });
+
+      it("returns 404 when the share id matched nothing", async () => {
+        supabaseState.tables.workflow_shares = { data: [], error: null };
+
+        const res = await request(app)
+          .delete("/workflows/w-personal/shares/s-unknown")
+          .set(...AUTH);
+
+        expect(res.status).toBe(404);
+        expect(res.body.detail).toBe("Access grant not found");
+      });
+
+      it("reports a failed delete instead of a false 204", async () => {
+        supabaseState.tables.workflow_shares = {
+          data: null,
+          error: { message: "boom" },
+        };
+
+        const res = await request(app)
+          .delete("/workflows/w-personal/shares/s1")
+          .set(...AUTH);
+
+        expect(res.status).toBe(500);
+        expect(res.body.detail).toBe("Something went wrong. Please try again.");
+      });
+    });
+
+    // A rejected batch must leave nothing behind: the loop used to validate
+    // and write one email at a time, so a bad third address returned 400
+    // with the first two overrides already persisted.
+    it("writes no org override when a later email in the batch is invalid", async () => {
+      supabaseState.tables.workflows = {
+        data: { id: "w-org", user_id: "u1", org_id: "org-1" },
+        error: null,
+      };
+      const upserts: unknown[] = [];
+      vi.mocked(createServerSupabase).mockImplementationOnce(() => {
+        const build = (
+          resolve: (filters: Record<string, unknown>) => unknown,
+        ) => {
+          const filters: Record<string, unknown> = {};
+          const b: Record<string, unknown> = {};
+          for (const method of ["select", "order", "limit", "in", "is"])
+            b[method] = () => b;
+          b.eq = (column: string, value: unknown) => {
+            filters[column] = value;
+            return b;
+          };
+          b.upsert = (payload: unknown) => {
+            upserts.push(payload);
+            return b;
+          };
+          b.single = () => Promise.resolve({ data: resolve(filters), error: null });
+          b.maybeSingle = b.single;
+          b.then = (onResolve: (v: unknown) => unknown) =>
+            Promise.resolve({ data: resolve(filters), error: null }).then(
+              onResolve,
+            );
+          return b;
+        };
+        return {
+          from: (table: string) => {
+            if (table === "workflows")
+              return build(() => ({
+                id: "w-org",
+                user_id: "u1",
+                org_id: "org-1",
+              }));
+            if (table === "user_profiles")
+              return build((filters) => {
+                const email = String(filters.email ?? "");
+                return email
+                  ? { user_id: `u-${email.split("@")[0]}`, email }
+                  : null;
+              });
+            if (table === "org_members")
+              return build((filters) =>
+                // The third address belongs to a real user who is not in
+                // this organization.
+                filters.user_id === "u-third"
+                  ? null
+                  : { user_id: filters.user_id, role: "member" },
+              );
+            return build(() => null);
+          },
+          rpc: () => Promise.resolve({ data: null, error: null }),
+          auth: {
+            getUser: () =>
+              Promise.resolve({ data: { user: { id: "u1" } }, error: null }),
+          },
+        } as unknown as ReturnType<typeof createServerSupabase>;
+      });
+
+      const res = await request(app)
+        .post("/workflows/w-org/share")
+        .set(...AUTH)
+        .send({
+          emails: ["first@firm.test", "second@firm.test", "third@firm.test"],
+          role: "viewer",
+        });
+
+      expect(res.status).toBe(400);
+      expect(upserts).toEqual([]);
+    });
   });
 
   describe("organization workflow Owner operations", () => {

--- a/backend/src/__tests__/integration/workflows.routes.test.ts
+++ b/backend/src/__tests__/integration/workflows.routes.test.ts
@@ -129,6 +129,7 @@ vi.mock("../../lib/documentVersions", () => ({
 }));
 
 import { app } from "../../app";
+import { ensureDocAccess } from "../../lib/access";
 import { createServerSupabase } from "../../lib/supabase";
 import { resetEnsuredDefaultUsersForTests } from "../../lib/workflowCatalog";
 
@@ -679,82 +680,161 @@ describe("workflows.routes", () => {
       });
     });
 
-    // A rejected batch must leave nothing behind: the loop used to validate
-    // and write one email at a time, so a bad third address returned 400
-    // with the first two overrides already persisted.
-    it("writes no org override when a later email in the batch is invalid", async () => {
+    // ── organization overrides are written as ONE statement ─────────────
+    // The loop used to validate and write one email at a time, so a bad
+    // third address returned 400 with the first two overrides already
+    // persisted: the caller read "nothing happened" while access had
+    // silently changed for two people. Validation now completes first, and
+    // the write is a single bulk upsert so a trigger refusal rolls the whole
+    // batch back rather than stopping half way.
+    function orgShareDb(options: { upsertError?: string } = {}) {
+      const upserts: { payload: unknown; options: unknown }[] = [];
+      const build = (resolve: (filters: Record<string, unknown>) => unknown) => {
+        const filters: Record<string, unknown> = {};
+        const b: Record<string, unknown> = {};
+        for (const method of ["select", "order", "limit", "in", "is"])
+          b[method] = () => b;
+        b.eq = (column: string, value: unknown) => {
+          filters[column] = value;
+          return b;
+        };
+        b.upsert = (payload: unknown, upsertOptions?: unknown) => {
+          upserts.push({ payload, options: upsertOptions });
+          return b;
+        };
+        const settle = () => ({
+          data: resolve(filters),
+          error:
+            upserts.length && options.upsertError
+              ? { message: options.upsertError }
+              : null,
+        });
+        b.single = () => Promise.resolve(settle());
+        b.maybeSingle = b.single;
+        b.then = (onResolve: (v: unknown) => unknown) =>
+          Promise.resolve(settle()).then(onResolve);
+        return b;
+      };
+      const db = {
+        from: (table: string) => {
+          if (table === "workflows")
+            return build(() => ({
+              id: "w-org",
+              user_id: "u1",
+              org_id: "org-1",
+            }));
+          if (table === "user_profiles")
+            return build((filters) => {
+              const email = String(filters.email ?? "");
+              return email
+                ? { user_id: `u-${email.split("@")[0]}`, email }
+                : null;
+            });
+          if (table === "org_members")
+            return build((filters) =>
+              // The third address belongs to a real user who is not in this
+              // organization.
+              filters.user_id === "u-third"
+                ? null
+                : { user_id: filters.user_id, role: "member" },
+            );
+          return build(() => null);
+        },
+        rpc: () => Promise.resolve({ data: null, error: null }),
+        auth: {
+          getUser: () =>
+            Promise.resolve({ data: { user: { id: "u1" } }, error: null }),
+        },
+      } as unknown as ReturnType<typeof createServerSupabase>;
+      return { db, upserts };
+    }
+
+    function shareOrgWorkflow(emails: string[]) {
       supabaseState.tables.workflows = {
         data: { id: "w-org", user_id: "u1", org_id: "org-1" },
         error: null,
       };
-      const upserts: unknown[] = [];
-      vi.mocked(createServerSupabase).mockImplementationOnce(() => {
-        const build = (
-          resolve: (filters: Record<string, unknown>) => unknown,
-        ) => {
-          const filters: Record<string, unknown> = {};
-          const b: Record<string, unknown> = {};
-          for (const method of ["select", "order", "limit", "in", "is"])
-            b[method] = () => b;
-          b.eq = (column: string, value: unknown) => {
-            filters[column] = value;
-            return b;
-          };
-          b.upsert = (payload: unknown) => {
-            upserts.push(payload);
-            return b;
-          };
-          b.single = () => Promise.resolve({ data: resolve(filters), error: null });
-          b.maybeSingle = b.single;
-          b.then = (onResolve: (v: unknown) => unknown) =>
-            Promise.resolve({ data: resolve(filters), error: null }).then(
-              onResolve,
-            );
-          return b;
-        };
-        return {
-          from: (table: string) => {
-            if (table === "workflows")
-              return build(() => ({
-                id: "w-org",
-                user_id: "u1",
-                org_id: "org-1",
-              }));
-            if (table === "user_profiles")
-              return build((filters) => {
-                const email = String(filters.email ?? "");
-                return email
-                  ? { user_id: `u-${email.split("@")[0]}`, email }
-                  : null;
-              });
-            if (table === "org_members")
-              return build((filters) =>
-                // The third address belongs to a real user who is not in
-                // this organization.
-                filters.user_id === "u-third"
-                  ? null
-                  : { user_id: filters.user_id, role: "member" },
-              );
-            return build(() => null);
-          },
-          rpc: () => Promise.resolve({ data: null, error: null }),
-          auth: {
-            getUser: () =>
-              Promise.resolve({ data: { user: { id: "u1" } }, error: null }),
-          },
-        } as unknown as ReturnType<typeof createServerSupabase>;
-      });
-
-      const res = await request(app)
+      return request(app)
         .post("/workflows/w-org/share")
         .set(...AUTH)
-        .send({
-          emails: ["first@firm.test", "second@firm.test", "third@firm.test"],
-          role: "viewer",
-        });
+        .send({ emails, role: "viewer" });
+    }
 
-      expect(res.status).toBe(400);
-      expect(upserts).toEqual([]);
+    it("writes no org override when a later email in the batch is invalid", async () => {
+      const { db, upserts } = orgShareDb();
+      vi.mocked(createServerSupabase).mockImplementationOnce(() => db);
+
+      const res = await shareOrgWorkflow([
+        "first@firm.test",
+        "second@firm.test",
+        "third@firm.test",
+      ]);
+
+      // SOFT, both of them: "nothing was written" is the claim that matters,
+      // and a plain assertion on the status would abandon the run before it
+      // was ever checked — so a regression that wrote the first two rows AND
+      // changed the status code would have been reported as a status bug.
+      expect.soft(res.status).toBe(400);
+      expect.soft(upserts).toEqual([]);
+    });
+
+    it("writes the whole batch in exactly one upsert", async () => {
+      // One statement, so a trigger refusal on any row rolls back the rest.
+      // Three separate upserts would be three separate transactions.
+      const { db, upserts } = orgShareDb();
+      vi.mocked(createServerSupabase).mockImplementationOnce(() => db);
+
+      const res = await shareOrgWorkflow([
+        "first@firm.test",
+        "second@firm.test",
+      ]);
+
+      expect(res.status).toBe(204);
+      expect(upserts).toHaveLength(1);
+      expect(upserts[0].payload).toEqual([
+        expect.objectContaining({
+          workflow_id: "w-org",
+          org_id: "org-1",
+          user_id: "u-first",
+          role: "viewer",
+          assigned_by: "u1",
+        }),
+        expect.objectContaining({
+          workflow_id: "w-org",
+          org_id: "org-1",
+          user_id: "u-second",
+          role: "viewer",
+          assigned_by: "u1",
+        }),
+      ]);
+      // Upsert, not insert: re-sharing with somebody who already has an
+      // override must change their role rather than fail on the key.
+      expect(upserts[0].options).toEqual({
+        onConflict: "workflow_id,user_id",
+      });
+    });
+
+    it("answers 500 and writes nothing when the bulk upsert is refused", async () => {
+      // The org-membership triggers can still refuse a row after validation
+      // passed. That is a database failure, not a bad request, and the whole
+      // statement rolls back.
+      const { db, upserts } = orgShareDb({
+        upsertError: "org_members_protect_last_admin",
+      });
+      vi.mocked(createServerSupabase).mockImplementationOnce(() => db);
+
+      const res = await shareOrgWorkflow([
+        "first@firm.test",
+        "second@firm.test",
+      ]);
+
+      expect.soft(res.status).toBe(500);
+      expect.soft(res.body.detail).toBe(
+        "Something went wrong. Please try again.",
+      );
+      // One attempt, all-or-nothing — not two rows written and a third
+      // refused.
+      expect.soft(upserts).toHaveLength(1);
     });
   });
 
@@ -853,6 +933,118 @@ describe("workflows.routes", () => {
         .set(...AUTH);
 
       expect(res.status).toBe(404);
+    });
+  });
+  // ── POST /workflows/:workflowId/assets/from-documents ─────────────────
+  // ensureDocAccess resolves a document through its project, then its
+  // workflow, then its ORG. A row selected without org_id therefore looks
+  // container-less and is refused — so every organization-library file was
+  // unattachable, answering "One or more files could not be found" for a
+  // file the caller is looking straight at.
+  describe("POST /workflows/:workflowId/assets/from-documents", () => {
+    const DOC_ID = "55555555-5555-4555-8555-555555555555";
+
+    /**
+     * PROJECTS the row to the columns the caller selected, which is what
+     * makes a missing column in the select string observable at all. The
+     * shared stub hands back whole rows regardless of `.select()`, so under
+     * it this bug is invisible.
+     */
+    function projectingDb(row: Record<string, unknown>) {
+      const selects: Record<string, string> = {};
+      const build = (table: string, resolve: () => unknown) => {
+        let columns = "*";
+        const b: Record<string, unknown> = {};
+        for (const method of ["eq", "in", "is", "order", "limit"])
+          b[method] = () => b;
+        b.select = (value?: string) => {
+          columns = value ?? "*";
+          selects[table] = columns;
+          return b;
+        };
+        const project = (value: unknown) => {
+          if (columns === "*" || !value || typeof value !== "object")
+            return value;
+          const wanted = columns.split(",").map((column) => column.trim());
+          return Object.fromEntries(
+            Object.entries(value as Record<string, unknown>).filter(
+              ([column]) => wanted.includes(column),
+            ),
+          );
+        };
+        const settle = () => {
+          const value = resolve();
+          return {
+            data: Array.isArray(value) ? value.map(project) : project(value),
+            error: null,
+          };
+        };
+        b.single = () => Promise.resolve(settle());
+        b.maybeSingle = b.single;
+        b.then = (onResolve: (v: unknown) => unknown) =>
+          Promise.resolve(settle()).then(onResolve);
+        return b;
+      };
+      const db = {
+        from: (table: string) => {
+          if (table === "workflows")
+            return build(table, () => ({
+              id: "w-org",
+              user_id: "u1",
+              org_id: "org-1",
+              type: "assistant",
+            }));
+          if (table === "documents") return build(table, () => [row]);
+          return build(table, () => []);
+        },
+        rpc: () => Promise.resolve({ data: null, error: null }),
+        auth: {
+          getUser: () =>
+            Promise.resolve({ data: { user: { id: "u1" } }, error: null }),
+        },
+      } as unknown as ReturnType<typeof createServerSupabase>;
+      return { db, selects };
+    }
+
+    it("selects org_id, so an org-library file attaches", async () => {
+      supabaseState.tables.workflows = {
+        data: { id: "w-org", user_id: "u1", org_id: "org-1", type: "assistant" },
+        error: null,
+      };
+      // Mirrors the real fall-through: a row with no project, no workflow and
+      // no org has no container to grant access, so it is refused.
+      vi.mocked(ensureDocAccess).mockImplementation(
+        async (document: unknown) => ({
+          ok: Boolean(
+            (document as Record<string, unknown>).project_id ??
+              (document as Record<string, unknown>).workflow_id ??
+              (document as Record<string, unknown>).org_id,
+          ),
+        }),
+      );
+      const { db, selects } = projectingDb({
+        id: DOC_ID,
+        user_id: "u2",
+        project_id: null,
+        workflow_id: null,
+        // Filed straight in the organization's library.
+        org_id: "org-1",
+        current_version_id: null,
+      });
+      vi.mocked(createServerSupabase).mockImplementationOnce(() => db);
+
+      const res = await request(app)
+        .post("/workflows/w-org/assets/from-documents")
+        .set(...AUTH)
+        .send({ document_ids: [DOC_ID] });
+
+      // Past the access gate. (409 because the fixture has no ready version,
+      // which is a later guard entirely — the point is that it is no longer
+      // "could not be found".)
+      expect(res.status).toBe(409);
+      expect(res.body.detail).toBe("One or more files are not ready");
+      expect(selects.documents).toContain("org_id");
+      expect(selects.documents).toContain("workflow_id");
     });
   });
 });

--- a/backend/src/lib/__tests__/access.test.ts
+++ b/backend/src/lib/__tests__/access.test.ts
@@ -31,6 +31,12 @@ function makeDb(
                     rows = rows.slice(0, n);
                     return query;
                 },
+                // Paged reads: `.range(from, to)` is inclusive at both ends,
+                // and returning a short page is what stops the caller's loop.
+                range: (from: number, to: number) => {
+                    rows = rows.slice(from, to + 1);
+                    return query;
+                },
                 eq: (column: string, value: unknown) => {
                     rows = rows.filter((row) => row[column] === value);
                     return query;
@@ -826,5 +832,188 @@ describe("ensureChatAccess", () => {
                 db,
             ),
         ).resolves.toEqual({ ok: false });
+    });
+});
+
+// ---------------------------------------------------------------------------
+// listAccessibleProjectIds — completeness and cost
+//
+// This helper scopes chat lists and similar collection reads, so a project it
+// silently omits is a project the caller cannot find at all. The previous
+// shape had two faults that only appear at a real firm's size: an unpaged
+// `.in("org_id", …)` that PostgREST truncates at its db-max-rows cap, and a
+// per-row `checkProjectAccess` fan-out of two or three round trips EACH.
+// ---------------------------------------------------------------------------
+
+/**
+ * Wraps the fake above so every query it is handed is recorded — which table,
+ * which filters, and every `.range()` page. Counting queries is the only way
+ * to state "one batched read, not one per project" as an assertion.
+ */
+function makeRecordingDb(tables: Record<string, Row[]>) {
+    const queries: {
+        table: string;
+        filters: string[];
+        ranges: [number, number][];
+    }[] = [];
+    const base = makeDb(tables);
+    const db = {
+        from(table: string) {
+            const record = {
+                table,
+                filters: [] as string[],
+                ranges: [] as [number, number][],
+            };
+            queries.push(record);
+            const inner = base.from(table);
+            const proxy: unknown = new Proxy(inner, {
+                get(target, prop, receiver) {
+                    const value = Reflect.get(target, prop, receiver);
+                    if (typeof value !== "function") return value;
+                    return (...args: unknown[]) => {
+                        if (prop === "range")
+                            record.ranges.push([
+                                args[0] as number,
+                                args[1] as number,
+                            ]);
+                        if (prop === "eq" || prop === "in" || prop === "is")
+                            record.filters.push(`${String(prop)}:${args[0]}`);
+                        const out = (value as (...a: unknown[]) => unknown).apply(
+                            target,
+                            args,
+                        );
+                        return out === target ? proxy : out;
+                    };
+                },
+            });
+            return proxy;
+        },
+    } as any;
+    return { db, queries };
+}
+
+describe("listAccessibleProjectIds", () => {
+    const orgProjects = (count: number) =>
+        Array.from({ length: count }, (_, index) => ({
+            id: `p${String(index).padStart(4, "0")}`,
+            user_id: "founder",
+            org_id: "org-1",
+        }));
+
+    it("pages through an org with more projects than one read returns", async () => {
+        // 1500 matters, a 1000-row page. The unpaged read came back with the
+        // first 1000 and no error, so the remaining 500 simply were not there
+        // — and nothing in the response said so.
+        const { db, queries } = makeRecordingDb({
+            org_members: [{ org_id: "org-1", user_id: "u1", role: "member" }],
+            projects: orgProjects(1500),
+            project_access_grants: [],
+            project_org_access_overrides: [],
+        });
+
+        const ids = await listAccessibleProjectIds("u1", "u1@example.com", db);
+
+        expect(ids).toHaveLength(1500);
+        expect(ids).toContain("p1499");
+        // Each page is its own query, so collect the ranges across them.
+        const orgReads = queries.filter(
+            (query) =>
+                query.table === "projects" &&
+                query.filters.includes("in:org_id"),
+        );
+        // Two pages: a full one, then a short one that ends the loop.
+        expect(orgReads.flatMap((query) => query.ranges)).toEqual([
+            [0, 999],
+            [1000, 1999],
+        ]);
+    });
+
+    it("reads the deny overrides once for the whole org, not once per project", async () => {
+        const { db, queries } = makeRecordingDb({
+            org_members: [{ org_id: "org-1", user_id: "u1", role: "member" }],
+            projects: orgProjects(40),
+            project_access_grants: [],
+            project_org_access_overrides: [],
+        });
+
+        await listAccessibleProjectIds("u1", "u1@example.com", db);
+
+        const overrideReads = queries.filter(
+            (query) => query.table === "project_org_access_overrides",
+        );
+        // One. The fan-out issued forty, plus a project row read and an
+        // org-role read apiece.
+        expect(overrideReads).toHaveLength(1);
+        // Scoped by ORG, not by an `.in()` over every candidate project id —
+        // that list is spliced into the PostgREST query string and grows with
+        // the firm's matters until the request line is refused.
+        expect(overrideReads[0].filters).toEqual([
+            "in:org_id",
+            "eq:user_id",
+            "eq:role",
+        ]);
+    });
+
+    it("hides a denied org project but keeps the creator's and the admin's", async () => {
+        // The two exemptions checkProjectAccess applies, re-derived inline:
+        // the creator and an org admin keep Owner and cannot be denied. Get
+        // this wrong in the batched shape and a partner loses their own
+        // matter to a deny row somebody else's role should never have.
+        const tables = {
+            org_members: [
+                { org_id: "org-1", user_id: "member", role: "member" },
+                { org_id: "org-1", user_id: "boss", role: "admin" },
+                { org_id: "org-1", user_id: "author", role: "member" },
+            ],
+            projects: [
+                { id: "walled", user_id: "author", org_id: "org-1" },
+                { id: "open", user_id: "author", org_id: "org-1" },
+            ],
+            project_access_grants: [],
+            project_org_access_overrides: [
+                {
+                    project_id: "walled",
+                    org_id: "org-1",
+                    user_id: "member",
+                    role: "deny",
+                },
+                {
+                    project_id: "walled",
+                    org_id: "org-1",
+                    user_id: "boss",
+                    role: "deny",
+                },
+                {
+                    project_id: "walled",
+                    org_id: "org-1",
+                    user_id: "author",
+                    role: "deny",
+                },
+            ],
+        };
+
+        await expect(
+            listAccessibleProjectIds(
+                "member",
+                "member@example.com",
+                makeRecordingDb(tables).db,
+            ),
+        ).resolves.toEqual(["open"]);
+        // An org admin cannot be denied.
+        await expect(
+            listAccessibleProjectIds(
+                "boss",
+                "boss@example.com",
+                makeRecordingDb(tables).db,
+            ),
+        ).resolves.toEqual(["walled", "open"]);
+        // Neither can the project's own creator.
+        await expect(
+            listAccessibleProjectIds(
+                "author",
+                "author@example.com",
+                makeRecordingDb(tables).db,
+            ),
+        ).resolves.toEqual(["walled", "open"]);
     });
 });

--- a/backend/src/lib/__tests__/auditExport.test.ts
+++ b/backend/src/lib/__tests__/auditExport.test.ts
@@ -15,6 +15,12 @@ function makeDb(events: Record<string, unknown>[], error?: { message: string }) 
             select: () => b,
             or: () => b,
             eq: () => b,
+            // The project scope resolves through lib/access now, which also
+            // composes .is()/.in() and .maybeSingle(). Every table still
+            // answers "no rows", so the caller sees no accessible projects.
+            is: () => b,
+            in: () => b,
+            maybeSingle: () => Promise.resolve({ data: null, error: null }),
             ilike: () => b,
             gte: () => b,
             lte: () => b,
@@ -103,6 +109,10 @@ function makeProfileDb(
             select: () => b,
             or: () => b,
             eq: () => b,
+            // See makeDb: the project scope's .is() chain runs first and
+            // finds nothing, so only the profile lookup below matters here.
+            is: () => b,
+            maybeSingle: () => Promise.resolve({ data: null, error: null }),
             ilike: () => b,
             gte: () => b,
             lte: () => b,

--- a/backend/src/lib/__tests__/auditExport.test.ts
+++ b/backend/src/lib/__tests__/auditExport.test.ts
@@ -80,7 +80,10 @@ describe("buildAuditCsv", () => {
     it("always reads page 1 — the export is one flat window", async () => {
         const { db, ranges } = makeDb([]);
         await buildAuditCsv(db, "u1", undefined, { ...query, page: 7 });
-        expect(ranges).toEqual([[0, AUDIT_EXPORT_LIMIT - 1]]);
+        // The accessible-project scan pages from 0 as well; what matters is
+        // that the EVENTS read is one flat window and nothing starts later.
+        expect(ranges).toContainEqual([0, AUDIT_EXPORT_LIMIT - 1]);
+        expect(ranges.every(([from]) => from === 0)).toBe(true);
     });
 
     it("throws on a query error so the export job retries", async () => {
@@ -118,7 +121,10 @@ function makeProfileDb(
             lte: () => b,
             contains: () => b,
             order: () => b,
-            in: () => {
+            in: (column: string) => {
+                // Only the profile lookup filters on user_id; every other
+                // `.in()` (project ids for the events read) keeps chaining.
+                if (column !== "user_id") return b;
                 profilesQueried = true;
                 return Promise.resolve({ data: profiles, error: null });
             },

--- a/backend/src/lib/__tests__/userDataCleanup.orgs.test.ts
+++ b/backend/src/lib/__tests__/userDataCleanup.orgs.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
     deleteUserOrganizations,
     deleteUserProjects,
+    listOrgsBlockingAccountDeletion,
 } from "../userDataCleanup";
 
 type Row = Record<string, unknown>;
@@ -150,6 +151,10 @@ function makeDb(
                 filters.push({ type: "in", col, vals });
                 return builder;
             },
+            maybeSingle: async () => {
+                const { data, error } = await resolveMany();
+                return { data: data?.[0] ?? null, error };
+            },
             then: (
                 resolve: (v: {
                     data: Row[] | null;
@@ -165,7 +170,14 @@ function makeDb(
 }
 
 describe("deleteUserOrganizations", () => {
-    it("hands administration to the earliest remaining member", async () => {
+    it("refuses rather than promoting an heir when members remain", async () => {
+        // The old behaviour promoted "the earliest remaining member": a firm's
+        // administration handed to whoever joined first, with no audit row and
+        // no consent — and cleanup_org_admin_access_overrides then deleted the
+        // new admin's `deny` overrides, so a person deliberately walled off
+        // from a matter became its owner because somebody else closed their
+        // account. The route refuses with a 409 long before this runs; this
+        // throw is the defense-in-depth copy on the durable job path.
         const db = makeDb({
             organizations: [{ id: "shared1", name: "Acme" }],
             org_members: [
@@ -193,13 +205,15 @@ describe("deleteUserOrganizations", () => {
             ],
         });
 
-        await deleteUserOrganizations(db, "u1");
+        await expect(deleteUserOrganizations(db, "u1")).rejects.toThrow(
+            /only admin of organization shared1/,
+        );
 
-        // The org survives its only admin's departure, with a successor.
+        // Nothing moved: no promotion, no departure, no deletion.
         expect(db._tables.organizations).toHaveLength(1);
         const members = db._tables.org_members as Row[];
-        expect(members.map((m) => m.user_id)).toEqual(["u2", "u3"]);
-        expect(members.find((m) => m.user_id === "u2")?.role).toBe("admin");
+        expect(members.map((m) => m.user_id)).toEqual(["u1", "u2", "u3"]);
+        expect(members.find((m) => m.user_id === "u2")?.role).toBe("member");
     });
 
     it("leaves a co-admin's org untouched", async () => {
@@ -245,18 +259,39 @@ describe("deleteUserOrganizations", () => {
             projects: [],
             workflows: [{ id: "w1", org_id: "o1", user_id: null }],
         });
-        await deleteUserOrganizations(db, "u1");
+        await expect(deleteUserOrganizations(db, "u1")).rejects.toThrow(
+            /only admin of organization o1/,
+        );
         expect(db._tables.organizations).toHaveLength(1);
         expect(db._tables.workflows).toEqual([
             { id: "w1", org_id: "o1", user_id: null },
         ]);
     });
 
-    it("keeps an org that still holds the firm's projects", async () => {
-        // Deleting it would SET NULL the org_id on those projects and strand
-        // the content this whole model exists to protect. The departing
-        // membership row is deliberately NOT deleted here — see the trigger
-        // test below.
+    it("counts an org's chats as content", async () => {
+        // The account-deletion probe used to omit `chats`, so an org whose
+        // last remaining content was a chat looked empty and was deleted —
+        // while deleteOrg refused the identical delete over the API. Both now
+        // read ORG_CONTENT_TABLES.
+        const db = makeDb({
+            organizations: [{ id: "o1", name: "Acme" }],
+            org_members: [
+                { id: "m1", org_id: "o1", user_id: "u1", role: "admin", created_at: 1 },
+            ],
+            projects: [],
+            documents: [],
+            chats: [{ id: "c1", org_id: "o1", user_id: null }],
+        });
+        await expect(deleteUserOrganizations(db, "u1")).rejects.toThrow(
+            /only admin of organization o1/,
+        );
+        expect(db._tables.organizations).toHaveLength(1);
+    });
+
+    it("refuses when the org still holds the firm's projects", async () => {
+        // The org cannot be deleted (its content FKs are ON DELETE RESTRICT)
+        // and the sole admin cannot leave it memberless, so the only honest
+        // answer is to refuse the account deletion.
         const db = makeDb({
             organizations: [{ id: "o1", name: "Acme" }],
             org_members: [
@@ -264,19 +299,21 @@ describe("deleteUserOrganizations", () => {
             ],
             projects: [{ id: "p1", org_id: "o1", user_id: "u1" }],
         });
-        await deleteUserOrganizations(db, "u1");
+        await expect(deleteUserOrganizations(db, "u1")).rejects.toThrow(
+            /only admin of organization o1/,
+        );
         expect(db._tables.organizations).toHaveLength(1);
         expect(db._tables.projects).toHaveLength(1);
     });
 
-    it("leaves the last admin's membership for the auth.users cascade", async () => {
-        // The half-finished-deletion bug. There is no heir and the org keeps
-        // its projects, so nothing can satisfy org_members_protect_last_admin
-        // at this moment: the organizations row is present and the member's
-        // auth.users row is present (the auth user is deleted only AFTER this
-        // cleanup returns). An explicit delete here raises SQLSTATE 23514, and
-        // account deletion 500s with storage already swept and personal rows
-        // already gone.
+    it("does not leave the last admin's membership for a cascade that never comes", async () => {
+        // The half-finished-deletion bug, and the reason the product now
+        // refuses. Leaving the row for auth.users to cascade produced a
+        // memberless organization in theory; in practice the cascade never
+        // ran — org_member_protect_resource_ownership refuses to remove a
+        // member who still owns the org's projects — so the durable job
+        // failed forever while the user, sessions revoked and sent to the
+        // login page, could log straight back in.
         const db = makeDb(
             {
                 organizations: [{ id: "o1", name: "Acme" }],
@@ -295,9 +332,9 @@ describe("deleteUserOrganizations", () => {
             { lastAdminTrigger: true },
         );
 
-        await expect(deleteUserOrganizations(db, "u1")).resolves.toBeUndefined();
-        // Untouched here; the FK (on delete cascade from auth.users) removes
-        // it moments later, and the trigger stands aside for that cascade.
+        await expect(deleteUserOrganizations(db, "u1")).rejects.toThrow(
+            /only admin of organization o1/,
+        );
         expect(db._tables.org_members).toHaveLength(1);
         expect(db._tables.organizations).toHaveLength(1);
         expect(db._tables.projects).toHaveLength(1);
@@ -368,6 +405,123 @@ describe("deleteUserOrganizations", () => {
         const invites = db._tables.org_invitations as Row[];
         expect(invites.find((i) => i.id === "i1")?.status).toBe("cancelled");
         expect(invites.find((i) => i.id === "i2")?.status).toBe("pending");
+    });
+});
+
+describe("listOrgsBlockingAccountDeletion", () => {
+    it("blocks a sole admin whose org still has members", async () => {
+        const db = makeDb({
+            organizations: [{ id: "o1", name: "Acme LLP" }],
+            org_members: [
+                { id: "m1", org_id: "o1", user_id: "u1", role: "admin", created_at: 1 },
+                { id: "m2", org_id: "o1", user_id: "u2", role: "member", created_at: 2 },
+            ],
+        });
+        await expect(
+            listOrgsBlockingAccountDeletion(db, "u1"),
+        ).resolves.toEqual([
+            { org_id: "o1", name: "Acme LLP", reason: "members" },
+        ]);
+    });
+
+    it("blocks a sole admin whose empty org still owns content", async () => {
+        // Nobody is left to promote, and the org cannot be deleted either:
+        // its content foreign keys are ON DELETE RESTRICT.
+        const db = makeDb({
+            organizations: [{ id: "o1", name: "Solo LLP" }],
+            org_members: [
+                { id: "m1", org_id: "o1", user_id: "u1", role: "admin", created_at: 1 },
+            ],
+            projects: [{ id: "p1", org_id: "o1", user_id: "u1" }],
+        });
+        await expect(
+            listOrgsBlockingAccountDeletion(db, "u1"),
+        ).resolves.toEqual([
+            { org_id: "o1", name: "Solo LLP", reason: "content" },
+        ]);
+    });
+
+    it("does not block an empty org with no other members", async () => {
+        // deleteUserOrganizations deletes this one outright, so the account
+        // deletion may proceed.
+        const db = makeDb({
+            organizations: [{ id: "o1", name: "Empty" }],
+            org_members: [
+                { id: "m1", org_id: "o1", user_id: "u1", role: "admin", created_at: 1 },
+            ],
+            projects: [],
+        });
+        await expect(listOrgsBlockingAccountDeletion(db, "u1")).resolves.toEqual(
+            [],
+        );
+    });
+
+    it("does not block when another admin can take over", async () => {
+        const db = makeDb({
+            organizations: [{ id: "o1", name: "Acme" }],
+            org_members: [
+                { id: "m1", org_id: "o1", user_id: "u1", role: "admin", created_at: 1 },
+                { id: "m2", org_id: "o1", user_id: "u2", role: "admin", created_at: 2 },
+            ],
+            projects: [{ id: "p1", org_id: "o1", user_id: "u1" }],
+        });
+        await expect(listOrgsBlockingAccountDeletion(db, "u1")).resolves.toEqual(
+            [],
+        );
+    });
+
+    it("does not block a plain member of somebody else's org", async () => {
+        const db = makeDb({
+            organizations: [{ id: "o1", name: "Acme" }],
+            org_members: [
+                { id: "m1", org_id: "o1", user_id: "u1", role: "member", created_at: 1 },
+                { id: "m2", org_id: "o1", user_id: "u2", role: "admin", created_at: 2 },
+            ],
+            projects: [{ id: "p1", org_id: "o1", user_id: "u1" }],
+        });
+        await expect(listOrgsBlockingAccountDeletion(db, "u1")).resolves.toEqual(
+            [],
+        );
+    });
+
+    it("reports every blocking org, not just the first", async () => {
+        const db = makeDb({
+            organizations: [
+                { id: "o1", name: "Org A" },
+                { id: "o2", name: "Org B" },
+            ],
+            org_members: [
+                { id: "m1", org_id: "o1", user_id: "u1", role: "admin", created_at: 1 },
+                { id: "m2", org_id: "o1", user_id: "u2", role: "member", created_at: 2 },
+                { id: "m3", org_id: "o2", user_id: "u1", role: "admin", created_at: 3 },
+            ],
+            chats: [{ id: "c1", org_id: "o2" }],
+        });
+        await expect(
+            listOrgsBlockingAccountDeletion(db, "u1"),
+        ).resolves.toEqual([
+            { org_id: "o1", name: "Org A", reason: "members" },
+            { org_id: "o2", name: "Org B", reason: "content" },
+        ]);
+    });
+
+    it("refuses to answer 'not blocking' because a lookup failed", async () => {
+        // "The database did not answer" must never read as "this org holds
+        // nothing" — that is the difference between refusing an account
+        // deletion and quietly deleting a firm's tenant.
+        const db = makeDb(
+            {
+                organizations: [{ id: "o1", name: "Acme" }],
+                org_members: [
+                    { id: "m1", org_id: "o1", user_id: "u1", role: "admin", created_at: 1 },
+                ],
+                projects: [{ id: "p1", org_id: "o1", user_id: "u1" }],
+            },
+            { selectErrors: { projects: "connection reset" } },
+        );
+        await expect(listOrgsBlockingAccountDeletion(db, "u1")).rejects.toThrow(
+            /Failed to load org projects/,
+        );
     });
 });
 

--- a/backend/src/lib/__tests__/userDataCleanup.orgs.test.ts
+++ b/backend/src/lib/__tests__/userDataCleanup.orgs.test.ts
@@ -1,12 +1,71 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
+// deleteUserAccountData reaches storage on its way through the cascade. The
+// refusal test below asserts it never gets there, so these have to be
+// observable no-ops rather than real calls.
+vi.mock("../storage", () => ({
+    deleteFile: vi.fn(async () => {}),
+    listFiles: vi.fn(async () => [] as string[]),
+    extractedTextKey: (versionId: string) => `extracted-text/${versionId}.txt`,
+}));
+
+import { deleteFile, listFiles } from "../storage";
+import { NonRetryableJobError } from "../dbq/runner";
 import {
+    deleteUserAccountData,
     deleteUserOrganizations,
     deleteUserProjects,
     listOrgsBlockingAccountDeletion,
 } from "../userDataCleanup";
 
 type Row = Record<string, unknown>;
+
+/**
+ * Await a rejection and hand back the error itself, so one call can be
+ * asserted on twice — its CLASS (which decides whether the queue retries it)
+ * and its message. `rejects.toThrow` would have to run the cleanup twice to
+ * check both.
+ */
+async function rejection(promise: PromiseLike<unknown>): Promise<unknown> {
+    return Promise.resolve(promise).then(
+        () => {
+            throw new Error("expected a rejection, but the call resolved");
+        },
+        (error: unknown) => error,
+    );
+}
+
+/**
+ * Wraps a db fake so every write it is asked to perform is recorded. Used to
+ * prove a refusal happened BEFORE anything was destroyed, which a surviving
+ * row count cannot: a delete that matched nothing leaves the same table
+ * behind as a delete that was never issued.
+ */
+function recordWrites(db: any) {
+    const writes: string[] = [];
+    const from = db.from.bind(db);
+    return {
+        db: {
+            ...db,
+            from(table: string) {
+                const builder: any = from(table);
+                return new Proxy(builder, {
+                    get(target, prop, receiver) {
+                        if (
+                            prop === "delete" ||
+                            prop === "update" ||
+                            prop === "insert" ||
+                            prop === "upsert"
+                        )
+                            writes.push(`${String(prop)} ${table}`);
+                        return Reflect.get(target, prop, receiver);
+                    },
+                });
+            },
+        } as any,
+        writes,
+    };
+}
 
 // Stateful fake with a minimal simulation of the ON DELETE CASCADE from
 // org_members → organizations, so deleting an org also drops its membership
@@ -205,9 +264,12 @@ describe("deleteUserOrganizations", () => {
             ],
         });
 
-        await expect(deleteUserOrganizations(db, "u1")).rejects.toThrow(
-            /only admin of organization shared1/,
-        );
+        const error = await rejection(deleteUserOrganizations(db, "u1"));
+        // NonRetryableJobError, not Error: no number of retries gives an
+        // organization a second admin, and a plain Error burned the whole
+        // retry budget re-deriving the same refusal.
+        expect(error).toBeInstanceOf(NonRetryableJobError);
+        expect((error as Error).message).toMatch(/only admin of organization shared1/);
 
         // Nothing moved: no promotion, no departure, no deletion.
         expect(db._tables.organizations).toHaveLength(1);
@@ -259,9 +321,12 @@ describe("deleteUserOrganizations", () => {
             projects: [],
             workflows: [{ id: "w1", org_id: "o1", user_id: null }],
         });
-        await expect(deleteUserOrganizations(db, "u1")).rejects.toThrow(
-            /only admin of organization o1/,
-        );
+        const error = await rejection(deleteUserOrganizations(db, "u1"));
+        // NonRetryableJobError, not Error: no number of retries gives an
+        // organization a second admin, and a plain Error burned the whole
+        // retry budget re-deriving the same refusal.
+        expect(error).toBeInstanceOf(NonRetryableJobError);
+        expect((error as Error).message).toMatch(/only admin of organization o1/);
         expect(db._tables.organizations).toHaveLength(1);
         expect(db._tables.workflows).toEqual([
             { id: "w1", org_id: "o1", user_id: null },
@@ -282,9 +347,12 @@ describe("deleteUserOrganizations", () => {
             documents: [],
             chats: [{ id: "c1", org_id: "o1", user_id: null }],
         });
-        await expect(deleteUserOrganizations(db, "u1")).rejects.toThrow(
-            /only admin of organization o1/,
-        );
+        const error = await rejection(deleteUserOrganizations(db, "u1"));
+        // NonRetryableJobError, not Error: no number of retries gives an
+        // organization a second admin, and a plain Error burned the whole
+        // retry budget re-deriving the same refusal.
+        expect(error).toBeInstanceOf(NonRetryableJobError);
+        expect((error as Error).message).toMatch(/only admin of organization o1/);
         expect(db._tables.organizations).toHaveLength(1);
     });
 
@@ -299,9 +367,12 @@ describe("deleteUserOrganizations", () => {
             ],
             projects: [{ id: "p1", org_id: "o1", user_id: "u1" }],
         });
-        await expect(deleteUserOrganizations(db, "u1")).rejects.toThrow(
-            /only admin of organization o1/,
-        );
+        const error = await rejection(deleteUserOrganizations(db, "u1"));
+        // NonRetryableJobError, not Error: no number of retries gives an
+        // organization a second admin, and a plain Error burned the whole
+        // retry budget re-deriving the same refusal.
+        expect(error).toBeInstanceOf(NonRetryableJobError);
+        expect((error as Error).message).toMatch(/only admin of organization o1/);
         expect(db._tables.organizations).toHaveLength(1);
         expect(db._tables.projects).toHaveLength(1);
     });
@@ -332,9 +403,12 @@ describe("deleteUserOrganizations", () => {
             { lastAdminTrigger: true },
         );
 
-        await expect(deleteUserOrganizations(db, "u1")).rejects.toThrow(
-            /only admin of organization o1/,
-        );
+        const error = await rejection(deleteUserOrganizations(db, "u1"));
+        // NonRetryableJobError, not Error: no number of retries gives an
+        // organization a second admin, and a plain Error burned the whole
+        // retry budget re-deriving the same refusal.
+        expect(error).toBeInstanceOf(NonRetryableJobError);
+        expect((error as Error).message).toMatch(/only admin of organization o1/);
         expect(db._tables.org_members).toHaveLength(1);
         expect(db._tables.organizations).toHaveLength(1);
         expect(db._tables.projects).toHaveLength(1);
@@ -565,5 +639,66 @@ describe("deleteUserProjects and organization ownership", () => {
         const projects = db._tables.projects as Row[];
         expect(projects).toHaveLength(2);
         expect(projects.find((p) => p.id === "firm")?.user_id).toBeNull();
+    });
+});
+
+describe("deleteUserAccountData refuses before it destroys", () => {
+    it("throws NonRetryableJobError without issuing a single write", async () => {
+        // THE ORDERING BUG. The sole-admin question used to be asked by
+        // deleteUserOrganizations, at the very END of the cascade — so the
+        // refusal was real, but it arrived after the account's projects,
+        // documents, storage objects and audit rows had already been
+        // destroyed, and the failed job could never put them back. Asking
+        // first costs nothing; asking last cost everything the check was
+        // meant to protect.
+        vi.mocked(deleteFile).mockClear();
+        vi.mocked(listFiles).mockClear();
+        const { db, writes } = recordWrites(
+            makeDb({
+                organizations: [{ id: "o1", name: "Acme LLP" }],
+                org_members: [
+                    {
+                        id: "m1",
+                        org_id: "o1",
+                        user_id: "u1",
+                        role: "admin",
+                        created_at: 1,
+                    },
+                    {
+                        id: "m2",
+                        org_id: "o1",
+                        user_id: "u2",
+                        role: "member",
+                        created_at: 2,
+                    },
+                ],
+                projects: [
+                    { id: "personal", user_id: "u1", org_id: null },
+                    { id: "firm", user_id: "u1", org_id: "o1" },
+                ],
+                documents: [{ id: "d1", project_id: "personal" }],
+                chats: [],
+                tabular_reviews: [],
+                audit_events: [{ id: "a1", user_id: "u1" }],
+            }),
+        );
+
+        const error = await rejection(
+            deleteUserAccountData(db, "u1", "u1@example.com"),
+        );
+
+        // Non-retryable: the org does not acquire a second admin because the
+        // queue asks twenty more times over the next few hours.
+        expect(error).toBeInstanceOf(NonRetryableJobError);
+        expect((error as Error).message).toMatch(/only admin of o1 \(members\)/);
+        // Nothing was written — not a delete, not the org-project detach.
+        expect(writes).toEqual([]);
+        // ...and nothing was removed from storage either.
+        expect(deleteFile).not.toHaveBeenCalled();
+        expect(listFiles).not.toHaveBeenCalled();
+        // The rows are all still there, which is the point of asking first.
+        expect(db._tables.projects).toHaveLength(2);
+        expect(db._tables.documents).toHaveLength(1);
+        expect(db._tables.audit_events).toHaveLength(1);
     });
 });

--- a/backend/src/lib/access.ts
+++ b/backend/src/lib/access.ts
@@ -368,6 +368,13 @@ export async function checkWorkflowAccess(
         };
     const email = normalizeEmail(userEmail);
     if (!email) return { ok: false };
+    // An exact match is correct because BOTH sides are canonical:
+    // normalizeEmail trims and lowercases the caller's address, and
+    // workflow_shares.shared_with_email carries a lowercase CHECK (added by
+    // migration 20260904_02, which also folded the legacy mixed-case rows).
+    // Before that constraint a mixed-case row listed for its recipient via
+    // get_workflows_overview — which lowers both sides — and then missed
+    // here, so the workflow 404'd the moment they opened it.
     const { data: share, error } = await db
         .from("workflow_shares")
         .select("role")

--- a/backend/src/lib/access.ts
+++ b/backend/src/lib/access.ts
@@ -578,10 +578,42 @@ export async function filterAccessibleDocumentIds(
     return verdicts.filter((entry) => entry.access.ok).map((entry) => entry.id);
 }
 
+const ACCESSIBLE_PROJECTS_PAGE_SIZE = 1000;
+/** Guards a runaway loop, not a product limit. */
+const ACCESSIBLE_PROJECTS_MAX_PAGES = 200;
+
+async function pageProjectRows<T>(
+    fetchPage: (from: number, to: number) => PromiseLike<{ data: T[] | null }>,
+): Promise<T[]> {
+    const rows: T[] = [];
+    for (let page = 0; page < ACCESSIBLE_PROJECTS_MAX_PAGES; page += 1) {
+        const from = page * ACCESSIBLE_PROJECTS_PAGE_SIZE;
+        const { data } = await fetchPage(
+            from,
+            from + ACCESSIBLE_PROJECTS_PAGE_SIZE - 1,
+        );
+        const batch = (data ?? []) as T[];
+        rows.push(...batch);
+        if (batch.length < ACCESSIBLE_PROJECTS_PAGE_SIZE) break;
+    }
+    return rows;
+}
+
 /**
  * Returns the set of project IDs the user can access — projects they created,
  * any project they hold an access grant on, and any project in an org they
  * belong to. Used to scope chat lists and similar collection queries.
+ *
+ * Written as THREE bounded, paged reads plus ONE batched override read, and
+ * deliberately not as `checkProjectAccess` per row. The previous shape issued
+ * an unordered, unpaged `.in("org_id", …)` — silently truncated by PostgREST's
+ * db-max-rows, so a large firm's audit trail simply lost the projects past the
+ * cap — and then fanned out one verdict per org project, each of which is
+ * itself two or three round trips. A firm with a few hundred matters paid
+ * ~1000 sequential queries for one chat-list request. Paging by `id` (the
+ * primary key, so the order is total and stable across pages) makes the reads
+ * complete; re-deriving the org verdict inline from the same rules
+ * checkProjectAccess applies makes them cheap.
  */
 export async function listAccessibleProjectIds(
     userId: string,
@@ -589,59 +621,116 @@ export async function listAccessibleProjectIds(
     db: Db,
 ): Promise<string[]> {
     const normalizedEmail = normalizeEmail(userEmail);
-    const orgIds = await listUserOrgIds(userId, db);
-    const [{ data: personalOwned }, { data: grants }, { data: orgProjects }] =
+
+    // Roles, not just ids: an org ADMIN cannot be denied a project, which is
+    // one of the two exemptions the override filter below has to honour.
+    const { data: membershipRows } = await db
+        .from("org_members")
+        .select("org_id, role")
+        .eq("user_id", userId);
+    const orgRoleByOrgId = new Map<string, string>();
+    for (const row of (membershipRows ?? []) as {
+        org_id?: string | null;
+        role?: string | null;
+    }[]) {
+        if (row.org_id) orgRoleByOrgId.set(row.org_id, row.role ?? "");
+    }
+    const orgIds = [...orgRoleByOrgId.keys()];
+
+    const { data: grants } = normalizedEmail
+        ? await db
+              .from("project_access_grants")
+              .select("project_id")
+              .eq("email", normalizedEmail)
+        : { data: [] as { project_id?: string | null }[] };
+    const grantIds = [
+        ...new Set(
+            ((grants ?? []) as { project_id?: string | null }[])
+                .map((grant) => grant.project_id)
+                .filter((id): id is string => !!id),
+        ),
+    ];
+
+    const [personalOwned, personalGranted, orgProjects, denials] =
         await Promise.all([
-            db
-                .from("projects")
-                .select("id")
-                .eq("user_id", userId)
-                .is("org_id", null),
-            normalizedEmail
-                ? db
-                      .from("project_access_grants")
-                      .select("project_id")
-                      .eq("email", normalizedEmail)
-                : Promise.resolve({ data: [] as { project_id: string }[] }),
-            orgIds.length > 0
-                ? db
-                      .from("projects")
-                      .select("id, user_id, org_id")
-                      .in("org_id", orgIds)
-                : Promise.resolve({
-                      data: [] as {
+            // Personal projects the caller created. Their ORG projects are
+            // resolved by the org branch instead, because a creator who has
+            // left the org no longer has access to them — exactly what
+            // checkProjectAccess answers.
+            pageProjectRows<{ id: string }>((from, to) =>
+                db
+                    .from("projects")
+                    .select("id")
+                    .eq("user_id", userId)
+                    .is("org_id", null)
+                    .order("id", { ascending: true })
+                    .range(from, to),
+            ),
+            grantIds.length
+                ? pageProjectRows<{ id: string }>((from, to) =>
+                      db
+                          .from("projects")
+                          .select("id")
+                          .in("id", grantIds)
+                          .is("org_id", null)
+                          .order("id", { ascending: true })
+                          .range(from, to),
+                  )
+                : Promise.resolve([] as { id: string }[]),
+            orgIds.length
+                ? pageProjectRows<{
+                      id: string;
+                      user_id: string | null;
+                      org_id: string;
+                  }>((from, to) =>
+                      db
+                          .from("projects")
+                          .select("id, user_id, org_id")
+                          .in("org_id", orgIds)
+                          .order("id", { ascending: true })
+                          .range(from, to),
+                  )
+                : Promise.resolve(
+                      [] as {
                           id: string;
                           user_id: string | null;
                           org_id: string;
                       }[],
+                  ),
+            // One read for every deny this caller holds anywhere in their
+            // orgs, instead of one verdict per project. Scoped by org_id so
+            // the filter is bounded by membership rather than by a list of
+            // every candidate project id.
+            orgIds.length
+                ? db
+                      .from("project_org_access_overrides")
+                      .select("project_id")
+                      .in("org_id", orgIds)
+                      .eq("user_id", userId)
+                      .eq("role", "deny")
+                : Promise.resolve({
+                      data: [] as { project_id?: string | null }[],
+                      error: null,
                   }),
         ]);
 
-    const grantIds = (grants ?? [])
-        .map((grant: { project_id?: string | null }) => grant.project_id)
-        .filter((id): id is string => !!id);
-    const { data: personalGranted } = grantIds.length
-        ? await db
-              .from("projects")
-              .select("id")
-              .in("id", grantIds)
-              .is("org_id", null)
-        : { data: [] as { id: string }[] };
-
-    const verdicts = await Promise.all(
-        ((orgProjects ?? []) as {
-            id: string;
-            user_id: string | null;
-            org_id: string;
-        }[]).map((project) =>
-            checkProjectAccess(project.id, userId, userEmail, db),
-        ),
+    const deniedProjectIds = new Set(
+        ((denials.data ?? []) as { project_id?: string | null }[])
+            .map((row) => row.project_id)
+            .filter((id): id is string => !!id),
     );
+
     const ids = new Set<string>();
-    for (const p of (personalOwned ?? []) as { id: string }[]) ids.add(p.id);
-    for (const p of (personalGranted ?? []) as { id: string }[]) ids.add(p.id);
-    for (let i = 0; i < verdicts.length; i += 1) {
-        if (verdicts[i]?.ok) ids.add(orgProjects?.[i]?.id as string);
+    for (const project of personalOwned) ids.add(project.id);
+    for (const project of personalGranted) ids.add(project.id);
+    for (const project of orgProjects) {
+        // The two exemptions checkProjectAccess applies: the creator and an
+        // org admin always keep Owner and cannot be denied.
+        const isCreator = !!project.user_id && project.user_id === userId;
+        const isOrgAdmin = orgRoleByOrgId.get(project.org_id) === "admin";
+        if (!isCreator && !isOrgAdmin && deniedProjectIds.has(project.id))
+            continue;
+        ids.add(project.id);
     }
     return [...ids];
 }

--- a/backend/src/lib/auditExport.ts
+++ b/backend/src/lib/auditExport.ts
@@ -6,6 +6,7 @@
 // router would drag in the whole HTTP surface.
 
 import type { createServerSupabase } from "./supabase";
+import { listAccessibleProjectIds } from "./access";
 import { normalizeDisplayName } from "./userLookup";
 
 type Db = ReturnType<typeof createServerSupabase>;
@@ -21,31 +22,20 @@ const DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
 /**
  * Which projects' audit rows this user may read.
  *
- * Direct project sharing is resolved from project_access_grants, the same
- * source used by the project access checks.
+ * Delegated to lib/access so the audit trail sees exactly what every other
+ * read path sees: creator, direct grant, organization membership, minus any
+ * per-project deny override. The local query this replaced knew only the
+ * first two, and organization projects carry no grants by construction — so
+ * an org admin's audit history was empty for their own firm's matters, and a
+ * project detached by account deletion (projects.user_id → NULL) dropped out
+ * of the audit trail permanently.
  */
 export async function accessibleProjectIds(
     db: Db,
     userId: string,
     email: string | undefined,
 ): Promise<string[]> {
-    const ids = new Set<string>();
-    const own = await db.from("projects").select("id").eq("user_id", userId);
-    for (const row of (own.data ?? []) as { id: string }[]) ids.add(row.id);
-    if (email) {
-        // Direct sharing is `project_access_grants`: one row per recipient,
-        // keyed on normalized email. This query gates access to an audit trail.
-        const shared = await db
-            .from("project_access_grants")
-            .select("project_id")
-            .eq("email", email.trim().toLowerCase());
-        for (const row of (shared.data ?? []) as {
-            project_id: string | null;
-        }[]) {
-            if (row.project_id) ids.add(row.project_id);
-        }
-    }
-    return [...ids];
+    return listAccessibleProjectIds(userId, email ?? null, db);
 }
 
 export type AuditQuery = {

--- a/backend/src/lib/auditExport.ts
+++ b/backend/src/lib/auditExport.ts
@@ -123,6 +123,86 @@ export function parseQuery(
     };
 }
 
+/**
+ * How many accessible project ids go into ONE PostgREST filter.
+ *
+ * The scope used to be a single `or=(user_id.eq.<id>,project_id.in.(<every
+ * accessible project id>))`, spliced into the query STRING. Each uuid costs
+ * 37 characters, so a few hundred matters pushed the request line past the
+ * proxy/PostgREST limit and the audit page answered 500 — and it degraded
+ * with the size of the firm, which is exactly the deployment that needs the
+ * audit trail most.
+ */
+const PROJECT_FILTER_CHUNK = 200;
+
+/**
+ * Deepest page the chunked read will assemble in memory.
+ *
+ * Chunking means the database can no longer apply one OFFSET for the whole
+ * result set: each chunk is ordered independently and the pages are merged
+ * here, so serving offset N costs N rows per chunk. `page` is already clamped
+ * to MAX_PAGE, which at 50 rows a page would be 5,000,000 rows — so bound the
+ * merge window too. Beyond it the page is empty; `total` is still exact, and
+ * the answer to "I need row 10,001" is a narrower filter or the CSV export.
+ */
+const MERGE_WINDOW_ROWS = 10_000;
+
+const AUDIT_EVENT_COLUMNS =
+    "id, created_at, user_id, user_email, action, status, title, surface, project_id, chat_id, document_id, review_id, model, detail";
+
+type AuditRow = Record<string, unknown>;
+
+type EventsResult = {
+    data: AuditRow[] | null;
+    error: { message: string } | null;
+    count?: number | null;
+};
+
+/**
+ * The slice of the PostgREST builder this query uses. Spelled out rather than
+ * inferred: the generated Supabase types recurse through every filter method,
+ * and threading them through a helper that applies six of them in a loop
+ * makes the checker give up ("type instantiation is excessively deep").
+ */
+type EventsQuery = {
+    eq(column: string, value: unknown): EventsQuery;
+    in(column: string, values: unknown[]): EventsQuery;
+    or(filter: string): EventsQuery;
+    ilike(column: string, pattern: string): EventsQuery;
+    gte(column: string, value: unknown): EventsQuery;
+    lte(column: string, value: unknown): EventsQuery;
+    order(
+        column: string,
+        options: { ascending: boolean; nullsFirst: boolean },
+    ): EventsQuery;
+    range(from: number, to: number): PromiseLike<EventsResult>;
+};
+
+function chunk<T>(values: T[], size: number): T[][] {
+    const out: T[][] = [];
+    for (let i = 0; i < values.length; i += size) out.push(values.slice(i, i + size));
+    return out;
+}
+
+/** Order two rows the way the database was asked to order them. */
+function compareRows(a: AuditRow, b: AuditRow, q: AuditQuery): number {
+    const left = a[q.sortBy];
+    const right = b[q.sortBy];
+    // nullsFirst: false — a missing value sorts last in BOTH directions,
+    // which is what PostgREST was told and what Postgres then does.
+    const leftMissing = left === null || left === undefined;
+    const rightMissing = right === null || right === undefined;
+    if (leftMissing || rightMissing) {
+        if (leftMissing && rightMissing) return String(a.id).localeCompare(String(b.id));
+        return leftMissing ? 1 : -1;
+    }
+    const direction = q.sortDirection === "asc" ? 1 : -1;
+    if (left < right) return -1 * direction;
+    if (left > right) return 1 * direction;
+    // Stable tie-break so the same row never appears on two pages.
+    return String(a.id).localeCompare(String(b.id));
+}
+
 export async function queryEvents(
     db: Db,
     userId: string,
@@ -131,29 +211,70 @@ export async function queryEvents(
     resolveDisplayNames = true,
 ) {
     const projectIds = await accessibleProjectIds(db, userId, email);
-    let query = db
-        .from("audit_events")
-        .select(
-            "id, created_at, user_id, user_email, action, status, title, surface, project_id, chat_id, document_id, review_id, model, detail",
-            { count: "exact" },
-        );
-    query = projectIds.length
-        ? query.or(
-              `user_id.eq.${userId},project_id.in.(${projectIds.join(",")})`,
-          )
-        : query.eq("user_id", userId);
-    if (q.action) query = query.eq("action", q.action);
-    if (q.status) query = query.eq("status", q.status);
-    if (q.surface) query = query.eq("surface", q.surface);
-    if (q.q) query = query.ilike("title", `%${escapeLikePattern(q.q)}%`);
-    if (q.from) query = query.gte("created_at", q.from);
-    if (q.to) query = query.lte("created_at", `${q.to}T23:59:59.999Z`);
-    const result = await query
-        .order(q.sortBy, {
+
+    const applyFilters = (query: EventsQuery): EventsQuery => {
+        let next = query;
+        if (q.action) next = next.eq("action", q.action);
+        if (q.status) next = next.eq("status", q.status);
+        if (q.surface) next = next.eq("surface", q.surface);
+        if (q.q) next = next.ilike("title", `%${escapeLikePattern(q.q)}%`);
+        if (q.from) next = next.gte("created_at", q.from);
+        if (q.to) next = next.lte("created_at", `${q.to}T23:59:59.999Z`);
+        return next.order(q.sortBy, {
             ascending: q.sortDirection === "asc",
             nullsFirst: false,
-        })
-        .range((q.page - 1) * q.limit, q.page * q.limit - 1);
+        });
+    };
+
+    const base = () =>
+        db
+            .from("audit_events")
+            .select(AUDIT_EVENT_COLUMNS, {
+                count: "exact",
+            }) as unknown as EventsQuery;
+
+    const offset = (q.page - 1) * q.limit;
+    let result: EventsResult;
+
+    if (projectIds.length === 0) {
+        result = await applyFilters(base().eq("user_id", userId)).range(
+            offset,
+            offset + q.limit - 1,
+        );
+    } else {
+        // The caller's OWN events and the events of projects they can reach
+        // are read as separate queries and merged here. Splitting on
+        // `user_id` keeps the two sides DISJOINT, which is what makes the
+        // exact counts summable and stops a row the caller wrote inside an
+        // accessible project appearing twice.
+        const window = Math.min(offset + q.limit, MERGE_WINDOW_ROWS);
+        const notTheCaller = `user_id.is.null,user_id.neq.${userId}`;
+        const responses: EventsResult[] = await Promise.all([
+            applyFilters(base().eq("user_id", userId)).range(0, window - 1),
+            ...chunk(projectIds, PROJECT_FILTER_CHUNK).map((ids) =>
+                applyFilters(
+                    base().in("project_id", ids).or(notTheCaller),
+                ).range(0, window - 1),
+            ),
+        ]);
+
+        const failed = responses.find((response) => response.error);
+        if (failed) return failed;
+
+        const merged = new Map<string, AuditRow>();
+        let count = 0;
+        for (const response of responses) {
+            count += response.count ?? 0;
+            for (const row of response.data ?? [])
+                merged.set(String(row.id), row);
+        }
+        const rows = [...merged.values()].sort((a, b) => compareRows(a, b, q));
+        result = {
+            data: rows.slice(offset, offset + q.limit),
+            error: null,
+            count,
+        };
+    }
 
     if (result.error || !result.data?.length) return result;
 
@@ -192,6 +313,7 @@ export async function queryEvents(
         }),
     };
 }
+
 
 export function csvCell(v: unknown): string {
     let s = v == null ? "" : String(v);

--- a/backend/src/lib/chat/contextBuilders.docAccess.test.ts
+++ b/backend/src/lib/chat/contextBuilders.docAccess.test.ts
@@ -1,0 +1,169 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// ---------------------------------------------------------------------------
+// buildDocContext — which attached documents the model may actually read.
+//
+// The builder used to filter with `.eq("user_id", userId)`: "I uploaded it"
+// stood in for "I may read it". So a colleague's document in a shared
+// organization matter, and any document whose uploader's account had been
+// deleted (documents.user_id → NULL), were dropped from the context — the
+// assistant claimed it could not see a file the caller has full access to.
+//
+// The verdict is now per document (ensureDocAccess), which must cut BOTH
+// ways: being mentioned in a chat the caller can read is not itself access.
+// ---------------------------------------------------------------------------
+
+vi.mock("../supabase", () => ({ createServerSupabase: vi.fn() }));
+vi.mock("../storage", () => ({ downloadFile: vi.fn() }));
+
+const ensureDocAccess = vi.fn(async (..._args: unknown[]) => ({ ok: true }));
+vi.mock("../access", () => ({
+  ensureDocAccess: (...args: unknown[]) => ensureDocAccess(...args),
+}));
+
+// Version enrichment is a separate concern; give every surviving doc a path
+// so the builder's "no bytes yet" skip never masks an access result.
+vi.mock("../documentVersions", () => ({
+  attachActiveVersionPaths: vi.fn(
+    async (_db: unknown, docs: Record<string, unknown>[]) => {
+      for (const doc of docs) {
+        doc.storage_path = `docs/${doc.id}.docx`;
+        doc.filename = `${doc.id}.docx`;
+        doc.file_type = "docx";
+      }
+      return docs;
+    },
+  ),
+}));
+
+import { buildDocContext } from "./contextBuilders";
+
+type Doc = {
+  id: string;
+  user_id: string | null;
+  project_id: string | null;
+  org_id?: string | null;
+  workflow_id?: string | null;
+  status?: string;
+};
+
+/**
+ * Honours the `.eq()` filters it is given, so a test fails if the builder
+ * goes back to scoping documents by uploader in SQL.
+ */
+function makeDb(docs: Doc[]) {
+  return {
+    from: () => {
+      const filters: Record<string, unknown> = {};
+      const b: Record<string, unknown> = {
+        select: () => b,
+        is: () => b,
+        order: () => b,
+        eq: (column: string, value: unknown) => {
+          filters[column] = value;
+          return b;
+        },
+        in: (column: string, value: unknown) => {
+          filters[`in:${column}`] = value;
+          return b;
+        },
+        then: (resolve: (v: unknown) => unknown) => {
+          const ids = (filters["in:id"] as string[] | undefined) ?? null;
+          const data = docs.filter(
+            (doc) =>
+              (!ids || ids.includes(doc.id)) &&
+              Object.entries(filters).every(
+                ([column, value]) =>
+                  column.startsWith("in:") ||
+                  (doc as Record<string, unknown>)[column] === value,
+              ),
+          );
+          return Promise.resolve({ data, error: null }).then(resolve);
+        },
+      };
+      return b;
+    },
+  } as never;
+}
+
+const message = (documentIds: string[]) => [
+  {
+    role: "user" as const,
+    content: "look at these",
+    files: documentIds.map((id) => ({ document_id: id })),
+  },
+] as never;
+
+describe("buildDocContext access scoping", () => {
+  beforeEach(() => {
+    ensureDocAccess.mockReset().mockResolvedValue({ ok: true });
+  });
+
+  it("includes documents the caller did not upload but may read", async () => {
+    const db = makeDb([
+      { id: "d-colleague", user_id: "u2", project_id: "p1", status: "ready" },
+      { id: "d-detached", user_id: null, project_id: "p1", status: "ready" },
+    ]);
+
+    const { docIndex } = await buildDocContext(
+      message(["d-colleague", "d-detached"]),
+      "u1",
+      db,
+      null,
+      "chat_messages",
+      "u1@test.local",
+    );
+
+    expect(
+      Object.values(docIndex).map((entry) => entry.document_id).sort(),
+    ).toEqual(["d-colleague", "d-detached"]);
+  });
+
+  it("drops a document the caller has no verdict for, however it was cited", async () => {
+    ensureDocAccess.mockImplementation(async (doc: unknown) => ({
+      ok: (doc as { id: string }).id === "d-mine",
+    }));
+    const db = makeDb([
+      { id: "d-mine", user_id: "u1", project_id: null, status: "ready" },
+      { id: "d-walled", user_id: "u2", project_id: "p-walled", status: "ready" },
+    ]);
+
+    const { docIndex, docStore } = await buildDocContext(
+      message(["d-mine", "d-walled"]),
+      "u1",
+      db,
+      null,
+      "chat_messages",
+      "u1@test.local",
+    );
+
+    expect(Object.values(docIndex).map((entry) => entry.document_id)).toEqual([
+      "d-mine",
+    ]);
+    expect([...docStore.values()].map((entry) => entry.storage_path)).toEqual([
+      "docs/d-mine.docx",
+    ]);
+  });
+
+  it("passes the caller's email so a direct grant still resolves", async () => {
+    const db = makeDb([
+      { id: "d1", user_id: "u2", project_id: "p1", status: "ready" },
+    ]);
+
+    await buildDocContext(
+      message(["d1"]),
+      "u1",
+      db,
+      null,
+      "chat_messages",
+      "u1@test.local",
+    );
+
+    expect(ensureDocAccess).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "d1" }),
+      "u1",
+      "u1@test.local",
+      db,
+    );
+  });
+});

--- a/backend/src/lib/chat/contextBuilders.docAccess.test.ts
+++ b/backend/src/lib/chat/contextBuilders.docAccess.test.ts
@@ -125,7 +125,10 @@ describe("buildDocContext access scoping", () => {
     }));
     const db = makeDb([
       { id: "d-mine", user_id: "u1", project_id: null, status: "ready" },
-      { id: "d-walled", user_id: "u2", project_id: "p-walled", status: "ready" },
+      // Uploaded by the CALLER, so nothing but the verdict can exclude it.
+      // With `user_id: "u2"` the old uploader-scoped filter dropped this row
+      // too, and the test passed whether or not the verdict was consulted.
+      { id: "d-walled", user_id: "u1", project_id: "p-walled", status: "ready" },
     ]);
 
     const { docIndex, docStore } = await buildDocContext(
@@ -165,5 +168,72 @@ describe("buildDocContext access scoping", () => {
       "u1@test.local",
       db,
     );
+  });
+
+  it("asks once per container, not once per document", async () => {
+    // ensureDocAccess resolves a document through its project, then its
+    // workflow, then its org — two or three round trips each. A turn citing
+    // five files from one matter used to pay for five identical project
+    // lookups before the model saw a byte. The container's answer does not
+    // depend on which document inside it was asked about.
+    const db = makeDb([
+      { id: "d1", user_id: "u1", project_id: "p1", status: "ready" },
+      { id: "d2", user_id: "u2", project_id: "p1", status: "ready" },
+      { id: "d3", user_id: null, project_id: "p1", status: "ready" },
+      { id: "d4", user_id: "u2", project_id: "p2", status: "ready" },
+      // No container at all: resolved individually, which is an in-memory
+      // `user_id === caller` comparison rather than a round trip.
+      { id: "d5", user_id: "u1", project_id: null, status: "ready" },
+    ]);
+
+    const { docIndex } = await buildDocContext(
+      message(["d1", "d2", "d3", "d4", "d5"]),
+      "u1",
+      db,
+      null,
+      "chat_messages",
+      "u1@test.local",
+    );
+
+    // Every document still reaches the model...
+    expect(
+      Object.values(docIndex)
+        .map((entry) => entry.document_id)
+        .sort(),
+    ).toEqual(["d1", "d2", "d3", "d4", "d5"]);
+    // ...on three verdicts: project p1, project p2, and the container-less
+    // d5. Five would mean the fan-out is back.
+    expect(ensureDocAccess).toHaveBeenCalledTimes(3);
+    const containers = ensureDocAccess.mock.calls.map(
+      (call) => (call[0] as { project_id: string | null }).project_id,
+    );
+    expect(containers.sort()).toEqual([null, "p1", "p2"]);
+  });
+
+  it("refuses a whole container once, without re-asking per document", async () => {
+    // The cache must cut both ways: a denied container denies every document
+    // in it, and still only costs one verdict.
+    ensureDocAccess.mockImplementation(async (doc: unknown) => ({
+      ok: (doc as { project_id: string | null }).project_id === "p-open",
+    }));
+    const db = makeDb([
+      { id: "d1", user_id: "u1", project_id: "p-open", status: "ready" },
+      { id: "d2", user_id: "u1", project_id: "p-walled", status: "ready" },
+      { id: "d3", user_id: "u1", project_id: "p-walled", status: "ready" },
+    ]);
+
+    const { docIndex } = await buildDocContext(
+      message(["d1", "d2", "d3"]),
+      "u1",
+      db,
+      null,
+      "chat_messages",
+      "u1@test.local",
+    );
+
+    expect(Object.values(docIndex).map((entry) => entry.document_id)).toEqual([
+      "d1",
+    ]);
+    expect(ensureDocAccess).toHaveBeenCalledTimes(2);
   });
 });

--- a/backend/src/lib/chat/contextBuilders.ts
+++ b/backend/src/lib/chat/contextBuilders.ts
@@ -1,5 +1,6 @@
 import crypto from "crypto";
 import { createServerSupabase } from "../supabase";
+import { ensureDocAccess } from "../access";
 import { attachActiveVersionPaths } from "../documentVersions";
 import {
   type DocStore,
@@ -550,6 +551,7 @@ export async function buildDocContext(
   db: ReturnType<typeof createServerSupabase>,
   chatId?: string | null,
   messageTable = "chat_messages",
+  userEmail?: string | null,
 ): Promise<{ docIndex: DocIndex; docStore: DocStore }> {
   const docIndex: DocIndex = {};
   const docStore: DocStore = new Map();
@@ -600,14 +602,22 @@ export async function buildDocContext(
 
   const ids = [...documentIds];
   if (ids.length > 0) {
+    // Uploading is not the same as being allowed to read: scoping this to
+    // `user_id = me` dropped every document the caller did not personally
+    // upload — a colleague's file in a shared org matter, or any document
+    // whose uploader's account was deleted (user_id → NULL) — so the model
+    // answered "I can't see that document" about a file the caller has full
+    // access to. The verdict is per document, not per chat: being cited in a
+    // readable chat never grants access to the cited file.
     const { data: docs } = await db
       .from("documents")
-      .select("id, current_version_id, status, library_kind")
+      .select(
+        "id, current_version_id, status, library_kind, user_id, project_id, org_id, workflow_id",
+      )
       .in("id", ids)
-      .eq("user_id", userId)
       .eq("status", "ready");
 
-    const docList = (docs ?? []) as unknown as {
+    const candidates = (docs ?? []) as unknown as {
       id: string;
       filename?: string | null;
       file_type?: string | null;
@@ -615,7 +625,17 @@ export async function buildDocContext(
       active_version_number?: number | null;
       storage_path?: string | null;
       library_kind?: string | null;
+      user_id: string | null;
+      project_id: string | null;
+      org_id?: string | null;
+      workflow_id?: string | null;
     }[];
+    const verdicts = await Promise.all(
+      candidates.map((doc) =>
+        ensureDocAccess(doc, userId, userEmail ?? null, db),
+      ),
+    );
+    const docList = candidates.filter((_, index) => verdicts[index]?.ok);
     await attachActiveVersionPaths(db, docList);
     for (let i = 0; i < docList.length; i++) {
       const doc = docList[i];

--- a/backend/src/lib/chat/contextBuilders.ts
+++ b/backend/src/lib/chat/contextBuilders.ts
@@ -630,12 +630,47 @@ export async function buildDocContext(
       org_id?: string | null;
       workflow_id?: string | null;
     }[];
-    const verdicts = await Promise.all(
-      candidates.map((doc) =>
-        ensureDocAccess(doc, userId, userEmail ?? null, db),
-      ),
-    );
-    const docList = candidates.filter((_, index) => verdicts[index]?.ok);
+    // ONE VERDICT PER CONTAINER, not per document. ensureDocAccess resolves
+    // a document through its project, then its workflow, then its org — and
+    // each of those is two or three round trips. A turn that cites fifteen
+    // files from the same matter used to pay for fifteen identical project
+    // lookups before the model saw a single byte. Whether the container
+    // admits the caller does not depend on which document inside it is
+    // asked about, so ask once per container and reuse the answer; a
+    // document with no container at all still resolves individually, which
+    // costs nothing (it is a `user_id === caller` comparison in memory).
+    const containerKey = (doc: {
+      project_id: string | null;
+      workflow_id?: string | null;
+      org_id?: string | null;
+    }) =>
+      doc.project_id
+        ? `project:${doc.project_id}`
+        : doc.workflow_id
+          ? `workflow:${doc.workflow_id}`
+          : doc.org_id
+            ? `org:${doc.org_id}`
+            : null;
+
+    const verdictByContainer = new Map<string, boolean>();
+    for (const doc of candidates) {
+      const key = containerKey(doc);
+      if (!key || verdictByContainer.has(key)) continue;
+      // The representative carries the container this verdict is about; its
+      // `user_id` only ever decides the ROLE, never `ok`, so reusing one
+      // document's answer for its siblings cannot widen access.
+      const verdict = await ensureDocAccess(doc, userId, userEmail ?? null, db);
+      verdictByContainer.set(key, verdict.ok);
+    }
+
+    const docList: typeof candidates = [];
+    for (const doc of candidates) {
+      const key = containerKey(doc);
+      const ok = key
+        ? (verdictByContainer.get(key) ?? false)
+        : (await ensureDocAccess(doc, userId, userEmail ?? null, db)).ok;
+      if (ok) docList.push(doc);
+    }
     await attachActiveVersionPaths(db, docList);
     for (let i = 0; i < docList.length; i++) {
       const doc = docList[i];

--- a/backend/src/lib/dbq/__tests__/handlers.test.ts
+++ b/backend/src/lib/dbq/__tests__/handlers.test.ts
@@ -12,8 +12,11 @@ vi.mock("../../audit", async (importOriginal) => {
 });
 
 const deleteUserAccountData = vi.fn(async () => {});
+const listOrgsBlockingAccountDeletion = vi.fn(async () => [] as unknown[]);
 vi.mock("../../userDataCleanup", () => ({
     deleteUserAccountData: (...a: unknown[]) => deleteUserAccountData(...a),
+    listOrgsBlockingAccountDeletion: (...a: unknown[]) =>
+        listOrgsBlockingAccountDeletion(...a),
 }));
 
 const buildUserAccountExport = vi.fn(async () => ({ hello: "world" }));
@@ -85,6 +88,7 @@ import {
     handleExportBuild,
     MAX_ZIP_EXPORT_DOCUMENTS,
 } from "../handlers";
+import { NonRetryableJobError } from "../runner";
 import type { DbJob } from "../types";
 
 const JOB = (kind: string, payload: Record<string, unknown>): DbJob => ({
@@ -106,6 +110,9 @@ const JOB = (kind: string, payload: Record<string, unknown>): DbJob => ({
 // Minimal db double for the handlers' own db_jobs queries.
 function makeDb(selectData: unknown[] = []) {
     const deletes: Record<string, unknown>[] = [];
+    // Every requested column list, so a test can assert that a handler asked
+    // for the columns its own access check needs.
+    const selects: string[] = [];
     // Ordered log of everything the handler did, so a test can assert not just
     // WHAT happened but in what order (erasure ordering is the invariant).
     const trace: string[] = [];
@@ -119,7 +126,8 @@ function makeDb(selectData: unknown[] = []) {
             filters: {},
         };
         const b: Record<string, unknown> = {
-            select() {
+            select(columns?: string) {
+                if (typeof columns === "string") selects.push(columns);
                 return b;
             },
             delete() {
@@ -157,6 +165,7 @@ function makeDb(selectData: unknown[] = []) {
     }
     return {
         deletes,
+        selects,
         trace,
         from,
         auth: { admin: { deleteUser: authDeleteUser } },
@@ -222,6 +231,29 @@ describe("handleChatTurnAudit", () => {
 });
 
 describe("handleAccountDelete", () => {
+    it("refuses, terminally, before destroying anything when an org blocks it", async () => {
+        // The route answers 409 for this account, but an org can gain a
+        // member between the request and the job, and old rows can be
+        // requeued. Ask BEFORE the first delete — and throw the
+        // non-retryable error, because no number of retries will give the
+        // organization a second admin.
+        const db = makeDb([]);
+        listOrgsBlockingAccountDeletion.mockResolvedValueOnce([
+            { org_id: "o1", name: "Org A", reason: "members" },
+        ]);
+
+        await expect(
+            handleAccountDelete(
+                db as never,
+                JOB("account.delete", { userId: "u1", userEmail: "u@x.test" }),
+            ),
+        ).rejects.toThrow(NonRetryableJobError);
+
+        expect(deleteUserAccountData).not.toHaveBeenCalled();
+        expect(db.auth.admin.deleteUser).not.toHaveBeenCalled();
+        expect(db.deletes).toHaveLength(0);
+    });
+
     it("runs the cascade and purges the user's other queue rows (not itself)", async () => {
         const db = makeDb([]);
         await handleAccountDelete(
@@ -235,11 +267,10 @@ describe("handleAccountDelete", () => {
         for (const d of db.deletes) expect(d["neq:id"]).toBe("job-1");
     });
 
-    // documents.user_id references auth.users ON DELETE CASCADE, and
-    // document_versions cascades from documents, so deleting the auth user is
-    // what destroys the rows recording where this account's files live. Do it
-    // first and the cascade has nothing left to read — the objects are
-    // orphaned in storage with no row pointing at them, forever.
+    // documents.user_id references auth.users ON DELETE SET NULL, so deleting
+    // the auth user first would not erase this account's rows — it would
+    // anonymise them, past the reach of every `eq("user_id", userId)` delete
+    // in the cascade, with their storage objects left behind forever.
     it("deletes the auth user LAST, after the data cascade", async () => {
         const db = makeDb([]);
         deleteUserAccountData.mockImplementation(async () => {
@@ -452,6 +483,45 @@ describe("handleExportBuild", () => {
         expect(contentType).toBe("application/zip");
         expect(out.filename).toBe("documents.zip");
         expect(out.content_type).toBe("application/zip");
+    });
+
+    // ensureDocAccess resolves a workflow asset through its workflow and an
+    // org document through its org. Selecting only user_id/project_id made
+    // both branches unreachable, so an org colleague's document and every
+    // detached document were silently dropped from the zip — the async
+    // export quietly returned less than the synchronous one.
+    it("selects the columns its own access check needs", async () => {
+        const db = makeDb([
+            {
+                id: "d1",
+                user_id: null,
+                project_id: null,
+                org_id: "o1",
+                workflow_id: "w1",
+            },
+        ]);
+
+        await handleExportBuild(
+            db as never,
+            JOB("export.build", {
+                userId: "u1",
+                userEmail: "u@x.test",
+                type: "documents-zip",
+                document_ids: ["d1"],
+            }),
+        );
+
+        const documentSelect = db.selects.find((columns) =>
+            columns.includes("current_version_id"),
+        );
+        expect(documentSelect).toContain("org_id");
+        expect(documentSelect).toContain("workflow_id");
+        expect(ensureDocAccess).toHaveBeenCalledWith(
+            expect.objectContaining({ org_id: "o1", workflow_id: "w1" }),
+            "u1",
+            "u@x.test",
+            db,
+        );
     });
 
     it("fails a documents-zip job whose documents are all inaccessible", async () => {

--- a/backend/src/lib/dbq/__tests__/runner.test.ts
+++ b/backend/src/lib/dbq/__tests__/runner.test.ts
@@ -4,6 +4,7 @@ vi.mock("../../supabase", () => ({ createServerSupabase: vi.fn() }));
 vi.mock("../../storage", () => ({ deleteFile: vi.fn() }));
 
 import {
+    NonRetryableJobError,
     processClaimedJob,
     retryDelayMs,
     runDbJobTick,
@@ -166,6 +167,27 @@ describe("processClaimedJob fencing", () => {
         );
         expect(db.updates[0].payload.status).toBe("failed");
         expect(db.updates[0].filters).toEqual({ ...FENCE, attempts: 3 });
+    });
+
+    it("fails a NonRetryableJobError immediately, with attempts left", async () => {
+        // A job the domain REFUSES is not a job the network flaked on.
+        // Account deletion for the only admin of a live organization will be
+        // refused identically on every one of its 20 attempts; retrying it
+        // for hours buries the reason and leaves the user's request in limbo.
+        const db = makeDb();
+        await processClaimedJob(
+            db as never,
+            {
+                "test.kind": async () => {
+                    throw new NonRetryableJobError("refused by the domain");
+                },
+            },
+            JOB({ attempts: 1, max_attempts: 20 }),
+        );
+        expect(db.updates[0].payload.status).toBe("failed");
+        expect(db.updates[0].payload.last_error).toBe("refused by the domain");
+        expect(db.updates[0].payload.finished_at).toBeTruthy();
+        expect(db.updates[0].filters).toEqual(FENCE);
     });
 
     it("fences the unknown-kind write to this claim", async () => {

--- a/backend/src/lib/dbq/handlers.ts
+++ b/backend/src/lib/dbq/handlers.ts
@@ -18,7 +18,10 @@ import {
     recordAudit,
     type ChatTurnAuditBase,
 } from "../audit";
-import { deleteUserAccountData } from "../userDataCleanup";
+import {
+    deleteUserAccountData,
+    listOrgsBlockingAccountDeletion,
+} from "../userDataCleanup";
 import {
     buildUserAccountExport,
     buildUserChatsExport,
@@ -60,7 +63,7 @@ import {
 import { publishCellUpdate } from "../queue/runProgress";
 import type { ConversionJobData } from "../queue/conversionQueue";
 import type { ExtractionJobData } from "../queue/extractionQueue";
-import { DB_JOB_FAILURE_HOOKS } from "./runner";
+import { DB_JOB_FAILURE_HOOKS, NonRetryableJobError } from "./runner";
 import type { Db, DbJob, DbJobHandlers } from "./types";
 
 /** The export types a client may request; anything else is a 400 upstream. */
@@ -101,6 +104,24 @@ export async function handleAccountDelete(db: Db, job: DbJob): Promise<void> {
     const userId = job.payload.userId as string | undefined;
     if (!userId) return;
     const userEmail = (job.payload.userEmail as string | undefined) ?? null;
+
+    // REFUSAL BEFORE DESTRUCTION. The route already answered 409 for an
+    // account that is the sole admin of an organization with members or
+    // content, but the org can change between the request and this job, and
+    // this handler is also reachable by requeueing an old row. Ask first,
+    // while nothing has been touched.
+    //
+    // Non-retryable on purpose: an organization does not acquire a second
+    // admin because we asked twenty more times over the next few hours. The
+    // row lands in `failed` with the reason legible on the first attempt.
+    const blockers = await listOrgsBlockingAccountDeletion(db, userId);
+    if (blockers.length > 0) {
+        throw new NonRetryableJobError(
+            `Account is the only admin of ${blockers.length} organization(s) that still hold members or content: ${blockers
+                .map((b) => `${b.org_id} (${b.reason})`)
+                .join(", ")}`,
+        );
+    }
 
     // The whole cascade is deletes — idempotent by nature, so a crash midway
     // simply re-runs. The user's sessions were revoked by the route, so no new
@@ -169,15 +190,16 @@ export async function handleAccountDelete(db: Db, job: DbJob): Promise<void> {
 
     // The auth user goes LAST, and only once every row above is gone.
     //
-    // documents.user_id references auth.users ON DELETE CASCADE, and
-    // document_versions cascades from documents in turn, so deleting the auth
-    // user destroys the only record of where this account's files live —
-    // storage_path, pdf_storage_path, and the version ids the extracted-text
-    // cache is keyed by. Delete auth first and the cascade above has nothing
-    // left to read: `generated/<userId>/…`, `extracted-text/<versionId>.txt`
-    // and every object uploaded by OTHER users into this user's projects are
-    // orphaned in object storage permanently, with no row anywhere pointing at
-    // them. Erasure that leaves the files behind is not erasure.
+    // documents.user_id references auth.users ON DELETE SET NULL (an
+    // organization's documents outlive the account that uploaded them), so
+    // deleting the auth user first does not destroy this account's rows — it
+    // ANONYMISES them. Every personal document would be left with a null
+    // user_id and no org: matched by none of the `eq("user_id", userId)`
+    // deletes above, listed nowhere, and still pointing at
+    // `generated/<userId>/…` and `extracted-text/<versionId>.txt` objects
+    // that nothing would ever sweep. Erasure that leaves the rows and the
+    // files behind is not erasure — so the data goes first, by user_id, while
+    // the user_id is still on it.
     //
     // Deleting it here also makes the job's retry budget mean something: while
     // this step is outstanding the account still exists, so a permanently
@@ -286,9 +308,15 @@ async function buildDocumentsZipExport(
         throw new Error(`[export.build] malformed payload on job ${job.id}`);
     }
 
+    // org_id and workflow_id are part of the verdict, not decoration:
+    // ensureDocAccess resolves a workflow asset through its workflow and an
+    // org document through its org. Selecting only project_id/user_id made
+    // both branches unreachable, so an org colleague's document and every
+    // detached document were silently dropped from the zip. The sync route
+    // (documents.ts) already selects the full set.
     const { data: rawDocs, error } = await db
         .from("documents")
-        .select("id, current_version_id, user_id, project_id")
+        .select("id, current_version_id, user_id, project_id, org_id, workflow_id")
         .in("id", documentIds as string[]);
     if (error) throw new Error(`[export.build] ${error.message}`);
 
@@ -299,6 +327,8 @@ async function buildDocumentsZipExport(
         id: string;
         user_id: string;
         project_id: string | null;
+        org_id?: string | null;
+        workflow_id?: string | null;
     }[]) {
         // Access is re-checked HERE, not at enqueue time: the payload's ids
         // are stale by definition (a share can be revoked while the job

--- a/backend/src/lib/dbq/runner.ts
+++ b/backend/src/lib/dbq/runner.ts
@@ -59,10 +59,29 @@ export type DbJobFailureHook = (db: Db, job: DbJob) => Promise<void>;
 export const DB_JOB_FAILURE_HOOKS: Record<string, DbJobFailureHook> = {};
 
 /**
+ * "Retrying cannot fix this." A handler throws it when the job is refused by
+ * a rule, not defeated by a transient fault — and the state machine skips
+ * straight to `failed`, the same way an unknown kind does.
+ *
+ * The retry budget is for flaky networks and busy databases. Spending 20
+ * attempts over hours on a job the domain will refuse identically every time
+ * (account deletion for the only admin of an organization that still has
+ * members) buries the real reason under a wall of repeats and leaves the
+ * user's request in limbo far longer than it needs to be.
+ */
+export class NonRetryableJobError extends Error {
+    constructor(message: string) {
+        super(message);
+        this.name = "NonRetryableJobError";
+    }
+}
+
+/**
  * Run one claimed job through its handler and persist the outcome:
  *   handler resolves        -> done (+ optional result)
  *   handler throws, retries -> pending again with run_at pushed back
  *   handler throws, spent   -> failed (terminal, kept for inspection)
+ *   handler throws NonRetryableJobError -> failed immediately
  *   unknown kind            -> failed immediately (retrying can't fix it)
  * Exported for unit tests; the poll loop below is just claim + fan-in.
  */
@@ -122,7 +141,9 @@ export async function processClaimedJob(
     } catch (err) {
         const message =
             err instanceof Error ? err.message : String(err ?? "unknown");
-        const spent = job.attempts >= job.max_attempts;
+        const spent =
+            err instanceof NonRetryableJobError ||
+            job.attempts >= job.max_attempts;
         const delayMs = retryDelayMs(job.attempts);
         await fence(
             db.from("db_jobs").update(

--- a/backend/src/lib/orgAccessOverrides.ts
+++ b/backend/src/lib/orgAccessOverrides.ts
@@ -276,6 +276,50 @@ export async function setOrgAccessOverride(
     return { ok: true, override: data as OrgAccessOverride };
 }
 
+/**
+ * Persist a WHOLE BATCH of overrides in one statement.
+ *
+ * A loop of single upserts is not atomic: the org-membership triggers on
+ * these tables can refuse the fourth row after the first three have already
+ * committed, and the caller then answers 500 with access silently changed for
+ * three people. One upsert is one statement, so a trigger refusal on any
+ * target rolls the whole batch back and nothing is written.
+ */
+export async function setOrgAccessOverrides(
+    db: Db,
+    params: {
+        kind: OrgResourceKind;
+        resourceId: string;
+        orgId: string;
+        userIds: string[];
+        role: OrgAssignableRole;
+        assignedBy: string;
+    },
+): Promise<{ ok: true } | { ok: false; detail: string }> {
+    if (params.userIds.length === 0) return { ok: true };
+    const config = CONFIG[params.kind];
+    const updatedAt = new Date().toISOString();
+    const { error } = await db.from(config.table).upsert(
+        params.userIds.map((userId) => ({
+            [config.resourceColumn]: params.resourceId,
+            org_id: params.orgId,
+            user_id: userId,
+            role: params.role,
+            assigned_by: params.assignedBy,
+            updated_at: updatedAt,
+        })),
+        { onConflict: `${config.resourceColumn},user_id` },
+    );
+    if (error)
+        return {
+            ok: false,
+            detail:
+                error.message ??
+                "Failed to save organization access overrides",
+        };
+    return { ok: true };
+}
+
 export async function deleteOrgAccessOverride(
     db: Db,
     params: {

--- a/backend/src/lib/orgs.ts
+++ b/backend/src/lib/orgs.ts
@@ -39,6 +39,30 @@ type DbError = { code?: string; message: string } | null;
 /** How long a pending invitation stays acceptable. */
 export const INVITATION_TTL_DAYS = 14;
 
+/**
+ * Every table that carries its own `org_id` — the complete inventory of what
+ * an organization can directly own.
+ *
+ * ONE list, because two different call sites ask the same question and used
+ * to disagree about the answer: `deleteOrg` below (may this org be deleted?)
+ * and account deletion (`listOrgsBlockingAccountDeletion` in
+ * lib/userDataCleanup.ts). The account-deletion probe omitted `chats`, so an
+ * org whose only remaining content was a chat looked empty and was deleted —
+ * while `deleteOrg` refused the very same delete over the API.
+ *
+ * Every one of these foreign keys is ON DELETE RESTRICT, so an incomplete
+ * probe does not silently detach content: the database refuses the delete and
+ * the caller gets a raw constraint error instead of an intentional 409. The
+ * probe exists to answer first.
+ */
+export const ORG_CONTENT_TABLES = [
+    "projects",
+    "documents",
+    "chats",
+    "tabular_reviews",
+    "workflows",
+] as const;
+
 export type InvitationStatus =
     | "pending"
     | "accepted"
@@ -223,15 +247,8 @@ export async function deleteOrg(
         .maybeSingle();
     if (!org) return { ok: false, kind: "not_found" };
 
-    const resourceTables = [
-        "projects",
-        "documents",
-        "chats",
-        "tabular_reviews",
-        "workflows",
-    ] as const;
     const inventories = await Promise.all(
-        resourceTables.map(async (table) => ({
+        ORG_CONTENT_TABLES.map(async (table) => ({
             table,
             result: await db.from(table).select("id").eq("org_id", params.orgId),
         })),

--- a/backend/src/lib/tabular/tabular.generate.ts
+++ b/backend/src/lib/tabular/tabular.generate.ts
@@ -19,6 +19,7 @@
 
 import { type UserApiKeys } from "../llm";
 import { ensureReviewAccess, filterAccessibleDocumentIds } from "../access";
+import { can } from "../permissions";
 import { loadReviewRows, type ReviewRow } from "./tabular.rows";
 import {
     validateSelectedModel,
@@ -45,6 +46,7 @@ export async function prepareTabularGenerate(
 ): Promise<
     | { ok: true; data: PreparedGenerate }
     | { ok: false; kind: "not_found" }
+    | { ok: false; kind: "forbidden" }
     | { ok: false; kind: "no_columns" }
     | ({ ok: false; kind: "model" } & Omit<ModelValidationFailure, "ok">)
 > {
@@ -58,6 +60,13 @@ export async function prepareTabularGenerate(
     if (reviewError || !review) return { ok: false, kind: "not_found" };
     const access = await ensureReviewAccess(review, userId, userEmail, db);
     if (!access.ok) return { ok: false, kind: "not_found" };
+    // GENERATION IS A WRITE. It claims the review's generation lease, calls a
+    // paid model with the caller's keys, persists a cell per column per row
+    // and stamps an audit event in the caller's name. `access.ok` alone let a
+    // review VIEWER do all of that — read-only access is not permission to
+    // rewrite the review's contents.
+    if (!can(access.projectRole, "content.edit"))
+        return { ok: false, kind: "forbidden" };
 
     const columns: Column[] = review.columns_config ?? [];
     if (columns.length === 0) return { ok: false, kind: "no_columns" };

--- a/backend/src/lib/userDataCleanup.ts
+++ b/backend/src/lib/userDataCleanup.ts
@@ -3,6 +3,7 @@ import { deleteFile, extractedTextKey, listFiles } from "./storage";
 import { enqueueStorageCleanup } from "./dbq/enqueue";
 import { removeGrantsForEmail } from "./projectAccess";
 import { removeContentGrantsForEmail } from "./contentAccess";
+import { ORG_CONTENT_TABLES } from "./orgs";
 
 type Db = ReturnType<typeof createServerSupabase>;
 
@@ -80,17 +81,27 @@ const PROJECT_CONTENT_TABLES = [
 ] as const;
 
 /**
- * Every table with its own `org_id` column — the full inventory of what an
- * organization can directly own. An org may only be deleted when a probe of
- * ALL of these comes back empty; anything less fires the ON DELETE SET NULL
- * foreign keys on rows the org still owned.
+ * Does this organization still directly own anything?
+ *
+ * The inventory lives in lib/orgs.ts so this and the `deleteOrg` API path
+ * answer the identical question. Every org_id foreign key is ON DELETE
+ * RESTRICT, so an org that owns content cannot be deleted at all — the probe
+ * is how we say so deliberately instead of surfacing a constraint violation.
  */
-const ORG_CONTENT_TABLES = [
-    "projects",
-    "documents",
-    "workflows",
-    "tabular_reviews",
-] as const;
+async function orgOwnsContent(db: Db, orgId: string): Promise<boolean> {
+    for (const table of ORG_CONTENT_TABLES) {
+        const { data, error } = await (db as any)
+            .from(table)
+            .select("id")
+            .eq("org_id", orgId)
+            .limit(1);
+        // A transient read error must never read as "this org holds nothing":
+        // that is the difference between tidying up and deleting a firm.
+        await throwIfError(error, `Failed to load org ${table}`);
+        if (((data ?? []) as unknown[]).length > 0) return true;
+    }
+    return false;
+}
 
 /**
  * Every organization-owned project this user left content in — including
@@ -566,6 +577,110 @@ async function deleteUserExportArtifacts(userId: string) {
     }
 }
 
+/** One organization that stands between a user and deleting their account. */
+export type AccountDeletionOrgBlocker = {
+    org_id: string;
+    name: string;
+    /**
+     * "members" — other people are still in the org and would be left with
+     * nobody able to administer it (or, worse, with an arbitrary successor).
+     * "content" — nobody else is left, but the org still owns matters, so it
+     * cannot be deleted either.
+     */
+    reason: "members" | "content";
+};
+
+/**
+ * The organizations that make this account undeletable, and why.
+ *
+ * PRODUCT DECISION: an account that is the SOLE ADMIN of an organization
+ * which still has other members, or still owns content, cannot be deleted.
+ * The user must appoint another admin or delete the organization first.
+ *
+ * Both of the alternatives were implemented here before, and both were wrong:
+ *
+ *  - Auto-promoting "the earliest remaining member" hands a firm's matters to
+ *    whoever happened to join first, with no audit row and no consent. Worse,
+ *    the cleanup_org_admin_access_overrides trigger then deletes that
+ *    member's `deny` overrides — so a person deliberately walled off from a
+ *    matter becomes its owner as a side effect of somebody else closing their
+ *    account.
+ *  - Leaving the membership row "for the auth.users cascade" produced an
+ *    organization with zero members: invisible in every listing, undeletable
+ *    (its content FKs are ON DELETE RESTRICT), and holding content nobody can
+ *    reach. In practice the cascade did not even get that far — the
+ *    org_member_protect_resource_ownership trigger refuses to remove a member
+ *    who still owns the org's projects, so the durable account.delete job
+ *    failed forever while the user, whose sessions were revoked and who had
+ *    been sent to the login page, could simply log back in.
+ *
+ * Refusing up front is the only outcome that leaves the database, the
+ * organization and the user in a state each of them agrees with.
+ */
+export async function listOrgsBlockingAccountDeletion(
+    db: Db,
+    userId: string,
+): Promise<AccountDeletionOrgBlocker[]> {
+    const { data: memberships, error: membershipError } = await db
+        .from("org_members")
+        .select("id, org_id, role")
+        .eq("user_id", userId);
+    await throwIfError(membershipError, "Failed to load org memberships");
+
+    const blockers: AccountDeletionOrgBlocker[] = [];
+    for (const m of (memberships ?? []) as {
+        id: string;
+        org_id: string;
+        role: string;
+    }[]) {
+        if (m.role !== "admin") continue;
+
+        const { data: otherAdmins, error: otherAdminsError } = await db
+            .from("org_members")
+            .select("id")
+            .eq("org_id", m.org_id)
+            .eq("role", "admin")
+            .neq("id", m.id)
+            .limit(1);
+        await throwIfError(otherAdminsError, "Failed to load org admins");
+        // Somebody else can administer it: leaving is unremarkable.
+        if (((otherAdmins ?? []) as unknown[]).length > 0) continue;
+
+        const { data: otherMembers, error: otherMembersError } = await db
+            .from("org_members")
+            .select("id")
+            .eq("org_id", m.org_id)
+            .neq("id", m.id)
+            .limit(1);
+        await throwIfError(
+            otherMembersError,
+            "Failed to load remaining org members",
+        );
+        const hasOtherMembers = ((otherMembers ?? []) as unknown[]).length > 0;
+        if (!hasOtherMembers && !(await orgOwnsContent(db, m.org_id))) {
+            // Nobody and nothing left: deleteUserOrganizations deletes the
+            // whole org, so this one blocks nothing.
+            continue;
+        }
+
+        const { data: org, error: orgError } = await db
+            .from("organizations")
+            .select("id, name")
+            .eq("id", m.org_id)
+            .maybeSingle();
+        await throwIfError(orgError, "Failed to load organization");
+        blockers.push({
+            org_id: m.org_id,
+            name:
+                typeof (org as { name?: unknown } | null)?.name === "string"
+                    ? ((org as { name: string }).name)
+                    : "your organization",
+            reason: hasOtherMembers ? "members" : "content",
+        });
+    }
+    return blockers;
+}
+
 /**
  * Tear down a user's organization footprint on account deletion.
  *
@@ -574,16 +689,13 @@ async function deleteUserExportArtifacts(userId: string) {
  * people or content in it:
  *
  *  - The departing user's membership row is removed.
- *  - If they were the org's sole admin, the earliest remaining member is
- *    promoted so the org is never stranded without anyone able to administer
- *    it. The promotion happens BEFORE the removal, both to avoid a window
- *    where the org has no admin and because the
- *    org_members_protect_last_admin trigger would otherwise reject the
- *    delete outright.
- *  - An org left with no members at all is deleted only when it also holds no
- *    projects. An org whose last member leaves but whose matters live on is
- *    kept: deleting it would take the firm's content with it, which is
- *    exactly the outcome this model exists to prevent.
+ *  - A sole admin whose org still has members or content is REFUSED — see
+ *    listOrgsBlockingAccountDeletion for why neither auto-promotion nor
+ *    "leave it to the cascade" is an acceptable alternative. The route
+ *    answers 409 long before this runs; the throw here is defense in depth
+ *    for the durable job path, and it fires before anything is destroyed.
+ *  - An org left with no members and no content at all is deleted, which is
+ *    what closing a personal workspace should do.
  *  - Any invitations the user sent lose their inviter reference through the
  *    FK's ON DELETE SET NULL; invitations addressed TO them are cancelled.
  */
@@ -609,84 +721,41 @@ export async function deleteUserOrganizations(
                 .select("id")
                 .eq("org_id", m.org_id)
                 .eq("role", "admin")
-                .neq("id", m.id);
+                .neq("id", m.id)
+                .limit(1);
             await throwIfError(otherAdminsError, "Failed to load org admins");
             if (((otherAdmins ?? []) as unknown[]).length === 0) {
-                const { data: remaining, error: remainingError } = await db
-                    .from("org_members")
-                    .select("id")
-                    .eq("org_id", m.org_id)
-                    .neq("id", m.id)
-                    .order("created_at", { ascending: true })
-                    .limit(1);
+                const { data: otherMembers, error: otherMembersError } =
+                    await db
+                        .from("org_members")
+                        .select("id")
+                        .eq("org_id", m.org_id)
+                        .neq("id", m.id)
+                        .limit(1);
                 await throwIfError(
-                    remainingError,
+                    otherMembersError,
                     "Failed to load remaining org members",
                 );
-                const heir = ((remaining ?? []) as { id: string }[])[0];
-                if (heir) {
-                    const { error: promoteError } = await db
-                        .from("org_members")
-                        .update({ role: "admin" })
-                        .eq("id", heir.id);
-                    await throwIfError(
-                        promoteError,
-                        "Failed to hand off org administration",
+                const hasOtherMembers =
+                    ((otherMembers ?? []) as unknown[]).length > 0;
+
+                if (hasOtherMembers || (await orgOwnsContent(db, m.org_id))) {
+                    // Unreachable through the API — routes/user.ts refuses
+                    // this account with a 409 before enqueueing anything, and
+                    // the job handler re-checks before it destroys a single
+                    // row. Reaching it means the org changed underneath a
+                    // request that was already in flight, so stop here rather
+                    // than improvise a successor.
+                    throw new Error(
+                        `Cannot delete this account while it is the only admin of organization ${m.org_id}`,
                     );
-                } else {
-                    // "The org owns nothing" must be judged against every
-                    // table that carries its own org_id — documents,
-                    // workflows and tabular reviews are filed under an org
-                    // independently of any project, and this very cleanup
-                    // detaches (keeps) them a few steps earlier. Probing
-                    // projects alone deleted an org that still owned
-                    // detached workflows; the ON DELETE SET NULL FK then
-                    // blanked their org_id, leaving rows with no creator
-                    // and no org — reachable by no access branch, listed
-                    // nowhere, deletable by nothing.
-                    let orgOwnsContent = false;
-                    for (const table of ORG_CONTENT_TABLES) {
-                        const { data: rows, error: rowsError } = await db
-                            .from(table)
-                            .select("id")
-                            .eq("org_id", m.org_id)
-                            .limit(1);
-                        await throwIfError(
-                            rowsError,
-                            `Failed to load org ${table}`,
-                        );
-                        if (((rows ?? []) as unknown[]).length > 0) {
-                            orgOwnsContent = true;
-                            break;
-                        }
-                    }
-                    if (!orgOwnsContent) {
-                        await deleteByIds(db, "organizations", [m.org_id]);
-                        continue; // cascade removed the membership row
-                    }
-                    // Sole admin, sole member, and the org keeps its content
-                    // — so neither escape route below applies: there is
-                    // nobody to promote and the organization must survive.
-                    //
-                    // Deleting the membership row HERE is what the
-                    // org_members_protect_last_admin trigger exists to refuse.
-                    // Both of its stand-aside conditions are still false at
-                    // this moment: the organizations row is present (we just
-                    // decided to keep it) and the member's auth.users row is
-                    // present (routes/user.ts deletes the auth user only
-                    // AFTER this cleanup returns). The trigger raises 23514,
-                    // throwIfError turns that into a 500, and the account
-                    // deletion dies half-finished — storage swept, personal
-                    // rows gone, account still there.
-                    //
-                    // So leave the row alone and let the FK do it. org_members
-                    // .user_id is `references auth.users(id) on delete
-                    // cascade`, and the trigger's second escape hatch fires
-                    // exactly for that cascade ("the member's auth row is
-                    // already gone"). The membership disappears moments later
-                    // with nobody having to argue with the invariant.
-                    continue;
                 }
+
+                // Nobody and nothing left: the org goes with the account, and
+                // the ON DELETE CASCADE from organizations takes the
+                // membership row with it.
+                await deleteByIds(db, "organizations", [m.org_id]);
+                continue;
             }
         }
 
@@ -1001,8 +1070,9 @@ export async function deleteUserAccountData(
     // database which objects under this user's storage prefixes are orphans.
     await deleteOrphanedUserStorage(db, userId);
 
-    // Organizations use ON DELETE SET NULL on content (not CASCADE), so the
-    // content deletions above never touch the user's org memberships — settle
-    // those (and hand off administration where needed) here.
+    // An organization's content is held by ON DELETE RESTRICT foreign keys —
+    // deleting an org that still owns anything is refused outright, never
+    // silently detached — so none of the content deletions above touch the
+    // user's org memberships. Settle those here.
     await deleteUserOrganizations(db, userId, userEmail);
 }

--- a/backend/src/lib/userDataCleanup.ts
+++ b/backend/src/lib/userDataCleanup.ts
@@ -1,6 +1,7 @@
 import { createServerSupabase } from "./supabase";
 import { deleteFile, extractedTextKey, listFiles } from "./storage";
 import { enqueueStorageCleanup } from "./dbq/enqueue";
+import { NonRetryableJobError } from "./dbq/runner";
 import { removeGrantsForEmail } from "./projectAccess";
 import { removeContentGrantsForEmail } from "./contentAccess";
 import { ORG_CONTENT_TABLES } from "./orgs";
@@ -692,8 +693,11 @@ export async function listOrgsBlockingAccountDeletion(
  *  - A sole admin whose org still has members or content is REFUSED — see
  *    listOrgsBlockingAccountDeletion for why neither auto-promotion nor
  *    "leave it to the cascade" is an acceptable alternative. The route
- *    answers 409 long before this runs; the throw here is defense in depth
- *    for the durable job path, and it fires before anything is destroyed.
+ *    answers 409 long before this runs, and deleteUserAccountData re-asks
+ *    the same question as its FIRST act, before a single row is destroyed.
+ *    The throw here is the last line of defence for a caller that reached
+ *    this function on its own, so by the time it fires the caller's content
+ *    is already gone — which is exactly why the check above it exists.
  *  - An org left with no members and no content at all is deleted, which is
  *    what closing a personal workspace should do.
  *  - Any invitations the user sent lose their inviter reference through the
@@ -742,11 +746,17 @@ export async function deleteUserOrganizations(
                 if (hasOtherMembers || (await orgOwnsContent(db, m.org_id))) {
                     // Unreachable through the API — routes/user.ts refuses
                     // this account with a 409 before enqueueing anything, and
-                    // the job handler re-checks before it destroys a single
-                    // row. Reaching it means the org changed underneath a
-                    // request that was already in flight, so stop here rather
-                    // than improvise a successor.
-                    throw new Error(
+                    // deleteUserAccountData re-checks before it destroys a
+                    // single row. Reaching it means the org changed underneath
+                    // a request that was already in flight, so stop here
+                    // rather than improvise a successor.
+                    //
+                    // NonRetryableJobError, not Error: an organization does
+                    // not acquire a second admin because the queue asked
+                    // twenty more times over the next few hours. A plain
+                    // Error burned the whole retry budget re-deriving the
+                    // same refusal and buried the reason under the repeats.
+                    throw new NonRetryableJobError(
                         `Cannot delete this account while it is the only admin of organization ${m.org_id}`,
                     );
                 }
@@ -978,6 +988,22 @@ export async function deleteUserAccountData(
     userId: string,
     userEmail?: string | null,
 ) {
+    // REFUSAL BEFORE DESTRUCTION — and this must be the first statement in
+    // the function. The same question used to be asked by
+    // deleteUserOrganizations at the very END of the cascade, by which point
+    // the account's documents, storage objects and audit rows were already
+    // gone: the refusal was real, but it arrived after the data it was meant
+    // to protect had been destroyed, and the failed job could never undo it.
+    // Ask while nothing has been touched, so a refusal costs nothing.
+    const blockers = await listOrgsBlockingAccountDeletion(db, userId);
+    if (blockers.length > 0) {
+        throw new NonRetryableJobError(
+            `Cannot delete this account while it is the only admin of ${blockers
+                .map((blocker) => `${blocker.org_id} (${blocker.reason})`)
+                .join(", ")}`,
+        );
+    }
+
     const { personal: personalProjectIds, org: createdOrgProjectIds } =
         await partitionOwnedProjects(db, userId);
     // Retention follows the organization's projects, not this user's. Their

--- a/backend/src/routes/__tests__/audit.test.ts
+++ b/backend/src/routes/__tests__/audit.test.ts
@@ -122,14 +122,32 @@ describe("parseQuery", () => {
 /**
  * Chainable Supabase mock.
  *
- * `owned` answers the `projects` lookup (.eq on user_id) and `shared` answers
- * the `project_access_grants` lookup, which is where direct sharing lives.
+ * `owned` answers the personal `projects` lookup, `shared` answers the
+ * `project_access_grants` lookup (where direct sharing lives), and `org`
+ * supplies the third branch: the caller's memberships, that org's projects,
+ * and any per-project deny override.
+ *
+ * The audit scope now delegates to lib/access.listAccessibleProjectIds, which
+ * composes .eq/.in/.is chains over four tables and re-checks every org
+ * project — so the stub answers on the FILTERS applied, not just the table
+ * named.
  */
+type Filters = {
+    eq: Record<string, unknown>;
+    in: Record<string, unknown>;
+    is: Record<string, unknown>;
+};
+
 function makeDb(
     owned: string[],
     shared: string[],
     events: Record<string, unknown>[] = [],
     profiles: Record<string, unknown>[] = [],
+    org: {
+        memberships?: { org_id: string; role: string }[];
+        projects?: { id: string; user_id: string | null; org_id: string }[];
+        denies?: string[];
+    } = {},
 ) {
     const calls: {
         or?: string;
@@ -140,34 +158,58 @@ function makeDb(
         grantEmail?: unknown;
     } = { eq: [] };
 
-    function projectsBuilder() {
-        const b: any = {
-            select: () => b,
-            eq: () => b,
-            then: (resolve: (v: { data: { id: string }[] }) => unknown) =>
-                Promise.resolve({
-                    data: owned.map((id) => ({ id })),
-                }).then(resolve),
-        };
-        return b;
-    }
+    const memberships = org.memberships ?? [];
+    const orgProjects = org.projects ?? [];
+    const denied = new Set(org.denies ?? []);
 
-    function grantsBuilder() {
+    function filterBuilder(resolve: (filters: Filters) => unknown[]) {
+        const filters: Filters = { eq: {}, in: {}, is: {} };
         const b: any = {
             select: () => b,
             eq: (column: string, value: unknown) => {
                 if (column === "email") calls.grantEmail = value;
+                filters.eq[column] = value;
                 return b;
             },
-            then: (
-                resolve: (v: { data: { project_id: string }[] }) => unknown,
-            ) =>
+            in: (column: string, value: unknown) => {
+                filters.in[column] = value;
+                return b;
+            },
+            is: (column: string, value: unknown) => {
+                filters.is[column] = value;
+                return b;
+            },
+            order: () => b,
+            maybeSingle: () =>
                 Promise.resolve({
-                    data: shared.map((id) => ({ project_id: id })),
-                }).then(resolve),
+                    data: resolve(filters)[0] ?? null,
+                    error: null,
+                }),
+            then: (resolveFn: (v: unknown) => unknown) =>
+                Promise.resolve({ data: resolve(filters), error: null }).then(
+                    resolveFn,
+                ),
         };
         return b;
     }
+
+    // Personal-owned, org-scoped, per-id and single-project lookups all hit
+    // `projects`; only the filters tell them apart.
+    const projectsResolver = (filters: Filters): unknown[] => {
+        if (filters.eq.id)
+            return orgProjects.filter(
+                (project) => project.id === filters.eq.id,
+            );
+        if (filters.in.org_id)
+            return orgProjects.filter((project) =>
+                (filters.in.org_id as string[]).includes(project.org_id),
+            );
+        if (filters.in.id)
+            return (filters.in.id as string[])
+                .filter((id) => shared.includes(id))
+                .map((id) => ({ id }));
+        return owned.map((id) => ({ id }));
+    };
 
     function auditBuilder() {
         const b: any = {
@@ -216,8 +258,25 @@ function makeDb(
 
     const db = {
         from(table: string) {
-            if (table === "projects") return projectsBuilder();
-            if (table === "project_access_grants") return grantsBuilder();
+            if (table === "projects") return filterBuilder(projectsResolver);
+            if (table === "project_access_grants")
+                return filterBuilder(() =>
+                    shared.map((id) => ({ project_id: id })),
+                );
+            if (table === "org_members")
+                return filterBuilder((filters) =>
+                    memberships.filter(
+                        (membership) =>
+                            !filters.eq.org_id ||
+                            membership.org_id === filters.eq.org_id,
+                    ),
+                );
+            if (table === "project_org_access_overrides")
+                return filterBuilder((filters) =>
+                    denied.has(filters.eq.project_id as string)
+                        ? [{ role: "deny" }]
+                        : [],
+                );
             if (table === "user_profiles") return profilesBuilder();
             return auditBuilder();
         },
@@ -266,6 +325,44 @@ describe("queryEvents visibility scoping", () => {
         const { db } = makeDb([], ["p-granted"]);
         const visible = await accessibleProjectIds(db, "u1", "u1@example.com");
         expect(visible).toContain("p-granted");
+    });
+
+    // Organization projects carry no access grants by construction, so the
+    // old owner-or-grant query left an org admin's audit history empty for
+    // their own firm's matters — including every project detached by an
+    // account deletion (projects.user_id → NULL).
+    it("admits an organization project the caller does not own", async () => {
+        const { db } = makeDb([], [], [], [], {
+            memberships: [{ org_id: "o1", role: "member" }],
+            projects: [
+                { id: "p-colleague", user_id: "u2", org_id: "o1" },
+                { id: "p-detached", user_id: null, org_id: "o1" },
+            ],
+        });
+
+        const visible = await accessibleProjectIds(db, "u1", "u1@example.com");
+
+        expect(visible).toEqual(
+            expect.arrayContaining(["p-colleague", "p-detached"]),
+        );
+    });
+
+    // The audit trail is a read path like any other: an ethical wall has to
+    // hold here too, or the wall leaks the walled matter's history.
+    it("excludes an organization project the caller is denied on", async () => {
+        const { db } = makeDb([], [], [], [], {
+            memberships: [{ org_id: "o1", role: "member" }],
+            projects: [
+                { id: "p-open", user_id: "u2", org_id: "o1" },
+                { id: "p-walled", user_id: "u2", org_id: "o1" },
+            ],
+            denies: ["p-walled"],
+        });
+
+        const visible = await accessibleProjectIds(db, "u1", "u1@example.com");
+
+        expect(visible).toContain("p-open");
+        expect(visible).not.toContain("p-walled");
     });
 
     it("applies categorical filters and the requested sort", async () => {

--- a/backend/src/routes/__tests__/audit.test.ts
+++ b/backend/src/routes/__tests__/audit.test.ts
@@ -151,12 +151,13 @@ function makeDb(
 ) {
     const calls: {
         or?: string;
+        in: [string, unknown][];
         eq: [string, unknown][];
         order?: [string, { ascending: boolean; nullsFirst: boolean }];
         ilike?: [string, string];
         profileUserIds?: string[];
         grantEmail?: unknown;
-    } = { eq: [] };
+    } = { eq: [], in: [] };
 
     const memberships = org.memberships ?? [];
     const orgProjects = org.projects ?? [];
@@ -180,6 +181,9 @@ function makeDb(
                 return b;
             },
             order: () => b,
+            // listAccessibleProjectIds pages its scans; one page is enough here.
+            range: () =>
+                Promise.resolve({ data: resolve(filters), error: null }),
             maybeSingle: () =>
                 Promise.resolve({
                     data: resolve(filters)[0] ?? null,
@@ -216,6 +220,10 @@ function makeDb(
             select: () => b,
             or: (expr: string) => {
                 calls.or = expr;
+                return b;
+            },
+            in: (col: string, val: unknown) => {
+                calls.in.push([col, val]);
                 return b;
             },
             eq: (col: string, val: unknown) => {
@@ -272,11 +280,26 @@ function makeDb(
                     ),
                 );
             if (table === "project_org_access_overrides")
-                return filterBuilder((filters) =>
-                    denied.has(filters.eq.project_id as string)
-                        ? [{ role: "deny" }]
-                        : [],
-                );
+                // Two readers: the per-project verdict (eq project_id) and
+                // the batched scan keyed by the caller's org memberships
+                // (in org_id + eq user_id + eq role).
+                return filterBuilder((filters) => {
+                    if (filters.eq.project_id)
+                        return denied.has(filters.eq.project_id as string)
+                            ? [{ role: "deny" }]
+                            : [];
+                    const orgIds = (filters.in.org_id as string[]) ?? [];
+                    return orgProjects
+                        .filter(
+                            (project) =>
+                                denied.has(project.id) &&
+                                orgIds.includes(project.org_id),
+                        )
+                        .map((project) => ({
+                            project_id: project.id,
+                            role: "deny",
+                        }));
+                });
             if (table === "user_profiles") return profilesBuilder();
             return auditBuilder();
         },
@@ -295,8 +318,18 @@ describe("queryEvents visibility scoping", () => {
     it("scopes to own events OR accessible project events (owned + shared)", async () => {
         const { db, calls } = makeDb(["p-own"], ["p-shared"]);
         await queryEvents(db, "u1", "u1@example.com", query);
-        expect(calls.or).toBe("user_id.eq.u1,project_id.in.(p-own,p-shared)");
-        expect(calls.eq).toEqual([]);
+        // Two disjoint reads: the caller's own rows, and rows written by
+        // OTHER people inside projects the caller can reach. Disjoint is what
+        // makes the exact counts summable and keeps the project-id filter out
+        // of the URL's `or=` clause, which overflowed past a few hundred ids.
+        expect(calls.eq).toContainEqual(["user_id", "u1"]);
+        const projectFilter = calls.in.find(([col]) => col === "project_id");
+        expect(projectFilter).toBeDefined();
+        expect([...(projectFilter![1] as string[])].sort()).toEqual([
+            "p-own",
+            "p-shared",
+        ]);
+        expect(calls.or).toBe("user_id.is.null,user_id.neq.u1");
     });
 
     it("falls back to own-events-only when no projects are accessible", async () => {

--- a/backend/src/routes/chat.ts
+++ b/backend/src/routes/chat.ts
@@ -41,7 +41,6 @@ import {
     normalizeEmail,
     resolveContentOrgId,
 } from "../lib/access";
-import { loadProfileUsersByEmail } from "../lib/userLookup";
 import {
     deleteContentGrant,
     listContentGrants,
@@ -85,9 +84,17 @@ async function validateAccessibleProjectId(
 ): Promise<{ ok: true } | { ok: false; status: number; detail: string }> {
     if (!projectId) return { ok: true };
     // Creating a chat under a project contributes content to it: member+.
+    // A Viewer can see the project, so answering 404 would claim it does not
+    // exist; the refusal is 403 and names the reason instead.
     const access = await checkProjectAccess(projectId, userId, userEmail, db);
-    if (!access.ok || !can(access.projectRole, "content.edit"))
+    if (!access.ok)
         return { ok: false, status: 404, detail: "Project not found" };
+    if (!can(access.projectRole, "content.edit"))
+        return {
+            ok: false,
+            status: 403,
+            detail: "You do not have permission to write in this project.",
+        };
     return { ok: true };
 }
 
@@ -318,16 +325,24 @@ chatRouter.post("/:chatId/access", requireAuth, async (req, res) => {
         return void res.status(400).json({
             detail: "Deny is only available for organization members",
         });
-    const { userById } = await loadProfileUsersByEmail(db);
+    // One creator's email, one row read. This used to scan every profile in
+    // the deployment to build two maps and then use a single entry.
+    const creatorProfile = access.chat.user_id
+        ? await db
+              .from("user_profiles")
+              .select("email")
+              .eq("user_id", access.chat.user_id)
+              .maybeSingle()
+        : null;
     const result = await upsertContentGrant(db, {
         kind: "chat",
         resourceId: chatId,
         email: req.body?.email,
         role: req.body?.role,
         createdBy: userId,
-        creatorEmail: access.chat.user_id
-            ? userById.get(access.chat.user_id)?.email
-            : null,
+        creatorEmail:
+            (creatorProfile?.data as { email?: string | null } | null)?.email ??
+            null,
     });
     if (!result.ok) {
         if (result.kind === "validation")
@@ -668,7 +683,13 @@ chatRouter.post("/:chatId/generate-title", requireAuth, async (req, res) => {
             apiKeys: settings.api_keys,
         });
 
-        await db.from("chats").update({ title }).eq("id", chatId);
+        // Read the write. An ignored error answered 200 with the new title,
+        // so the sidebar renamed the chat and reverted on the next reload.
+        const { error: titleError } = await db
+            .from("chats")
+            .update({ title })
+            .eq("id", chatId);
+        if (titleError) return void sendInternalError(res, titleError);
 
         res.json({ title });
     } catch (err) {
@@ -893,6 +914,8 @@ chatRouter.post("/", requireAuth, async (req, res) => {
         userId,
         db,
         chatId,
+        "chat_messages",
+        userEmail,
     );
     const docAvailability = Object.entries(docIndex).map(([doc_id, info]) => ({
         doc_id,
@@ -1099,12 +1122,26 @@ chatRouter.post("/", requireAuth, async (req, res) => {
 
         if (!chatTitle && lastUser?.content) {
             const title = lastUser.content.slice(0, 120);
-            await db.from("chats").update({ title }).eq("id", chatId);
-            chatTitle = title;
-            if (shouldGenerateTitle && !stream.signal.aborted) {
-                write(
-                    `data: ${JSON.stringify({ type: "chat_title", chatId, title })}\n\n`,
-                );
+            // The SSE response is already streaming, so a failure here cannot
+            // become an HTTP error — but it must not be announced either: an
+            // ignored error pushed a chat_title frame the client rendered and
+            // the next reload undid. Log it and leave the chat untitled.
+            const { error: titleError } = await db
+                .from("chats")
+                .update({ title })
+                .eq("id", chatId);
+            if (titleError) {
+                console.error("[chat/stream] failed to save chat title", {
+                    chatId,
+                    message: titleError.message,
+                });
+            } else {
+                chatTitle = title;
+                if (shouldGenerateTitle && !stream.signal.aborted) {
+                    write(
+                        `data: ${JSON.stringify({ type: "chat_title", chatId, title })}\n\n`,
+                    );
+                }
             }
         }
         void enqueueChatTurnAudit(

--- a/backend/src/routes/chat.ts
+++ b/backend/src/routes/chat.ts
@@ -334,6 +334,13 @@ chatRouter.post("/:chatId/access", requireAuth, async (req, res) => {
               .eq("user_id", access.chat.user_id)
               .maybeSingle()
         : null;
+    // A failed read is not "the creator has no email". Swallowing the error
+    // sent `creatorEmail: null` into upsertContentGrant, which is what stops
+    // the creator being handed a guest grant on their own chat — so a
+    // transient database fault quietly created exactly the row the check
+    // exists to prevent.
+    if (creatorProfile?.error)
+        return void sendInternalError(res, creatorProfile.error);
     const result = await upsertContentGrant(db, {
         kind: "chat",
         resourceId: chatId,

--- a/backend/src/routes/documents.ts
+++ b/backend/src/routes/documents.ts
@@ -48,6 +48,15 @@ import {
 } from "../lib/documentDisplay";
 
 export const documentsRouter = Router();
+
+/**
+ * "Not found" is for rows the caller cannot see at all. A Viewer who can open
+ * a document but not change it gets a refusal that names the reason, so the
+ * UI stops telling people their document disappeared.
+ */
+const DOCUMENT_EDIT_FORBIDDEN =
+  "You do not have permission to edit content in this project.";
+
 const isDev = process.env.NODE_ENV !== "production";
 const devLog = (...args: Parameters<typeof console.log>) => {
   if (isDev) console.log(...args);
@@ -155,19 +164,33 @@ documentsRouter.get("/:documentId", requireAuth, async (req, res) => {
 });
 
 // DELETE /single-documents/:documentId
+// Scoped by the same rule as DELETE .../versions/:versionId, not by
+// `user_id = me`: that older scope meant an org admin could not remove a
+// colleague's document from a matter the firm owns, and — once account
+// deletion started blanking documents.user_id instead of destroying org
+// content — that NOBODY could remove a departed colleague's document.
 documentsRouter.delete("/:documentId", requireAuth, async (req, res) => {
   const userId = res.locals.userId as string;
+  const userEmail = res.locals.userEmail as string | undefined;
   const { documentId } = req.params;
   const db = createServerSupabase();
 
-  const { data: doc, error } = await db
+  const { data: doc } = await db
     .from("documents")
-    .select("id")
+    .select("id, user_id, project_id, org_id, workflow_id")
     .eq("id", documentId)
-    .eq("user_id", userId)
     .single();
-  if (error || !doc)
+  if (!doc) return void res.status(404).json({ detail: "Document not found" });
+  const access = await ensureDocAccess(doc, userId, userEmail, db);
+  if (!access.ok)
     return void res.status(404).json({ detail: "Document not found" });
+  if (
+    !creatorScopedAllowed(access, doc.user_id) &&
+    !(doc.workflow_id && can(access.projectRole, "content.edit"))
+  )
+    return void res.status(403).json({
+      detail: "You do not have permission to delete this document.",
+    });
 
   await deleteDocumentAndVersionFiles(db, documentId);
   res.status(204).send();
@@ -842,8 +865,12 @@ documentsRouter.patch(
     if (!doc)
       return void res.status(404).json({ detail: "Document not found" });
     const access = await ensureDocAccess(doc, userId, userEmail, db);
-    if (!access.ok || !can(access.projectRole, "content.edit"))
+    // A document a Viewer can open has not disappeared — say so, instead of
+    // reporting the read-only tier as a missing row.
+    if (!access.ok)
       return void res.status(404).json({ detail: "Document not found" });
+    if (!can(access.projectRole, "content.edit"))
+      return void res.status(403).json({ detail: DOCUMENT_EDIT_FORBIDDEN });
 
     const raw = req.body?.filename;
     const filename =
@@ -1103,8 +1130,10 @@ async function handleEditResolution(
   devLog(`[edit-resolution] fetched doc`, { doc, docErr });
   if (!doc) return void res.status(404).json({ detail: "Document not found" });
   const access = await ensureDocAccess(doc, userId, userEmail, db);
-  if (!access.ok || !can(access.projectRole, "content.edit"))
+  if (!access.ok)
     return void res.status(404).json({ detail: "Document not found" });
+  if (!can(access.projectRole, "content.edit"))
+    return void res.status(403).json({ detail: DOCUMENT_EDIT_FORBIDDEN });
 
   const active = await loadActiveVersion(documentId, db);
   const latestPath = active?.storage_path ?? null;

--- a/backend/src/routes/documents.ts
+++ b/backend/src/routes/documents.ts
@@ -913,12 +913,19 @@ documentsRouter.delete(
     if (!doc)
       return void res.status(404).json({ detail: "Document not found" });
     const access = await ensureDocAccess(doc, userId, userEmail, db);
-    if (
-      !access.ok ||
-      (!creatorScopedAllowed(access, doc.user_id) &&
-        !(doc.workflow_id && can(access.projectRole, "content.edit")))
-    )
+    // Same split as the whole-document DELETE above: a caller with no verdict
+    // is told the row does not exist, and a caller who can open the document
+    // but not delete this version is REFUSED by name. Collapsing both into
+    // 404 told a Viewer their version had vanished.
+    if (!access.ok)
       return void res.status(404).json({ detail: "Document not found" });
+    if (
+      !creatorScopedAllowed(access, doc.user_id) &&
+      !(doc.workflow_id && can(access.projectRole, "content.edit"))
+    )
+      return void res.status(403).json({
+        detail: "You do not have permission to delete this version.",
+      });
 
     const { data: versions, error: versionsErr } = await db
       .from("document_versions")

--- a/backend/src/routes/projects.ts
+++ b/backend/src/routes/projects.ts
@@ -23,7 +23,6 @@ import { convertedPdfKey } from "../lib/convert";
 import {
   checkProjectAccess,
   getOrgRole,
-  listUserOrgIds,
   normalizeEmail,
   resolveContentOrgId,
 } from "../lib/access";
@@ -55,6 +54,16 @@ import {
 import { ensureResourceAccessSummaries } from "../lib/resourceAccessSummary";
 
 export const projectsRouter = Router();
+
+/**
+ * A project the caller can open but not write to is not a missing project.
+ * Collapsing "you cannot see this" and "your role is read-only" into one 404
+ * told a Viewer their matter had vanished, so every write gate answers 404
+ * only when checkProjectAccess itself refuses, and 403 with an intentional
+ * message when the role is simply too low.
+ */
+const DOCS_ORGANIZE_FORBIDDEN =
+  "You do not have permission to organize documents in this project.";
 
 function normalizeOptionalString(value: unknown) {
   if (typeof value !== "string") return null;
@@ -475,21 +484,79 @@ async function handleProjectDirectorySearch(req: Request, res: Response) {
     }
   }
   // Third access branch (multi-tenant): projects in an org the caller belongs
-  // to are searchable, mirroring listAccessibleProjectIds and the overview
-  // RPCs — otherwise the document picker would hide org content the project
-  // list shows.
-  const orgIds = await listUserOrgIds(userId, db);
-  if (orgIds.length > 0) {
-    projectQueries.push(db.from("projects").select("*").in("org_id", orgIds));
+  // to are searchable, otherwise the document picker would hide org content
+  // the project list shows. Membership alone is not the verdict, though:
+  // every other path resolves the project through checkProjectAccess /
+  // project_access_role, which return "no access" for a per-project deny
+  // override. Without the same filter here the picker hands a walled-off
+  // member the matter's name, cm_number and its document filenames.
+  const { data: membershipRows, error: membershipError } = await db
+    .from("org_members")
+    .select("org_id, role")
+    .eq("user_id", userId);
+  if (membershipError) return void sendInternalError(res, membershipError);
+  const orgRoleByOrgId = new Map<string, string>();
+  for (const row of (membershipRows ?? []) as {
+    org_id?: string | null;
+    role?: string | null;
+  }[]) {
+    if (row.org_id) orgRoleByOrgId.set(row.org_id, row.role ?? "");
   }
-  const projectResults = await Promise.all(projectQueries);
-  const projectError = projectResults.find((result) => result.error)?.error;
+  const orgIds = [...orgRoleByOrgId.keys()];
+  const [projectResults, orgProjectsResult] = await Promise.all([
+    Promise.all(projectQueries),
+    orgIds.length > 0
+      ? db.from("projects").select("*").in("org_id", orgIds)
+      : Promise.resolve({
+          data: [] as Record<string, unknown>[],
+          error: null,
+        }),
+  ]);
+  const projectError =
+    projectResults.find((result) => result.error)?.error ??
+    orgProjectsResult.error;
   if (projectError)
     return void sendInternalError(res, projectError);
   const projectsById = new Map<string, Record<string, unknown>>();
   for (const result of projectResults) {
     for (const project of result.data ?? []) {
       projectsById.set(project.id as string, project);
+    }
+  }
+  const orgProjects = (orgProjectsResult.data ?? []) as Record<
+    string,
+    unknown
+  >[];
+  if (orgProjects.length > 0) {
+    // One batched read for the whole page, not a verdict per row: this is a
+    // filter over a result set and must not become an N+1. Mirrors
+    // listOrgResources, including its exemptions — the creator and org
+    // admins keep Owner and cannot be denied.
+    const candidateIds = orgProjects
+      .map((project) => project.id)
+      .filter((id): id is string => typeof id === "string");
+    const { data: denialRows, error: denialError } = await db
+      .from("project_org_access_overrides")
+      .select("project_id")
+      .in("project_id", candidateIds)
+      .eq("user_id", userId)
+      .eq("role", "deny");
+    // Fail closed: an unreadable override table must hide rows, never reveal
+    // them.
+    if (denialError) return void sendInternalError(res, denialError);
+    const deniedProjectIds = new Set(
+      ((denialRows ?? []) as { project_id?: string | null }[])
+        .map((row) => row.project_id)
+        .filter((id): id is string => !!id),
+    );
+    for (const project of orgProjects) {
+      const projectId = project.id as string;
+      const orgId = project.org_id as string | null;
+      const isCreator = project.user_id === userId;
+      const isOrgAdmin = !!orgId && orgRoleByOrgId.get(orgId) === "admin";
+      if (!isCreator && !isOrgAdmin && deniedProjectIds.has(projectId))
+        continue;
+      projectsById.set(projectId, project);
     }
   }
   const accessibleProjectIds = [...projectsById.keys()];
@@ -1177,8 +1244,10 @@ projectsRouter.post(
     const db = createServerSupabase();
 
     const access = await checkProjectAccess(projectId, userId, userEmail, db);
-    if (!access.ok || !can(access.projectRole, "docs.organize"))
+    if (!access.ok)
       return void res.status(404).json({ detail: "Project not found" });
+    if (!can(access.projectRole, "docs.organize"))
+      return void res.status(403).json({ detail: DOCS_ORGANIZE_FORBIDDEN });
 
     // Adding-by-id pulls a doc into the project — only the doc's owner
     // is allowed to do that, so other people's standalone docs can't be
@@ -1367,8 +1436,10 @@ projectsRouter.patch(
   const db = createServerSupabase();
 
   const access = await checkProjectAccess(projectId, userId, userEmail, db);
-  if (!access.ok || !can(access.projectRole, "docs.organize"))
+  if (!access.ok)
     return void res.status(404).json({ detail: "Project not found" });
+  if (!can(access.projectRole, "docs.organize"))
+    return void res.status(403).json({ detail: DOCS_ORGANIZE_FORBIDDEN });
 
   const { data: doc } = await db
     .from("documents")
@@ -1509,8 +1580,10 @@ projectsRouter.post(
     // yet. It therefore needs the same docs.organize gate its sibling folder
     // routes declare; without it a viewer — whose whole tier is read-only —
     // could POST an arbitrary nested folder tree into someone else's project.
-    if (!access.ok || !can(access.projectRole, "docs.organize"))
+    if (!access.ok)
       return void res.status(404).json({ detail: "Project not found" });
+    if (!can(access.projectRole, "docs.organize"))
+      return void res.status(403).json({ detail: DOCS_ORGANIZE_FORBIDDEN });
     if (baseFolderId) {
       const parent = await loadProjectFolder(db, projectId, baseFolderId);
       if (!parent)
@@ -1552,8 +1625,10 @@ projectsRouter.post("/:projectId/folders", requireAuth, async (req, res) => {
 
   const db = createServerSupabase();
   const access = await checkProjectAccess(projectId, userId, userEmail, db);
-  if (!access.ok || !can(access.projectRole, "docs.organize"))
+  if (!access.ok)
     return void res.status(404).json({ detail: "Project not found" });
+  if (!can(access.projectRole, "docs.organize"))
+    return void res.status(403).json({ detail: DOCS_ORGANIZE_FORBIDDEN });
 
   // Verify parent folder belongs to this project
   if (parent_folder_id) {
@@ -1598,8 +1673,10 @@ projectsRouter.patch(
   // Re-shaping the folder tree is member work, alongside the documents it
   // holds — Will's review put "organize documents and folders" on one line.
   const access = await checkProjectAccess(projectId, userId, userEmail, db);
-  if (!access.ok || !can(access.projectRole, "docs.organize"))
+  if (!access.ok)
     return void res.status(404).json({ detail: "Project not found" });
+  if (!can(access.projectRole, "docs.organize"))
+    return void res.status(403).json({ detail: DOCS_ORGANIZE_FORBIDDEN });
 
     const updates: Record<string, unknown> = {
       updated_at: new Date().toISOString(),
@@ -1663,8 +1740,10 @@ projectsRouter.delete(
   // member may already do. Gating the folder higher bought no safety, only a
   // confusing extra tier.
   const access = await checkProjectAccess(projectId, userId, userEmail, db);
-  if (!access.ok || !can(access.projectRole, "docs.organize"))
+  if (!access.ok)
     return void res.status(404).json({ detail: "Project not found" });
+  if (!can(access.projectRole, "docs.organize"))
+    return void res.status(403).json({ detail: DOCS_ORGANIZE_FORBIDDEN });
 
   const { data: allFolders, error: foldersError } = await db
     .from("project_subfolders")
@@ -1732,8 +1811,10 @@ projectsRouter.patch(
 
   const db = createServerSupabase();
   const access = await checkProjectAccess(projectId, userId, userEmail, db);
-  if (!access.ok || !can(access.projectRole, "docs.organize"))
+  if (!access.ok)
     return void res.status(404).json({ detail: "Project not found" });
+  if (!can(access.projectRole, "docs.organize"))
+    return void res.status(403).json({ detail: DOCS_ORGANIZE_FORBIDDEN });
 
   if (folder_id) {
     const folder = await loadProjectFolder(db, projectId, folder_id);

--- a/backend/src/routes/projects.ts
+++ b/backend/src/routes/projects.ts
@@ -459,9 +459,8 @@ async function handleProjectDirectorySearch(req: Request, res: Response) {
   const db = createServerSupabase();
   const normalizedUserEmail = userEmail?.trim().toLowerCase();
 
-  const projectQueries = [
-    db.from("projects").select("*").eq("user_id", userId),
-  ];
+  const createdQuery = db.from("projects").select("*").eq("user_id", userId);
+  const projectQueries = [createdQuery];
   if (normalizedUserEmail) {
     // Direct access now lives in project_access_grants (one row per
     // recipient, with a role) rather than the roleless shared_with array, so
@@ -518,7 +517,20 @@ async function handleProjectDirectorySearch(req: Request, res: Response) {
   if (projectError)
     return void sendInternalError(res, projectError);
   const projectsById = new Map<string, Record<string, unknown>>();
-  for (const result of projectResults) {
+  const [createdResult, ...grantResults] = projectResults;
+  // The "I created it" branch is NOT a verdict on its own. A creator who has
+  // since LEFT the organization keeps the projects.user_id row, but
+  // checkProjectAccess — which every other read path uses — answers "no
+  // access" for them, so the picker was the one surface still offering an
+  // org matter that 404s the moment it is opened. An org project is only
+  // theirs to see while they are still in that org; the org branch below
+  // re-admits it (with the deny override applied) when they are.
+  for (const project of createdResult?.data ?? []) {
+    const orgId = project.org_id as string | null | undefined;
+    if (orgId && !orgRoleByOrgId.has(orgId)) continue;
+    projectsById.set(project.id as string, project);
+  }
+  for (const result of grantResults) {
     for (const project of result.data ?? []) {
       projectsById.set(project.id as string, project);
     }
@@ -532,13 +544,16 @@ async function handleProjectDirectorySearch(req: Request, res: Response) {
     // filter over a result set and must not become an N+1. Mirrors
     // listOrgResources, including its exemptions — the creator and org
     // admins keep Owner and cannot be denied.
-    const candidateIds = orgProjects
-      .map((project) => project.id)
-      .filter((id): id is string => typeof id === "string");
+    // Scoped by ORG, not by an .in() over every candidate project id: that
+    // list grows with the firm's matters and is spliced verbatim into the
+    // PostgREST query string, so a large tenant sent a URL past the server's
+    // request-line limit and the read failed (fail-closed, so the picker went
+    // blank). org_id is bounded by the caller's memberships, which is the
+    // same shape listOrgResources uses.
     const { data: denialRows, error: denialError } = await db
       .from("project_org_access_overrides")
       .select("project_id")
-      .in("project_id", candidateIds)
+      .in("org_id", orgIds)
       .eq("user_id", userId)
       .eq("role", "deny");
     // Fail closed: an unreadable override table must hide rows, never reveal

--- a/backend/src/routes/tabular.ts
+++ b/backend/src/routes/tabular.ts
@@ -507,8 +507,14 @@ tabularRouter.post("/", requireAuth, async (req, res) => {
             userEmail,
             db,
         );
-        if (!access.ok || !can(access.projectRole, "content.edit"))
+        // A Viewer can open the project, so "not found" would be a lie; the
+        // read-only tier gets a refusal that names itself.
+        if (!access.ok)
             return void res.status(404).json({ detail: "Project not found" });
+        if (!can(access.projectRole, "content.edit"))
+            return void res.status(403).json({
+                detail: "You do not have permission to write in this project.",
+            });
     }
     const allowedDocumentIds = Array.isArray(document_ids)
         ? await filterAccessibleDocumentIds(document_ids, userId, userEmail, db)
@@ -1262,8 +1268,12 @@ tabularRouter.post(
         if (reviewError || !review)
             return void res.status(404).json({ detail: "Review not found" });
         const access = await ensureReviewAccess(review, userId, userEmail, db);
-        if (!access.ok || !can(access.projectRole, "content.edit"))
+        if (!access.ok)
             return void res.status(404).json({ detail: "Review not found" });
+        if (!can(access.projectRole, "content.edit"))
+            return void res
+                .status(403)
+                .json({ detail: "Only a review editor can regenerate cells" });
         if (isReviewGenerationRunning(review)) {
             return void res.status(409).json({
                 code: "review_running",

--- a/backend/src/routes/tabular.ts
+++ b/backend/src/routes/tabular.ts
@@ -92,6 +92,14 @@ import { normalizeSearchTerm } from "../lib/search";
 import { parseTabularReviewSort } from "../lib/sort";
 
 export const tabularRouter = Router();
+
+/**
+ * "Not found" is for reviews the caller cannot see at all. A Viewer who can
+ * open a review but not change it gets a refusal that names the reason, so
+ * the UI stops telling people their review disappeared.
+ */
+export const REVIEW_EDIT_FORBIDDEN =
+    "You do not have permission to edit content in this review.";
 const TABULAR_GENERATION_CONCURRENCY = 3;
 // The lease timings live in lib/tabular/tabular.shared.ts because the queue
 // workers hold the same lease on the async path and must agree on them.
@@ -1576,6 +1584,8 @@ tabularRouter.post("/:reviewId/generate", requireAuth, async (req, res) => {
     if (!prepared.ok) {
         if (prepared.kind === "not_found")
             return void res.status(404).json({ detail: "Review not found" });
+        if (prepared.kind === "forbidden")
+            return void res.status(403).json({ detail: REVIEW_EDIT_FORBIDDEN });
         if (prepared.kind === "no_columns")
             return void res
                 .status(400)
@@ -1903,6 +1913,14 @@ tabularRouter.get(
                 return void res
                     .status(404)
                     .json({ detail: "Review not found" });
+            // Same gate as the POST it resumes: the reconnect stream exists
+            // to rejoin a run this caller was entitled to start, and a Viewer
+            // never was. They read the finished cells through the review
+            // itself, not through the generation channel.
+            if (prepared.kind === "forbidden")
+                return void res
+                    .status(403)
+                    .json({ detail: REVIEW_EDIT_FORBIDDEN });
             if (prepared.kind === "no_columns")
                 return void res
                     .status(400)
@@ -2378,8 +2396,12 @@ tabularRouter.post("/:reviewId/chat", requireAuth, async (req, res) => {
         userEmail,
         db,
     );
-    if (!reviewAccess.ok || !can(reviewAccess.projectRole, "content.edit"))
+    // A viewer can open this review — saying it does not exist is a lie the
+    // UI then repeats. Only a caller with no verdict at all gets the 404.
+    if (!reviewAccess.ok)
         return void res.status(404).json({ detail: "Review not found" });
+    if (!can(reviewAccess.projectRole, "content.edit"))
+        return void res.status(403).json({ detail: REVIEW_EDIT_FORBIDDEN });
 
     // Fetch all cells and logical review rows for this review.
     const { data: cells } = await db

--- a/backend/src/routes/uploadSessions.ts
+++ b/backend/src/routes/uploadSessions.ts
@@ -184,9 +184,16 @@ export async function validateDestinationAccess(
       const projectId = destination.project_id as string;
       const access = await checkProjectAccess(projectId, userId, userEmail, db);
       // Uploading into a project is content work: a viewer can open the
-      // project but must not be able to open an upload session into it.
-      if (!access.ok || !can(access.projectRole, "content.edit")) {
+      // project but must not be able to open an upload session into it. That
+      // viewer is refused, not told the project vanished.
+      if (!access.ok) {
         res.status(404).json({ detail: "Project not found" });
+        return false;
+      }
+      if (!can(access.projectRole, "content.edit")) {
+        res.status(403).json({
+          detail: "You do not have permission to write in this project.",
+        });
         return false;
       }
       const folderIds = Array.from(

--- a/backend/src/routes/uploadSessions.ts
+++ b/backend/src/routes/uploadSessions.ts
@@ -276,12 +276,24 @@ export async function validateDestinationAccess(
       access.ok &&
       (creatorScopedAllowed(access, document.user_id) ||
         (Boolean(document.workflow_id) && canEditContent));
-    if (
-      !access.ok ||
-      !canEditContent ||
-      (manifest.purpose === "document_version_replace" && !canReplace)
-    ) {
+    // Split, the way the project branch above already splits: no verdict at
+    // all is a 404, and a caller who can open the document but not write to
+    // it is refused by name. Collapsing both into 404 told every Viewer
+    // their document had disappeared the moment they tried to upload.
+    if (!access.ok) {
       res.status(404).json({ detail: "Document not found" });
+      return false;
+    }
+    if (!canEditContent) {
+      res.status(403).json({
+        detail: "You do not have permission to edit content in this project.",
+      });
+      return false;
+    }
+    if (manifest.purpose === "document_version_replace" && !canReplace) {
+      res.status(403).json({
+        detail: "You do not have permission to replace this version.",
+      });
       return false;
     }
     if (manifest.purpose === "document_version_create") return true;

--- a/backend/src/routes/user.ts
+++ b/backend/src/routes/user.ts
@@ -47,6 +47,7 @@ import {
     deleteAllUserTabularReviews,
     deleteUserAccountData,
     deleteUserProjects,
+    listOrgsBlockingAccountDeletion,
 } from "../lib/userDataCleanup";
 import {
     acceptInvitation,
@@ -1773,15 +1774,38 @@ userRouter.delete(
         const token = res.locals.token as string | undefined;
         const db = createServerSupabase();
         try {
+            // ORGANIZATIONS FIRST. An account that is the only admin of an
+            // organization which still has members or content cannot be
+            // deleted: promoting an arbitrary successor hands a firm's
+            // matters to whoever joined first (and silently clears their
+            // `deny` overrides), while removing the member outright is
+            // refused by org_member_protect_resource_ownership and leaves the
+            // organization memberless, invisible and undeletable. Answer 409
+            // and let the user choose a successor. This check runs BEFORE the
+            // enqueue so nothing is scheduled, revoked, or destroyed.
+            const blockingOrgs = await listOrgsBlockingAccountDeletion(
+                db,
+                userId,
+            );
+            if (blockingOrgs.length > 0) {
+                const names = blockingOrgs.map((org) => org.name).join(", ");
+                return void res.status(409).json({
+                    code: "org_successor_required",
+                    detail: `You are the only admin of ${names}. Make another member an admin, or delete the organization, before deleting your account.`,
+                    organizations: blockingOrgs,
+                });
+            }
+
             // DATA FIRST, AUTH LAST — main's ordering, kept.
             //
-            // documents.user_id references auth.users ON DELETE CASCADE (and
-            // document_versions cascades from documents), so deleting the auth
-            // user first destroys every row that records where this account's
-            // files live. The cascade would then find nothing to clean up and
-            // the objects would be orphaned in storage forever. The auth user
-            // is therefore deleted by the job, as its final step, once the
-            // data is actually gone.
+            // documents.user_id references auth.users ON DELETE SET NULL (an
+            // organization's documents outlive their uploader), so deleting
+            // the auth user first would not erase this account's rows — it
+            // would anonymise them, leaving personal documents with a null
+            // user_id that the by-user deletes no longer match and whose
+            // storage objects nothing would ever sweep. The auth user is
+            // therefore deleted by the job, as its final step, once the data
+            // is actually gone.
             //
             // What the user experiences is unchanged: their sessions are
             // revoked here, immediately, so the account is unusable from the

--- a/backend/src/routes/user.ts
+++ b/backend/src/routes/user.ts
@@ -48,6 +48,7 @@ import {
     deleteUserAccountData,
     deleteUserProjects,
     listOrgsBlockingAccountDeletion,
+    type AccountDeletionOrgBlocker,
 } from "../lib/userDataCleanup";
 import {
     acceptInvitation,
@@ -1763,6 +1764,36 @@ userRouter.patch(
     },
 );
 
+/**
+ * Turn the sole-admin blockers into instructions the user can actually act
+ * on. The two reasons need DIFFERENT actions — appointing a successor fixes
+ * an org that still has members, and does nothing for an org whose only
+ * problem is that it still owns matters — so a single "make another member
+ * an admin" sentence sent the second group off to look for members who do
+ * not exist. A mixed batch gets both sentences, each naming its own orgs.
+ */
+export function describeAccountDeletionBlockers(
+    blockers: AccountDeletionOrgBlocker[],
+): string {
+    const named = (reason: AccountDeletionOrgBlocker["reason"]) =>
+        blockers
+            .filter((blocker) => blocker.reason === reason)
+            .map((blocker) => blocker.name)
+            .join(", ");
+    const sentences: string[] = [];
+    const withMembers = named("members");
+    if (withMembers)
+        sentences.push(
+            `You are the only admin of ${withMembers}. Make another member an admin, or delete the organization, before deleting your account.`,
+        );
+    const withContent = named("content");
+    if (withContent)
+        sentences.push(
+            `You are the only admin of ${withContent}, which still owns content. Delete or move the organization's projects, workflows, documents and reviews, or delete the organization, before deleting your account.`,
+        );
+    return sentences.join(" ");
+}
+
 // DELETE /user/account
 userRouter.delete(
     "/account",
@@ -1788,10 +1819,9 @@ userRouter.delete(
                 userId,
             );
             if (blockingOrgs.length > 0) {
-                const names = blockingOrgs.map((org) => org.name).join(", ");
                 return void res.status(409).json({
                     code: "org_successor_required",
-                    detail: `You are the only admin of ${names}. Make another member an admin, or delete the organization, before deleting your account.`,
+                    detail: describeAccountDeletionBlockers(blockingOrgs),
                     organizations: blockingOrgs,
                 });
             }

--- a/backend/src/routes/wordChat.ts
+++ b/backend/src/routes/wordChat.ts
@@ -990,6 +990,7 @@ wordChatRouter.post("/", requireAuth, async (req, res) => {
     db,
     persistChat ? chatId : null,
     "word_chat_messages",
+    userEmail,
   );
   const activeDocumentText = parsedDocumentContext.documentContext;
   if (activeDocumentText !== undefined) {

--- a/backend/src/routes/workflows.ts
+++ b/backend/src/routes/workflows.ts
@@ -1557,12 +1557,24 @@ workflowsRouter.delete(
         userId: shareId,
       });
       if (!result.ok) return void sendInternalError(res, result.detail);
+      if (!result.removed)
+        return void res
+          .status(404)
+          .json({ detail: "Access override not found" });
     } else {
-      await db
+      // Read the result. Ignoring it made a failed delete and an unknown
+      // share id indistinguishable from a real revocation: both answered
+      // 204, so the client removed the row from its list while the person
+      // it named kept access. Mirrors DELETE /projects/:id/access/:email.
+      const { data: removed, error } = await db
         .from("workflow_shares")
         .delete()
         .eq("id", shareId)
-        .eq("workflow_id", workflowId);
+        .eq("workflow_id", workflowId)
+        .select("id");
+      if (error) return void sendInternalError(res, error);
+      if (((removed ?? []) as unknown[]).length === 0)
+        return void res.status(404).json({ detail: "Access grant not found" });
     }
     res.status(204).send();
   }),
@@ -1620,6 +1632,12 @@ workflowsRouter.post(
         return void res.status(400).json({
           detail: "role must be owner, editor, viewer or deny",
         });
+      // Validate EVERY target before writing ANY override. Interleaving the
+      // two loops meant a rejected third email — a non-member, the creator,
+      // an admin — returned 400 with the first two overrides already
+      // persisted: the caller read "nothing happened" while access had
+      // silently changed for two people.
+      const targets: { userId: string }[] = [];
       for (const email of normalizedEmails) {
         const target = await findOrgMemberByEmail(db, orgId, email);
         if (!target.ok) {
@@ -1635,11 +1653,16 @@ workflowsRouter.post(
           return void res.status(400).json({
             detail: "Organization admins always have owner access",
           });
+        targets.push({ userId: target.member.userId });
+      }
+      // Validation is now complete, so only a database failure can still
+      // stop this half-way — and that answers 500, not a misleading 400.
+      for (const target of targets) {
         const result = await setOrgAccessOverride(db, {
           kind: "workflow",
           resourceId: workflowId,
           orgId,
-          userId: target.member.userId,
+          userId: target.userId,
           role,
           assignedBy: userId,
         });

--- a/backend/src/routes/workflows.ts
+++ b/backend/src/routes/workflows.ts
@@ -39,7 +39,7 @@ import {
   findOrgMemberByEmail,
   isOrgAssignableRole,
   listOrgAccessPeople,
-  setOrgAccessOverride,
+  setOrgAccessOverrides,
 } from "../lib/orgAccessOverrides";
 import { convertedPdfKey } from "../lib/convert";
 import { copyFile, storageKey } from "../lib/storage";
@@ -1116,7 +1116,15 @@ workflowsRouter.post(
 
     const { data: sourceDocuments, error: documentsError } = await db
       .from("documents")
-      .select("id, user_id, project_id, workflow_id, current_version_id")
+      // org_id and workflow_id are part of the VERDICT, not decoration:
+      // ensureDocAccess falls through project -> workflow -> org, so a
+      // document selected without them looks container-less and is refused.
+      // Omitting org_id made every organization-library file unattachable —
+      // "One or more files could not be found" for a file the caller is
+      // looking straight at.
+      .select(
+        "id, user_id, project_id, org_id, workflow_id, current_version_id",
+      )
       .in("id", documentIds);
     if (documentsError) return void sendInternalError(res, documentsError);
     if (!sourceDocuments || sourceDocuments.length !== documentIds.length) {
@@ -1655,19 +1663,20 @@ workflowsRouter.post(
           });
         targets.push({ userId: target.member.userId });
       }
-      // Validation is now complete, so only a database failure can still
-      // stop this half-way — and that answers 500, not a misleading 400.
-      for (const target of targets) {
-        const result = await setOrgAccessOverride(db, {
-          kind: "workflow",
-          resourceId: workflowId,
-          orgId,
-          userId: target.userId,
-          role,
-          assignedBy: userId,
-        });
-        if (!result.ok) return void sendInternalError(res, result.detail);
-      }
+      // Validation is complete, so only a database failure can still stop
+      // this — and it must not stop it HALF WAY. One bulk upsert is one
+      // statement: the org-membership triggers on the override table can
+      // still refuse a row, and when they do the whole batch rolls back
+      // instead of leaving the people ahead of the refusal already granted.
+      const written = await setOrgAccessOverrides(db, {
+        kind: "workflow",
+        resourceId: workflowId,
+        orgId,
+        userIds: targets.map((target) => target.userId),
+        role,
+        assignedBy: userId,
+      });
+      if (!written.ok) return void sendInternalError(res, written.detail);
       return void res.status(204).send();
     }
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -31,6 +31,33 @@ not evidence that an older database has completed every upgrade step. The
 repository's schema-drift CI separately checks that its pinned historical
 baseline converges with the fresh schema after all later migrations run.
 
+### After the organization-access upgrade: `tabular_review_legacy_shares`
+
+`20260904_02_migrate_legacy_sharing.sql` converts the old roleless
+`shared_with` arrays into real access grants. One shape has nowhere to go: a
+tabular review that lives INSIDE a project now inherits access from that
+project, so a share on the review alone cannot be reproduced without handing
+the recipient the whole matter. Rather than widen access silently or discard
+it, the migration copies those `(review, project, email)` triples into
+`public.tabular_review_legacy_shares` and drops nothing else.
+
+It is populated once, by that migration, on an upgraded deployment only —
+fresh installs create it empty and it is never written again at runtime. The
+table carries no foreign keys, so the record survives the review or project
+being deleted. It is `service_role`-only; read it with the service key:
+
+```sql
+select l.email, l.project_id, l.tabular_review_id, l.archived_at
+from public.tabular_review_legacy_shares l
+order by l.archived_at desc;
+```
+
+Each row is a person who could see that review before the upgrade and cannot
+now. For each one, decide deliberately: grant them access to the project (or
+add them to the organization) if they should still have it, and otherwise do
+nothing. The table is a record, not a queue — nothing reads it, and rows may
+be deleted once every recipient has been dealt with.
+
 Apply the workflow catalog migration before deploying the matching backend
 release, then run the dedicated ingestion job from the built backend artifact:
 

--- a/e2e/chat-management.spec.ts
+++ b/e2e/chat-management.spec.ts
@@ -10,6 +10,7 @@
  */
 import { test, expect, type Page } from "@playwright/test";
 import { hasLlmKey, LLM_SKIP_REASON } from "./llm";
+import { createProject } from "./projects";
 
 /* ─── Helpers ────────────────────────────────────────────────────────────────── */
 
@@ -200,8 +201,15 @@ test("rename chat: sidebar rename interaction updates the title", async ({ page 
     // ── Step 8: assert the new title appears in the sidebar ──────────────────────
     // ChatHistoryContext.renameChatFn optimistically updates the chat title in state.
     // SidebarChatItem re-renders the title button with the new text.
+    //
+    // exact: true is load-bearing. The row's menu trigger now carries
+    // aria-label="Actions for <title>" (an a11y fix worth keeping), and
+    // Playwright's default name matching is a case-insensitive SUBSTRING
+    // match — so a bare { name: newTitle } resolves to the title button AND
+    // its sibling trigger, and the assertion dies on a strict-mode violation
+    // rather than on anything real.
     await expect(
-        page.getByRole("button", { name: newTitle })
+        page.getByRole("button", { name: newTitle, exact: true })
     ).toBeVisible({ timeout: 10_000 });
 });
 
@@ -276,7 +284,12 @@ test("delete chat: sidebar delete action removes the chat from history", async (
     await renameInput.press("Enter");
 
     // The renamed chat's title button now uniquely identifies its row.
-    const targetTitle = page.getByRole("button", { name: uniqueTitle });
+    // exact: true — the row's menu trigger is labelled "Actions for <title>",
+    // which Playwright's default substring name matching also hits.
+    const targetTitle = page.getByRole("button", {
+        name: uniqueTitle,
+        exact: true,
+    });
     await expect(targetTitle).toBeVisible({ timeout: 10_000 });
     // The row wrapper that contains that title button (for reaching its menu).
     const targetRow = page
@@ -308,40 +321,20 @@ test("project assistant: create a new chat and submit a question", async ({ page
     // headroom beyond the 30s default.
     test.setTimeout(120_000);
 
-    // ── Step 1: navigate to projects ─────────────────────────────────────────────
-    await page.goto("/projects");
-    await expect(page).toHaveURL(/\/projects/, { timeout: 10_000 });
-
-    // ── Step 2: open the "New project" modal ─────────────────────────────────────
-    const createBtn = page.getByRole("button", { name: "New project" });
-    await expect(createBtn).toBeVisible({ timeout: 10_000 });
-    await createBtn.click();
-
-    // ── Step 3: fill in the project name ─────────────────────────────────────────
-    // NewProjectModal.tsx line 203: disabled={!name.trim() || loading}
-    // PDF upload is optional — we omit it to keep this test focused on routing.
-    const nameInput = page.getByPlaceholder("Project name");
-    await expect(nameInput).toBeVisible({ timeout: 5_000 });
+    // ── Steps 1-4: create a project ──────────────────────────────────────────────
+    // The whole wizard (Details → Access → Add Documents) lives in one shared
+    // helper, e2e/projects.ts, so a step added to NewProjectModal cannot leave
+    // this spec behind — which is exactly what happened when the Access step
+    // landed: a single "Next" left this test on step two, and the
+    // /create project|creating/i primary it then waited for was two clicks
+    // away. No document is attached; this test is about routing.
+    // NewProjectModal.handleSubmit does NOT navigate itself — it calls
+    // onCreated() then onClose(). ProjectsOverview.onCreated inserts the row
+    // AND router.push(`/projects/${p.id}`), so the helper's waitForURL is what
+    // confirms creation; the name never re-appears in a list to click.
     const projectName = `E2E Chat Route ${Date.now()}`;
-    await nameInput.fill(projectName);
-
-    // NewProjectModal is a two-step wizard ("Details" → "Add Documents"); the
-    // "Create project" submit button only exists on the second step.
-    await page.getByRole("button", { name: "Next", exact: true }).click();
-
-    // ── Step 4: submit the form ──────────────────────────────────────────────────
-    // NewProjectModal.handleSubmit does NOT navigate itself — it calls onCreated()
-    // then onClose().  ProjectsOverview.onCreated (ProjectsOverview.tsx:475-478)
-    // inserts the row AND router.push(`/projects/${p.id}`), so the app navigates
-    // straight to the project detail page; the name never re-appears in a list to
-    // click.  Wait for that navigation instead of asserting a list row.
-    const submitBtn = page.getByRole("button", {
-        name: /create project|creating/i,
-    });
-    const projectUrl = /\/projects\/[^/]+$/;
-    await expect(submitBtn).toBeEnabled({ timeout: 10_000 });
-    await submitBtn.click();
-    await page.waitForURL(projectUrl, { timeout: 20_000 });
+    await createProject(page, projectName);
+    await expect(page).toHaveURL(/\/projects\/[^/]+$/);
 
     // ── Step 6: open the assistant tab and reach the empty-state "Create" ────────
     // The project assistant is now a nested route (/projects/[id]/assistant), not a

--- a/e2e/critical-path.spec.ts
+++ b/e2e/critical-path.spec.ts
@@ -8,6 +8,7 @@
  */
 import { test, expect, type Page } from "@playwright/test";
 import { hasLlmKey, LLM_SKIP_REASON } from "./llm";
+import { createProject } from "./projects";
 import path from "path";
 
 const PDF_FIXTURE = path.join(__dirname, "fixtures/test.pdf");
@@ -65,49 +66,16 @@ test("create project, upload PDF, ask a question and receive a response", async 
        so set it here. */
     test.setTimeout(120_000);
 
-    /* ── Step 1: navigate to projects ─────────────────────────────────────── */
-    await page.goto("/projects");
-    await expect(page).toHaveURL(/\/projects/);
-
-    /* ── Step 2: open the "New project" modal ────────────────────────────── */
-    /* The Plus icon button in the header has aria-label="New project" */
-    const createBtn = page.getByRole("button", { name: "New project" });
-    await expect(createBtn).toBeVisible({ timeout: 10_000 });
-    await createBtn.click();
-
-    /* ── Step 3: fill in the project name ─────────────────────────────────── */
-    const nameInput = page.getByPlaceholder("Project name");
-    await expect(nameInput).toBeVisible({ timeout: 5_000 });
-
+    /* ── Steps 1-5: create a project with the PDF attached ────────────────── */
+    /* The wizard (Details → Access → Add Documents) is driven from one shared
+       helper, e2e/projects.ts, so a new step cannot be added to the modal
+       without this spec picking it up. This spec used to walk the modal
+       itself, clicking a single "Next" and then a `button[type="submit"]`;
+       the Access step stranded it on step two and the final primary is a
+       type="button", so both halves were wrong. */
     const projectName = `E2E Test Project ${Date.now()}`;
-    await nameInput.fill(projectName);
-
-    /* ── Step 4: advance to "Add Documents" and upload a PDF ──────────────── */
-    /* NewProjectModal is a two-step wizard; the details step's primary action is
-       a plain "Next" and only the documents step carries the file input. */
-    await page.getByRole("button", { name: "Next", exact: true }).click();
-
-    const uploadBtn = page.getByRole("button", { name: /^Upload/ });
-    /* We need to trigger the hidden file input; intercept the chooser */
-    const fileChooserPromise = page.waitForEvent("filechooser");
-    await uploadBtn.click();
-    const fileChooser = await fileChooserPromise;
-    await fileChooser.setFiles(PDF_FIXTURE);
-
-    /* The button label should update to reflect the queued file */
-    await expect(
-        page.getByRole("button", { name: /^Upload \(1\)/ }),
-    ).toBeVisible({ timeout: 5_000 });
-
-    /* ── Step 5: submit the form ──────────────────────────────────────────── */
-    /* The PDF upload runs inside NewProjectModal.handleSubmit
-       (await Promise.all([uploadProjectDocument(...)])) BEFORE onCreated fires,
-       so the "Creating…" button state can persist for many seconds while the
-       file uploads. ProjectsOverview.onCreated then router.push()es to the new
-       project page, so wait for that navigation (generously, to cover the
-       upload). */
-    await page.click('button[type="submit"]');
-    await page.waitForURL(/\/projects\/[^/]+$/, { timeout: 30_000 });
+    await createProject(page, projectName, PDF_FIXTURE);
+    await expect(page).toHaveURL(/\/projects\/[^/]+$/);
 
     /* ── Step 6: open the project assistant ───────────────────────────────── */
     /* We're already on /projects/[id] (Documents tab by default). The project

--- a/e2e/project-management.spec.ts
+++ b/e2e/project-management.spec.ts
@@ -13,76 +13,9 @@
  */
 import { test, expect } from "@playwright/test";
 import path from "path";
+import { createProject } from "./projects";
 
 const PDF_FIXTURE = path.join(__dirname, "fixtures/test.pdf");
-
-// ─── Shared helper ────────────────────────────────────────────────────────────
-
-/**
- * Creates a new project via the "New project" modal and waits until
- * NewProjectModal's onCreated handler redirects to /projects/<id>.
- *
- * Pass `filePath` to also upload a document during creation.
- */
-async function createProject(
-    page: import("@playwright/test").Page,
-    projectName: string,
-    filePath?: string,
-) {
-    /* Creation is a navigation + modal wizard + (optionally) a file upload; the
-       per-test `{ timeout }` option passed to test() is silently ignored by
-       Playwright (that object only accepts tag/annotation), so raise the budget
-       here, where the slow work happens, for every caller. */
-    test.setTimeout(60_000);
-
-    await page.goto("/projects");
-    await expect(page).toHaveURL(/\/projects/, { timeout: 10_000 });
-
-    /* The Plus icon button in the header has aria-label="New project" */
-    const createBtn = page.getByRole("button", { name: "New project" });
-    await expect(createBtn).toBeVisible({ timeout: 10_000 });
-    await createBtn.click();
-
-    const nameInput = page.getByPlaceholder("Project name");
-    await expect(nameInput).toBeVisible({ timeout: 5_000 });
-    await nameInput.fill(projectName);
-
-    /* NewProjectModal is a three-step wizard: Details, Access, then Add
-       Documents. Project creation happens only from the final step. */
-    await page.getByRole("button", { name: "Next", exact: true }).click();
-    await expect(page.getByRole("dialog", { name: "Access" })).toBeVisible();
-    await page.getByRole("button", { name: "Next", exact: true }).click();
-    await expect(
-        page.getByRole("dialog", { name: "Add Documents" }),
-    ).toBeVisible();
-
-    if (filePath) {
-        /* On the documents step the footer "Upload" button opens a hidden file
-           input, and its label gains a "(n)" count once files are attached. */
-        const fileChooserPromise = page.waitForEvent("filechooser");
-        await page.getByRole("button", { name: /^Upload/ }).click();
-        (await fileChooserPromise).setFiles(filePath);
-        await expect(
-            page.getByRole("button", { name: /^Upload \(1\)/ }),
-        ).toBeVisible({ timeout: 5_000 });
-    }
-
-    /* Create — NewProjectModal's onCreated calls router.push(`/projects/${id}`).
-       The PDF upload runs (awaited) inside handleSubmit before onCreated fires,
-       so allow extra time for navigation when a file is attached.
-
-       (The modal's FileDirectory used to fan out a getProject() request per
-       existing project on open, which could overwhelm the local Supabase
-       gateway and required settle-waits plus a submit-retry loop here. The
-       directory now loads via one batched listProjects?include=documents
-       request, so a single submit is reliable.)
-
-       The documents step's primary action is a button whose label flips to
-       "Creating…" while in flight. */
-    const navTimeout = filePath ? 30_000 : 15_000;
-    await page.getByRole("button", { name: "Create project" }).click();
-    await page.waitForURL(/\/projects\/.+/, { timeout: navTimeout });
-}
 
 /**
  * Navigate to the projects list and return the table row for `projectName`.

--- a/e2e/project-management.spec.ts
+++ b/e2e/project-management.spec.ts
@@ -112,7 +112,11 @@ test("delete a project", async ({ page }) => {
      * The "Actions" button is conditionally rendered only when selectedIds.length > 0.
      * It opens a small dropdown containing a "Delete" option.
      */
-    const actionsBtn = page.getByRole("button", { name: /^Actions/ });
+    /* Exact name, not a /^Actions/ prefix: the sidebar's chat rows carry
+       "Actions for <title>" buttons, so the prefix matched more than one
+       element and Playwright's strict mode failed the click outright. The
+       toolbar's own button is named exactly "Actions". */
+    const actionsBtn = page.getByRole("button", { name: "Actions", exact: true });
     await expect(actionsBtn).toBeVisible({ timeout: 3_000 });
     await actionsBtn.click();
 

--- a/e2e/projects.ts
+++ b/e2e/projects.ts
@@ -1,0 +1,94 @@
+import { expect, test, type Page } from "@playwright/test";
+
+/**
+ * The one place the "New project" wizard is driven from.
+ *
+ * The wizard has grown a step at a time — Details, then Access, then Add
+ * Documents — and each time three specs had to be edited in lockstep.
+ * Twice they were not: critical-path and chat-management still clicked a
+ * single "Next" and then looked for controls that only exist on the final
+ * step, so both failed in CI the moment the Access step landed. Creation now
+ * lives here, so a fourth step is a one-file change and cannot be missed.
+ *
+ * Steps, and the controls that identify each:
+ *
+ *   Details          — "Project name" input, primary "Next"
+ *   Access           — Back / Skip / "Next"  (breadcrumb "Access", or
+ *                      "Organisational Access" outside the personal
+ *                      workspace; the substring locator matches both)
+ *   Add Documents    — secondary "Upload" (label gains "(n)" once files are
+ *                      attached) and the primary "Create project", which is
+ *                      a type="button", NOT a form submit.
+ *
+ * Pass `filePath` to also attach a document on the final step.
+ */
+export async function createProject(
+    page: Page,
+    projectName: string,
+    filePath?: string,
+): Promise<void> {
+    /* Creation is a navigation + a three-step wizard + (optionally) a file
+       upload; the per-test `{ timeout }` option passed to test() is silently
+       ignored by Playwright (that object only accepts tag/annotation), so
+       raise the budget here, where the slow work happens.
+
+       Only ever raise it: callers such as critical-path already set a larger
+       budget for a flow that continues into a live LLM turn, and lowering it
+       here would cut that flow short. `timeout: 0` means "no timeout" and is
+       left alone. */
+    const budget = filePath ? 90_000 : 60_000;
+    const current = test.info().timeout;
+    if (current !== 0 && current < budget) test.setTimeout(budget);
+
+    await page.goto("/projects");
+    await expect(page).toHaveURL(/\/projects/, { timeout: 10_000 });
+
+    /* The Plus icon button in the header has aria-label="New project" */
+    const createBtn = page.getByRole("button", { name: "New project" });
+    await expect(createBtn).toBeVisible({ timeout: 10_000 });
+    await createBtn.click();
+
+    const nameInput = page.getByPlaceholder("Project name");
+    await expect(nameInput).toBeVisible({ timeout: 5_000 });
+    await nameInput.fill(projectName);
+
+    /* Details → Access */
+    await page.getByRole("button", { name: "Next", exact: true }).click();
+    await expect(page.getByRole("dialog", { name: "Access" })).toBeVisible();
+
+    /* Access → Add Documents. "Next" keeps whatever the step defaulted to;
+       "Skip" would clear it. Nothing is entered here, so either works and
+       "Next" is the primary. */
+    await page.getByRole("button", { name: "Next", exact: true }).click();
+    await expect(
+        page.getByRole("dialog", { name: "Add Documents" }),
+    ).toBeVisible();
+
+    if (filePath) {
+        /* On the documents step the footer "Upload" button opens a hidden
+           file input, and its label gains a "(n)" count once files are
+           attached. */
+        const fileChooserPromise = page.waitForEvent("filechooser");
+        await page.getByRole("button", { name: /^Upload/ }).click();
+        (await fileChooserPromise).setFiles(filePath);
+        await expect(
+            page.getByRole("button", { name: /^Upload \(1\)/ }),
+        ).toBeVisible({ timeout: 5_000 });
+    }
+
+    /* Create — NewProjectModal's onCreated calls router.push(`/projects/${id}`).
+       Any attached upload runs (awaited) inside that handler before onCreated
+       fires, so allow extra time for the navigation when a file is attached.
+
+       (The modal's FileDirectory used to fan out a getProject() request per
+       existing project on open, which could overwhelm the local Supabase
+       gateway and required settle-waits plus a submit-retry loop here. The
+       directory now loads via one batched listProjects?include=documents
+       request, so a single submit is reliable.)
+
+       The documents step's primary action is a button whose label flips to
+       "Creating…" while in flight. */
+    const navTimeout = filePath ? 30_000 : 15_000;
+    await page.getByRole("button", { name: "Create project" }).click();
+    await page.waitForURL(/\/projects\/.+/, { timeout: navTimeout });
+}

--- a/e2e/projects.ts
+++ b/e2e/projects.ts
@@ -37,8 +37,16 @@ export async function createProject(
        here would cut that flow short. `timeout: 0` means "no timeout" and is
        left alone. */
     const budget = filePath ? 90_000 : 60_000;
-    const current = test.info().timeout;
-    if (current !== 0 && current < budget) test.setTimeout(budget);
+    /* `test.info()` throws outside a running test — a fixture, a global
+       setup, or any helper reused from a plain script — and this helper's
+       whole point is being callable from anywhere. A missing timeout budget
+       is not worth taking the caller down for. */
+    try {
+        const current = test.info().timeout;
+        if (current !== 0 && current < budget) test.setTimeout(budget);
+    } catch {
+        // Not inside a test: the caller owns its own timeout.
+    }
 
     await page.goto("/projects");
     await expect(page).toHaveURL(/\/projects/, { timeout: 10_000 });

--- a/frontend/src/app/(pages)/assistant/chat/[id]/page.roles.test.tsx
+++ b/frontend/src/app/(pages)/assistant/chat/[id]/page.roles.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from "@testing-library/react";
+import { act, render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 // Grant-reachable chats appear in the global sidebar since the parity
@@ -36,7 +36,7 @@ vi.mock("@/app/components/assistant/ChatView", () => ({
         canSend,
         chat,
     }: {
-        canSend?: boolean;
+        canSend?: boolean | null;
         chat?: { access_role?: string } | null;
     }) => (
         <>
@@ -83,5 +83,40 @@ describe("global chat page composer gating", () => {
             expect(screen.getByTestId("can-send")).toHaveTextContent("true"),
         );
         expect(screen.getByTestId("chat-role")).toHaveTextContent("editor");
+    });
+
+    it("says 'not known yet' rather than 'viewing only' while getChat is in flight", async () => {
+        // Every cold load starts with no initialMessages, so the old
+        // `useState(initialMessages.length > 0)` opened at FALSE — and a
+        // chat's own owner was told "Viewing only — sending needs edit
+        // access" until the fetch landed. null is the third answer: still
+        // fail-closed (ChatInput disables on it), but it asserts nothing
+        // about the caller's access.
+        let settle!: (value: ReturnType<typeof chatDetail>) => void;
+        getChat.mockReturnValue(
+            new Promise((resolve) => {
+                settle = resolve;
+            }),
+        );
+
+        render(<AssistantChatPage />);
+
+        expect(screen.getByTestId("can-send")).toHaveTextContent("null");
+
+        await act(async () => {
+            settle(chatDetail("owner"));
+        });
+        await waitFor(() =>
+            expect(screen.getByTestId("can-send")).toHaveTextContent("true"),
+        );
+    });
+
+    it("stays fail-closed when getChat never answers", async () => {
+        getChat.mockRejectedValue(new Error("boom"));
+        render(<AssistantChatPage />);
+
+        await waitFor(() => expect(getChat).toHaveBeenCalled());
+        // null, not true: an unknown standing is never a licence.
+        expect(screen.getByTestId("can-send")).not.toHaveTextContent("true");
     });
 });

--- a/frontend/src/app/(pages)/assistant/chat/[id]/page.tsx
+++ b/frontend/src/app/(pages)/assistant/chat/[id]/page.tsx
@@ -28,8 +28,16 @@ export default function AssistantChatPage() {
     // parity change, so a project VIEWER can land on this page — dropping
     // the served role handed them a live composer whose sends 403. Arriving
     // via "new chat" means the caller just created the thread: creator.
-    const [canSend, setCanSend] = useState<boolean>(
-        initialMessages.length > 0,
+    //
+    // Three states, not two. Initialising to `initialMessages.length > 0`
+    // read "false" on every cold load — the exact path a chat's own owner
+    // takes when they open it from the sidebar — so they were told "Viewing
+    // only — sending needs edit access" until getChat resolved. `null` says
+    // "not known yet": still fail-closed (the composer is disabled), but the
+    // placeholder stays neutral instead of asserting something false about
+    // their access. A failed getChat leaves it null and redirects.
+    const [canSend, setCanSend] = useState<boolean | null>(
+        initialMessages.length > 0 ? true : null,
     );
     const [chat, setChat] = useState<Chat | null>(null);
     const [chatModel, setChatModel] = useState<string | null | undefined>(

--- a/frontend/src/app/(pages)/projects/[id]/assistant/chat/[chatId]/page.roles.test.tsx
+++ b/frontend/src/app/(pages)/projects/[id]/assistant/chat/[chatId]/page.roles.test.tsx
@@ -1,0 +1,318 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { Suspense, type ReactNode } from "react";
+import { MikeApiError } from "@/app/lib/mikeApi";
+import ProjectAssistantChatPage from "./page";
+
+// What this file pins, for a chat that lives INSIDE a project:
+//
+//   1. Who is offered what. The server derives the caller's whole standing
+//      here from the project role (ensureSharedRowAccess): delete needs
+//      container.delete, rename and send need content.edit. The page used to
+//      add "…or I created this chat", which disagreed with the server in both
+//      directions — an editor who started the thread was offered a Delete that
+//      came back 403, a project owner who did not start it was refused one the
+//      server accepts, and a demoted viewer kept a live composer on their own
+//      old threads.
+//   2. That a refused rename or delete is SAID. ChatHistoryContext rethrows;
+//      the page awaited both with no catch, so the refusal became an unhandled
+//      rejection and the user saw a header title that had changed, a sidebar
+//      that snapped back, and no explanation.
+
+const {
+    deleteChat,
+    getChat,
+    getProject,
+    renameChatInHistory,
+    push,
+} = vi.hoisted(() => ({
+    deleteChat: vi.fn(),
+    getChat: vi.fn(),
+    getProject: vi.fn(),
+    renameChatInHistory: vi.fn(),
+    push: vi.fn(),
+}));
+
+// importOriginal so MikeApiError stays the real class — userFacingApiError
+// decides whether to show the server's own message with an `instanceof` test.
+vi.mock("@/app/lib/mikeApi", async (importOriginal) => ({
+    ...(await importOriginal<typeof import("@/app/lib/mikeApi")>()),
+    deleteChat: (...args: unknown[]) => deleteChat(...args),
+    getChat: (...args: unknown[]) => getChat(...args),
+    getProject: (...args: unknown[]) => getProject(...args),
+    deleteDocument: vi.fn(),
+    uploadProjectDocuments: vi.fn(),
+    createProjectFolder: vi.fn(),
+    renameProjectFolder: vi.fn(),
+    deleteProjectFolder: vi.fn(),
+    moveDocumentToFolder: vi.fn(),
+    moveSubfolderToFolder: vi.fn(),
+}));
+
+vi.mock("next/navigation", () => ({
+    useRouter: () => ({ push, replace: vi.fn() }),
+}));
+
+vi.mock("@/app/contexts/AuthContext", () => ({
+    useAuth: () => ({ user: { id: "creator", email: "creator@example.com" } }),
+}));
+vi.mock("@/app/contexts/UserProfileContext", () => ({
+    useUserProfile: () => ({ profile: null }),
+}));
+vi.mock("@/app/contexts/SidebarContext", () => ({
+    useSidebar: () => ({ setSidebarOpen: vi.fn() }),
+}));
+vi.mock("@/app/contexts/ChatHistoryContext", () => ({
+    useChatHistoryContext: () => ({
+        setCurrentChatId: vi.fn(),
+        newChatMessages: null,
+        setNewChatMessages: vi.fn(),
+        chats: [],
+        saveChat: vi.fn(),
+        renameChat: renameChatInHistory,
+    }),
+}));
+vi.mock("@/app/hooks/useAssistantChat", () => ({
+    useAssistantChat: () => ({
+        messages: [],
+        isResponseLoading: false,
+        handleChat: vi.fn(),
+        setMessages: vi.fn(),
+        cancel: vi.fn(),
+    }),
+}));
+
+// Heavy children reduced to the one fact each test needs.
+vi.mock("@/app/components/assistant/ChatInput", () => ({
+    ChatInput: ({ canSend }: { canSend?: boolean | null }) => (
+        <div data-testid="can-send">{String(canSend)}</div>
+    ),
+}));
+vi.mock("@/app/components/assistant/UserMessage", () => ({
+    UserMessage: () => null,
+}));
+vi.mock("@/app/components/assistant/AssistantMessage", () => ({
+    AssistantMessage: () => null,
+}));
+vi.mock("@/app/components/projects/ProjectExplorer", () => ({
+    ProjectExplorer: () => null,
+}));
+vi.mock("@/app/components/shared/views/PdfView", () => ({ PdfView: () => null }));
+vi.mock("@/app/components/shared/views/SpreadsheetView", () => ({
+    SpreadsheetView: () => null,
+}));
+vi.mock("@/app/components/shared/views/DocxView", () => ({
+    DocxView: () => null,
+}));
+vi.mock("@/app/components/chat/mike-icon", () => ({ MikeIcon: () => null }));
+
+// PageHeader renders its custom actions; HeaderActionsMenu is flattened to
+// plain buttons so the test can drive the page's handlers without Radix.
+vi.mock("@/app/components/shared/PageHeader", () => ({
+    PageHeader: ({
+        actions,
+    }: {
+        actions?: ({ type?: string; render?: ReactNode } | null | false)[];
+    }) => (
+        <div>
+            {(actions ?? []).map((action, index) =>
+                action && action.type === "custom" ? (
+                    <div key={index}>{action.render}</div>
+                ) : null,
+            )}
+        </div>
+    ),
+}));
+vi.mock("@/app/components/shared/HeaderActionsMenu", () => ({
+    HeaderActionsMenu: ({
+        items,
+    }: {
+        items: { label: string; onSelect: () => void; disabled?: boolean }[];
+    }) => (
+        <div>
+            {items.map((item) => (
+                <button
+                    key={item.label}
+                    type="button"
+                    disabled={item.disabled}
+                    onClick={item.onSelect}
+                >
+                    {item.label}
+                </button>
+            ))}
+        </div>
+    ),
+}));
+
+/** The project payload GET /projects/:id serves the caller. */
+function project(access_role: "owner" | "editor" | "viewer") {
+    return {
+        id: "p1",
+        name: "Matter",
+        access_role,
+        is_owner: access_role === "owner",
+        documents: [],
+        folders: [],
+    };
+}
+
+/**
+ * The chat detail. `user_id` is the CREATOR — deliberately the signed-in
+ * user in most cases here, because the creator arm is exactly what these
+ * tests prove is no longer consulted.
+ */
+function chatDetail(userId = "creator") {
+    return {
+        chat: {
+            id: "c1",
+            project_id: "p1",
+            user_id: userId,
+            title: "Quarterly filing",
+            model: null,
+            reasoning_level: null,
+        },
+        messages: [{ id: "m1", role: "user", content: "hi" }],
+    };
+}
+
+// The page reads its route params with React's `use()`, which suspends until
+// the promise settles — so it needs a boundary and a first await.
+async function renderPage() {
+    await act(async () => {
+        render(
+            <Suspense fallback={null}>
+                <ProjectAssistantChatPage
+                    params={Promise.resolve({ id: "p1", chatId: "c1" })}
+                />
+            </Suspense>,
+        );
+    });
+    await screen.findByText("Rename");
+}
+
+beforeEach(() => {
+    vi.clearAllMocks();
+    deleteChat.mockResolvedValue(undefined);
+    renameChatInHistory.mockResolvedValue(undefined);
+    getChat.mockResolvedValue(chatDetail());
+    vi.spyOn(window, "prompt").mockReturnValue("Renamed thread");
+});
+
+describe("project chat page — the project ladder, not the creator", () => {
+    it("refuses an editor the delete of a chat they created themselves", async () => {
+        // The headline reversal. content.edit does not reach
+        // container.delete, and the server would answer 403 — so the client
+        // must not fire the request at all.
+        getProject.mockResolvedValue(project("editor"));
+        await renderPage();
+        await waitFor(() =>
+            expect(screen.getByTestId("can-send")).toHaveTextContent("true"),
+        );
+
+        fireEvent.click(screen.getByRole("button", { name: "Delete" }));
+
+        await screen.findByText("Owner-only action");
+        expect(deleteChat).not.toHaveBeenCalled();
+    });
+
+    it("lets a project owner delete a colleague's chat", async () => {
+        // The other direction: the sidebar already offers this delete and the
+        // server accepts it, but the page refused it as "owner-only" because
+        // the caller did not start the thread.
+        getProject.mockResolvedValue(project("owner"));
+        getChat.mockResolvedValue(chatDetail("someone-else"));
+        await renderPage();
+
+        fireEvent.click(screen.getByRole("button", { name: "Delete" }));
+
+        await waitFor(() => expect(deleteChat).toHaveBeenCalledWith("c1"));
+        expect(screen.queryByText("Owner-only action")).not.toBeInTheDocument();
+    });
+
+    it("hands a demoted viewer a read-only composer on their own chat", async () => {
+        // Creating a thread does not outrank being demoted to viewer.
+        getProject.mockResolvedValue(project("viewer"));
+        await renderPage();
+
+        await waitFor(() =>
+            expect(screen.getByTestId("can-send")).toHaveTextContent("false"),
+        );
+    });
+
+    it("refuses a viewer's rename at the editor tier, not the owner one", async () => {
+        getProject.mockResolvedValue(project("viewer"));
+        await renderPage();
+
+        fireEvent.click(screen.getByRole("button", { name: "Rename" }));
+
+        expect(await screen.findByText("Editors only")).toBeInTheDocument();
+        expect(renameChatInHistory).not.toHaveBeenCalled();
+        expect(window.prompt).not.toHaveBeenCalled();
+    });
+
+    it("raises no refusal while the project role is still unknown", async () => {
+        // `roleFromLoaded(null)` is "not known", not "not allowed". Telling
+        // somebody they lack a role before the payload lands is a guess.
+        getProject.mockReturnValue(new Promise(() => {}));
+        await renderPage();
+
+        fireEvent.click(screen.getByRole("button", { name: "Delete" }));
+
+        await waitFor(() => expect(deleteChat).not.toHaveBeenCalled());
+        expect(screen.queryByText("Owner-only action")).not.toBeInTheDocument();
+    });
+});
+
+describe("project chat page — refused mutations are surfaced", () => {
+    it("tells the user when a delete is refused", async () => {
+        getProject.mockResolvedValue(project("owner"));
+        deleteChat.mockRejectedValue(
+            new MikeApiError({
+                message: "You do not have permission to delete this chat",
+                status: 403,
+            }),
+        );
+        await renderPage();
+
+        fireEvent.click(screen.getByRole("button", { name: "Delete" }));
+
+        expect(await screen.findByText("Chat not deleted")).toBeInTheDocument();
+        // The server's own 4xx wording, not a generic fallback.
+        expect(
+            screen.getByText("You do not have permission to delete this chat"),
+        ).toBeInTheDocument();
+        expect(push).not.toHaveBeenCalled();
+    });
+
+    it("puts the header title back when a rename is refused, and says so", async () => {
+        getProject.mockResolvedValue(project("owner"));
+        renameChatInHistory.mockRejectedValue(
+            new MikeApiError({
+                message: "You do not have permission to rename this chat",
+                status: 403,
+            }),
+        );
+        await renderPage();
+
+        fireEvent.click(screen.getByRole("button", { name: "Rename" }));
+
+        expect(await screen.findByText("Chat not renamed")).toBeInTheDocument();
+        expect(
+            screen.getByText("You do not have permission to rename this chat"),
+        ).toBeInTheDocument();
+    });
+
+    it("falls back to generic wording for a non-4xx delete failure", async () => {
+        getProject.mockResolvedValue(project("owner"));
+        deleteChat.mockRejectedValue(new Error("network"));
+        await renderPage();
+
+        fireEvent.click(screen.getByRole("button", { name: "Delete" }));
+
+        expect(
+            await screen.findByText(
+                "The chat could not be deleted. Please try again.",
+            ),
+        ).toBeInTheDocument();
+    });
+});

--- a/frontend/src/app/(pages)/projects/[id]/assistant/chat/[chatId]/page.roles.test.tsx
+++ b/frontend/src/app/(pages)/projects/[id]/assistant/chat/[chatId]/page.roles.test.tsx
@@ -261,6 +261,39 @@ describe("project chat page — the project ladder, not the creator", () => {
         await waitFor(() => expect(deleteChat).not.toHaveBeenCalled());
         expect(screen.queryByText("Owner-only action")).not.toBeInTheDocument();
     });
+
+    it("disables Rename and Delete while the project role is unknown", async () => {
+        // Silence was the right answer to "should we accuse them?" and the
+        // wrong one to "what does this menu item do?": clicking did nothing,
+        // with no refusal and no disabled state, which reads as broken.
+        getProject.mockReturnValue(new Promise(() => {}));
+        await renderPage();
+
+        expect(screen.getByRole("button", { name: "Rename" })).toBeDisabled();
+        expect(screen.getByRole("button", { name: "Delete" })).toBeDisabled();
+    });
+
+    it("re-enables them once the role arrives", async () => {
+        getProject.mockResolvedValue(project("owner"));
+        await renderPage();
+
+        await waitFor(() =>
+            expect(
+                screen.getByRole("button", { name: "Rename" }),
+            ).toBeEnabled(),
+        );
+        expect(screen.getByRole("button", { name: "Delete" })).toBeEnabled();
+    });
+
+    it("says nothing about sending until the project role is known", async () => {
+        // `false` here is an accusation — the composer reads "Viewing only".
+        // A project owner opening their own chat cold was told that for the
+        // length of the project fetch.
+        getProject.mockReturnValue(new Promise(() => {}));
+        await renderPage();
+
+        expect(screen.getByTestId("can-send")).toHaveTextContent("null");
+    });
 });
 
 describe("project chat page — refused mutations are surfaced", () => {

--- a/frontend/src/app/(pages)/projects/[id]/assistant/chat/[chatId]/page.tsx
+++ b/frontend/src/app/(pages)/projects/[id]/assistant/chat/[chatId]/page.tsx
@@ -44,6 +44,7 @@ import { PdfView } from "@/app/components/shared/views/PdfView";
 import { SpreadsheetView } from "@/app/components/shared/views/SpreadsheetView";
 import { ConfirmPopup } from "@/app/components/popups/ConfirmPopup";
 import { PermissionDeniedPopup } from "@/app/components/popups/PermissionDeniedPopup";
+import { WarningPopup } from "@/app/components/popups/WarningPopup";
 import { DocxView } from "@/app/components/shared/views/DocxView";
 import { MikeIcon } from "@/app/components/chat/mike-icon";
 import { useAuth } from "@/app/contexts/AuthContext";
@@ -69,6 +70,7 @@ import {
     removeDeletedDocumentTabs,
 } from "@/app/lib/folderDeleteState";
 import { can, roleFromLoaded } from "@/app/lib/permissions";
+import { userFacingApiError } from "@/app/lib/userFacingError";
 
 interface Props {
     params: Promise<{ id: string; chatId: string }>;
@@ -218,11 +220,14 @@ export default function ProjectAssistantChatPage({ params }: Props) {
 
     const [project, setProject] = useState<Project | null>(null);
     const [chatTitle, setChatTitle] = useState<string | null>(null);
-    const [chatOwnerId, setChatOwnerId] = useState<string | null>(null);
     const [ownerOnlyAction, setOwnerOnlyAction] = useState<string | null>(null);
     const [editorGateAction, setEditorGateAction] = useState<string | null>(
         null,
     );
+    const [chatActionError, setChatActionError] = useState<{
+        title: string;
+        message: string;
+    } | null>(null);
     const [chatLoaded, setChatLoaded] = useState(false);
     const [creatingChat, setCreatingChat] = useState(false);
     const [deletingChat, setDeletingChat] = useState(false);
@@ -306,12 +311,16 @@ export default function ProjectAssistantChatPage({ params }: Props) {
     // than a control appearing that was never theirs.
     const projectRole = roleFromLoaded(project);
     const canEditContent = can(projectRole, "content.edit");
-    // The chat's own creator keeps writing to it whatever their project role,
-    // because the server puts a row's creator at the top of that row's ladder.
-    // That exception is knowable without the project, so it still applies
-    // during the load window.
-    const canSendChat =
-        canEditContent || (!!chatOwnerId && chatOwnerId === user?.id);
+    // There is no creator exception on a PROJECT chat. The server derives the
+    // caller's whole standing here from the project role
+    // (ensureSharedRowAccess): content.edit to write or rename, and
+    // container.delete to delete. Adding "…or I started this thread" to the
+    // client made all three gates disagree with the server in both
+    // directions — an editor who created the chat was offered a Delete that
+    // came back 403, and a viewer demoted after starting a thread kept a live
+    // composer on it. The ladder is the only answer this page asks for.
+    const canSendChat = canEditContent;
+    const canDeleteChat = can(projectRole, "container.delete");
     const pendingInitialUserMessageRef = useRef<Message | null>(
         initialMessages.length === 1 && initialMessages[0].role === "user"
             ? initialMessages[0]
@@ -409,7 +418,6 @@ export default function ProjectAssistantChatPage({ params }: Props) {
         getChat(chatId)
             .then(({ chat, messages: loaded }) => {
                 setChatTitle(chat.title);
-                setChatOwnerId(chat.user_id ?? null);
                 setChatModel(chat.model ?? null);
                 setChatReasoningLevel(chat.reasoning_level ?? null);
                 if (loaded.length > 0) setMessages(loaded);
@@ -664,24 +672,38 @@ export default function ProjectAssistantChatPage({ params }: Props) {
     }
 
     async function handleDeleteChat() {
-        if (chatOwnerId && user?.id && chatOwnerId !== user.id) {
-            setOwnerOnlyAction("delete this chat");
+        if (!canDeleteChat) {
+            // Only accuse somebody of lacking a role once we know they do:
+            // `projectRole` is null for the whole load window, and a refusal
+            // popup raised then is a guess.
+            if (projectRole) setOwnerOnlyAction("delete this chat");
             return;
         }
         setDeletingChat(true);
         try {
             await deleteChat(chatId);
             router.push(`/projects/${projectId}/assistant`);
+        } catch (error) {
+            // Without this the refusal was an unhandled rejection and the
+            // page just sat there, indistinguishable from a slow delete.
+            setChatActionError({
+                title: "Chat not deleted",
+                message: userFacingApiError(
+                    error,
+                    "The chat could not be deleted. Please try again.",
+                ),
+            });
         } finally {
             setDeletingChat(false);
         }
     }
 
     async function handleRenameChat() {
-        if (chatOwnerId && user?.id && chatOwnerId !== user.id) {
-            setOwnerOnlyAction("rename this chat");
+        if (!canEditContent) {
+            if (projectRole) setEditorGateAction("rename this chat");
             return;
         }
+        const previousTitle = chatTitle;
         const nextTitle = window.prompt(
             "Rename chat",
             chatTitle ?? "Untitled New Chat",
@@ -689,7 +711,21 @@ export default function ProjectAssistantChatPage({ params }: Props) {
         const trimmed = nextTitle?.trim();
         if (!trimmed || trimmed === chatTitle) return;
         setChatTitle(trimmed);
-        await renameChatInHistory(chatId, trimmed);
+        try {
+            await renameChatInHistory(chatId, trimmed);
+        } catch (error) {
+            // ChatHistoryContext rethrows so the calling surface can speak.
+            // Unhandled, the header title stayed changed while the sidebar
+            // snapped back — the user saw two different titles and no reason.
+            setChatTitle(previousTitle);
+            setChatActionError({
+                title: "Chat not renamed",
+                message: userFacingApiError(
+                    error,
+                    "The chat could not be renamed. Please try again.",
+                ),
+            });
+        }
     }
 
     // ── Upload ────────────────────────────────────────────────────────────────
@@ -1486,6 +1522,12 @@ export default function ProjectAssistantChatPage({ params }: Props) {
                 requiredRole="editor"
                 contacts={project?.admin_contacts}
                 onClose={() => setEditorGateAction(null)}
+            />
+            <WarningPopup
+                open={!!chatActionError}
+                title={chatActionError?.title}
+                message={chatActionError?.message}
+                onClose={() => setChatActionError(null)}
             />
             <ConfirmPopup
                 open={!!pendingDeleteFolder}

--- a/frontend/src/app/(pages)/projects/[id]/assistant/chat/[chatId]/page.tsx
+++ b/frontend/src/app/(pages)/projects/[id]/assistant/chat/[chatId]/page.tsx
@@ -319,8 +319,22 @@ export default function ProjectAssistantChatPage({ params }: Props) {
     // directions — an editor who created the chat was offered a Delete that
     // came back 403, and a viewer demoted after starting a thread kept a live
     // composer on it. The ladder is the only answer this page asks for.
-    const canSendChat = canEditContent;
+    //
+    // Three answers, not two — the same tri-state the standalone chat page
+    // adopted. `can(null, …)` is false, and false here is a SENTENCE: the
+    // composer reads "Viewing only — sending needs edit access". A project
+    // owner opening their own chat cold saw that accusation for the length of
+    // GET /projects/:id. `null` keeps the composer closed while we wait
+    // without asserting anything about who the reader is.
+    const canSendChat = projectRole === null ? null : canEditContent;
     const canDeleteChat = can(projectRole, "container.delete");
+    // Rename and Delete are offered by the header menu, whose handlers return
+    // in silence while the role is unknown — deliberately, since accusing
+    // somebody before the payload lands is a guess, but a menu item that
+    // quietly does nothing when clicked is indistinguishable from a broken
+    // one. Disable them for that window, the way the upload button already
+    // does with `!canEditContent`.
+    const roleKnown = projectRole !== null;
     const pendingInitialUserMessageRef = useRef<Message | null>(
         initialMessages.length === 1 && initialMessages[0].role === "user"
             ? initialMessages[0]
@@ -664,7 +678,10 @@ export default function ProjectAssistantChatPage({ params }: Props) {
     async function handleNewChat() {
         setCreatingChat(true);
         try {
-            const id = await saveChat(projectId);
+            // A project chat's role comes from the project, so the sidebar's
+            // optimistic row has to carry the caller's project role rather
+            // than assume owner.
+            const id = await saveChat(projectId, projectRole);
             if (id) router.push(`/projects/${projectId}/assistant/chat/${id}`);
         } finally {
             setCreatingChat(false);
@@ -1049,6 +1066,7 @@ export default function ProjectAssistantChatPage({ params }: Props) {
                                         label: "Rename",
                                         icon: Pencil,
                                         onSelect: () => void handleRenameChat(),
+                                        disabled: !roleKnown,
                                     },
                                     {
                                         label: deletingChat
@@ -1056,7 +1074,7 @@ export default function ProjectAssistantChatPage({ params }: Props) {
                                             : "Delete",
                                         icon: Trash2,
                                         onSelect: () => void handleDeleteChat(),
-                                        disabled: deletingChat,
+                                        disabled: deletingChat || !roleKnown,
                                         variant: "danger",
                                     },
                                 ]}

--- a/frontend/src/app/(pages)/projects/[id]/assistant/page.roles.test.tsx
+++ b/frontend/src/app/(pages)/projects/[id]/assistant/page.roles.test.tsx
@@ -182,6 +182,11 @@ describe("project assistant chat deletion gating", () => {
         fireEvent.click(await screen.findByText("Actions"));
         fireEvent.click(await screen.findByText("Delete"));
 
+        // The bulk path asks first — nothing is sent until it is confirmed.
+        expect(await screen.findByText("Delete 3 chats?")).toBeInTheDocument();
+        expect(deleteChat).not.toHaveBeenCalled();
+        fireEvent.click(screen.getByRole("button", { name: "Delete" }));
+
         const notice = await screen.findByText(/skipped because only a project owner/);
         expect(notice.textContent).toContain(
             "1 selected chat was skipped because only a project owner can delete them.",

--- a/frontend/src/app/(pages)/projects/[id]/assistant/page.tsx
+++ b/frontend/src/app/(pages)/projects/[id]/assistant/page.tsx
@@ -14,6 +14,7 @@ import type { Chat } from "@/app/components/shared/types";
 import { useAuth } from "@/app/contexts/AuthContext";
 import { can, roleFrom } from "@/app/lib/permissions";
 import { userFacingApiError } from "@/app/lib/userFacingError";
+import { ConfirmPopup } from "@/app/components/popups/ConfirmPopup";
 import { WarningPopup } from "@/app/components/popups/WarningPopup";
 import { TabPillButton } from "@/app/components/ui/tab-pill-button";
 
@@ -75,6 +76,8 @@ export default function ProjectAssistantPage({ params }: Props) {
     const [renamingChatId, setRenamingChatId] = useState<string | null>(null);
     const [renameChatValue, setRenameChatValue] = useState("");
     const [actionsOpen, setActionsOpen] = useState(false);
+    const [confirmDeleteSelectedOpen, setConfirmDeleteSelectedOpen] =
+        useState(false);
     // One place for "the server refused, or the request failed" — the
     // silent `.catch(() => {})` this replaces is why a 403 used to look
     // exactly like a success until the page was reloaded.
@@ -153,8 +156,20 @@ export default function ProjectAssistantPage({ params }: Props) {
         setProjectChats((prev) => (prev ?? []).filter((c) => c.id !== chat.id));
     }
 
+    /**
+     * Both bulk entry points — the toolbar's Actions menu and the row menu's
+     * "Delete N chats" — ask first. A multi-row delete is the least reversible
+     * thing on this page, and one of the rows may belong to a colleague.
+     */
+    function requestDeleteSelectedChats() {
+        if (selectedChatIds.length === 0) return;
+        setActionsOpen(false);
+        setConfirmDeleteSelectedOpen(true);
+    }
+
     const handleDeleteSelectedChats = useCallback(async () => {
         const ids = [...selectedChatIds];
+        setConfirmDeleteSelectedOpen(false);
         setActionsOpen(false);
         setActionNotice(null);
         const roleById = new Map(
@@ -203,7 +218,7 @@ export default function ProjectAssistantPage({ params }: Props) {
                         selectedCount={selectedChatIds.length}
                         open={actionsOpen}
                         onOpenChange={setActionsOpen}
-                        onDelete={() => void handleDeleteSelectedChats()}
+                        onDelete={requestDeleteSelectedChats}
                     />
                 ) : undefined}
             />
@@ -224,12 +239,25 @@ export default function ProjectAssistantPage({ params }: Props) {
                     )
                 }
                 onDeleteChat={handleDeleteChatRow}
-                onDeleteSelectedChats={handleDeleteSelectedChats}
+                onDeleteSelectedChats={requestDeleteSelectedChats}
                 onOwnerOnlyAction={setOwnerOnlyAction}
                 submitChatRename={submitChatRename}
                 setSelectedChatIds={setSelectedChatIds}
                 setRenamingChatId={setRenamingChatId}
                 setRenameChatValue={setRenameChatValue}
+            />
+            <ConfirmPopup
+                open={confirmDeleteSelectedOpen && selectedChatIds.length > 0}
+                title={
+                    selectedChatIds.length === 1
+                        ? "Delete chat?"
+                        : `Delete ${selectedChatIds.length} chats?`
+                }
+                message="This cannot be undone."
+                confirmLabel="Delete"
+                confirmVariant="danger"
+                onCancel={() => setConfirmDeleteSelectedOpen(false)}
+                onConfirm={() => void handleDeleteSelectedChats()}
             />
             <WarningPopup
                 open={!!actionNotice}

--- a/frontend/src/app/(pages)/settings/page.test.tsx
+++ b/frontend/src/app/(pages)/settings/page.test.tsx
@@ -1,10 +1,13 @@
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { MikeApiError } from "@/app/lib/mikeApi";
 import SettingsPage from "./page";
 
 const state = vi.hoisted(() => ({
     push: vi.fn(),
+    signOut: vi.fn(),
+    deleteAccount: vi.fn(),
     updateEmail: vi.fn(),
     updateDisplayName: vi.fn(),
     updateOrganisation: vi.fn(),
@@ -28,7 +31,7 @@ vi.mock("next/navigation", () => ({
 vi.mock("@/app/contexts/AuthContext", () => ({
     useAuth: () => ({
         user: state.user,
-        signOut: vi.fn(),
+        signOut: state.signOut,
         updateEmail: state.updateEmail,
     }),
 }));
@@ -45,8 +48,12 @@ vi.mock("@/app/contexts/UserProfileContext", () => ({
     }),
 }));
 
-vi.mock("@/app/lib/mikeApi", () => ({
-    deleteAccount: vi.fn(),
+// The real module is spread back in because userFacingApiError resolves
+// MikeApiError from it; a bare object mock leaves that `instanceof` check
+// comparing against undefined.
+vi.mock("@/app/lib/mikeApi", async (importOriginal) => ({
+    ...(await importOriginal<typeof import("@/app/lib/mikeApi")>()),
+    deleteAccount: state.deleteAccount,
     isMfaRequiredError: vi.fn(() => false),
 }));
 
@@ -58,6 +65,9 @@ vi.mock("@/app/components/popups/MfaVerificationPopup", () => ({
 describe("SettingsPage Google email changes", () => {
     beforeEach(() => {
         state.push.mockReset();
+        state.signOut.mockReset();
+        state.deleteAccount.mockReset();
+        state.deleteAccount.mockResolvedValue(undefined);
         state.updateEmail.mockReset();
         state.updateDisplayName.mockReset();
         state.updateDisplayName.mockResolvedValue(true);
@@ -181,6 +191,32 @@ describe("SettingsPage Google email changes", () => {
         await waitFor(() =>
             expect(state.updateOrganisation).toHaveBeenCalledWith("New LLP"),
         );
+    });
+
+    it("keeps the session and shows the reason when deletion is refused", async () => {
+        const user = userEvent.setup();
+        const detail =
+            "You are the only admin of Elite Law LLP. Make another member an admin, or delete the organization, before deleting your account.";
+        state.deleteAccount.mockRejectedValue(
+            new MikeApiError({
+                status: 409,
+                code: "org_successor_required",
+                message: detail,
+            }),
+        );
+        render(<SettingsPage />);
+
+        await user.click(
+            screen.getByRole("button", { name: "Delete account" }),
+        );
+        await user.click(screen.getByRole("button", { name: "Delete" }));
+
+        // The 409 detail names the blocking organization; a generic "Failed to
+        // delete account" would leave the user with no way to unblock it.
+        expect(await screen.findByText(detail)).toBeInTheDocument();
+        expect(screen.getByText("Account not deleted")).toBeInTheDocument();
+        expect(state.signOut).not.toHaveBeenCalled();
+        expect(state.push).not.toHaveBeenCalled();
     });
 
     it("allows an existing display name to be cleared", async () => {

--- a/frontend/src/app/(pages)/settings/page.tsx
+++ b/frontend/src/app/(pages)/settings/page.tsx
@@ -16,6 +16,7 @@ import {
 } from "@/app/components/popups/MfaVerificationPopup";
 import { WarningPopup } from "@/app/components/popups/WarningPopup";
 import { deleteAccount, isMfaRequiredError } from "@/app/lib/mikeApi";
+import { userFacingApiError } from "@/app/lib/userFacingError";
 import { SettingsSection } from "./SettingsSection";
 
 const isDev = process.env.NODE_ENV !== "production";
@@ -51,6 +52,7 @@ export default function SettingsPage() {
     const [deleteConfirm, setDeleteConfirm] = useState(false);
     const [isDeleting, setIsDeleting] = useState(false);
     const [accountDeleteMfaOpen, setAccountDeleteMfaOpen] = useState(false);
+    const [deleteError, setDeleteError] = useState<string | null>(null);
     const requiresPasswordForEmailChange =
         user?.createdWithGoogle === true && profile?.passwordSet !== true;
 
@@ -95,6 +97,7 @@ export default function SettingsPage() {
     const handleDeleteAccount = async () => {
         devLog("[account/mfa] delete account requested");
         setIsDeleting(true);
+        setDeleteError(null);
         try {
             if (await needsMfaVerification()) {
                 setDeleteConfirm(false);
@@ -117,7 +120,16 @@ export default function SettingsPage() {
                 return;
             }
             setDeleteConfirm(false);
-            alert("Failed to delete account. Please try again.");
+            // Deletion can be refused for a reason only the user can act on —
+            // a 409 naming the organization they are the last admin of, for
+            // instance. That is an intentional 4xx detail, so it is shown
+            // verbatim; the session is untouched because nothing was deleted.
+            setDeleteError(
+                userFacingApiError(
+                    error,
+                    "Failed to delete account. Please try again.",
+                ),
+            );
         }
     };
 
@@ -409,6 +421,12 @@ export default function SettingsPage() {
                     setDeleteConfirm(false);
                 }}
                 onConfirm={() => void handleDeleteAccount()}
+            />
+            <WarningPopup
+                open={deleteError !== null}
+                title="Account not deleted"
+                message={deleteError}
+                onClose={() => setDeleteError(null)}
             />
             <WarningPopup
                 open={!!emailWarning}

--- a/frontend/src/app/(pages)/tabular-reviews/page.create.test.tsx
+++ b/frontend/src/app/(pages)/tabular-reviews/page.create.test.tsx
@@ -1,0 +1,338 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { MikeApiError } from "@/app/lib/mikeApi";
+import type { TabularReview } from "@/app/components/shared/types";
+import TabularReviewsPage from "./page";
+
+// What this file pins: what happens when the review is created but sharing it
+// is refused. The handler used to let the grant's rejection escape, so the
+// dialog showed the generic "Could not create the review." and a second Create
+// created a SECOND review. The review now survives the failure in a ref, the
+// message names what actually failed, and Create retries only the grants.
+
+const { createTabularReview, grantTabularReviewAccess, push, retry } =
+    vi.hoisted(() => ({
+        createTabularReview: vi.fn(),
+        grantTabularReviewAccess: vi.fn(),
+        push: vi.fn(),
+        retry: vi.fn(),
+    }));
+
+// importOriginal so MikeApiError stays the real class: userFacingApiError
+// decides with an `instanceof` test whether the server's own message may be
+// shown, and a stubbed class would silently take the generic branch.
+vi.mock("@/app/lib/mikeApi", async (importOriginal) => ({
+    ...(await importOriginal<typeof import("@/app/lib/mikeApi")>()),
+    createTabularReview: (...args: unknown[]) => createTabularReview(...args),
+    grantTabularReviewAccess: (...args: unknown[]) =>
+        grantTabularReviewAccess(...args),
+    listProjects: vi.fn(async () => []),
+    listWorkflows: vi.fn(async () => []),
+}));
+
+vi.mock("next/navigation", () => ({
+    usePathname: () => "/tabular-reviews",
+    useRouter: () => ({ push, replace: vi.fn() }),
+    useSearchParams: () => new URLSearchParams(),
+}));
+
+vi.mock("@/app/contexts/AuthContext", () => ({
+    useAuth: () => ({ user: { id: "me", email: "me@firm.test" } }),
+}));
+
+vi.mock("@/app/contexts/UserProfileContext", () => ({
+    useUserProfile: () => ({
+        profile: {
+            tabularModel: "gemini-3-flash-preview",
+            apiKeys: {
+                claude: { configured: false, source: null },
+                gemini: { configured: true, source: "user" },
+                openai: { configured: false, source: null },
+                openrouter: { configured: false, source: null },
+                vercel: { configured: false, source: null },
+                "opencode-go": { configured: false, source: null },
+                courtlistener: { configured: false, source: null },
+            },
+            openRouterModels: [],
+            vercelModels: [],
+            openCodeGoModels: [],
+        },
+        loading: false,
+        apiKeysDegraded: false,
+    }),
+}));
+
+vi.mock("@/app/hooks/useOllamaModels", () => ({
+    useOllamaModels: () => [],
+}));
+
+// The list itself is not what this file is about; the hook would otherwise
+// fetch on mount.
+vi.mock("@/app/hooks/usePaginatedTabularReviews", () => ({
+    usePaginatedTabularReviews: () => ({
+        reviews: [],
+        setReviews: vi.fn(),
+        loading: false,
+        loadingMore: false,
+        hasMore: false,
+        error: null,
+        loadMoreError: null,
+        loadMore: vi.fn(),
+        retry,
+        selectedReviewIds: [],
+        setSelectedReviewIds: vi.fn(),
+        selectAllMatching: vi.fn(),
+        selectingAll: false,
+        getReviewOwnerId: () => undefined,
+    }),
+}));
+
+type HeaderAction = { type: string; title?: string; onClick?: () => void };
+vi.mock("@/app/components/shared/PageHeader", () => ({
+    PageHeader: ({
+        actions,
+        children,
+    }: {
+        actions?: HeaderAction[];
+        children?: ReactNode;
+    }) => (
+        <div>
+            {children}
+            {(actions ?? [])
+                .filter((action) => action.type === "new")
+                .map((action) => (
+                    <button
+                        key={action.title}
+                        type="button"
+                        onClick={action.onClick}
+                    >
+                        {action.title}
+                    </button>
+                ))}
+        </div>
+    ),
+}));
+
+vi.mock("@/app/components/shared/FileDirectory", () => ({
+    FileDirectory: () => <div>Document directory</div>,
+}));
+
+// The real access step is a user-lookup surface of its own; here it just has
+// to hand the dialog one recipient to share with.
+vi.mock("@/app/components/modals/CreateAccessStep", () => ({
+    CreateAccessStep: ({
+        onDirectGrantsChange,
+    }: {
+        onDirectGrantsChange: (
+            grants: {
+                email: string;
+                display_name: string | null;
+                role: "editor";
+            }[],
+        ) => void;
+    }) => {
+        const recipient = (email: string) =>
+            ({ email, display_name: null, role: "editor" }) as const;
+        return (
+            <>
+                <button
+                    type="button"
+                    onClick={() =>
+                        onDirectGrantsChange([recipient("colleague@firm.test")])
+                    }
+                >
+                    add recipient
+                </button>
+                <button
+                    type="button"
+                    onClick={() =>
+                        onDirectGrantsChange([
+                            recipient("colleague@firm.test"),
+                            recipient("partner@firm.test"),
+                        ])
+                    }
+                >
+                    add two recipients
+                </button>
+            </>
+        );
+    },
+}));
+
+const createdReview = {
+    id: "review-1",
+    project_id: null,
+    user_id: "me",
+    title: "Diligence",
+    columns_config: [],
+    document_ids: [],
+    created_at: "2026-01-01T00:00:00Z",
+    updated_at: "2026-01-01T00:00:00Z",
+} as unknown as TabularReview;
+
+// The empty state behind the dialog offers its own "Create"; the one under
+// test is the dialog's submit button.
+function createButton() {
+    const submit = screen
+        .getAllByRole("button", { name: "Create" })
+        .find((button) => button.getAttribute("type") === "submit");
+    if (!submit) throw new Error("dialog Create button not found");
+    return submit;
+}
+
+async function openDialogAndReachCreate() {
+    render(<TabularReviewsPage />);
+    fireEvent.click(screen.getByRole("button", { name: "New tabular review" }));
+    fireEvent.change(await screen.findByLabelText("Review name"), {
+        target: { value: "Diligence" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Next" }));
+    fireEvent.click(screen.getByRole("button", { name: "add recipient" }));
+    fireEvent.click(screen.getByRole("button", { name: "Next" }));
+    return createButton();
+}
+
+describe("Tabular reviews page creation", () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        window.matchMedia = vi.fn().mockImplementation((query: string) => ({
+            matches: true,
+            media: query,
+            onchange: null,
+            addListener: vi.fn(),
+            removeListener: vi.fn(),
+            addEventListener: vi.fn(),
+            removeEventListener: vi.fn(),
+            dispatchEvent: vi.fn(),
+        }));
+    });
+
+    it("keeps the created review and reports the refused grant instead of creating a second review", async () => {
+        createTabularReview.mockResolvedValue(createdReview);
+        grantTabularReviewAccess.mockRejectedValue(
+            new MikeApiError({
+                message: "That address is not in your organization.",
+                status: 400,
+            }),
+        );
+
+        const create = await openDialogAndReachCreate();
+        fireEvent.click(create);
+
+        expect(
+            await screen.findByText(
+                "Review created, but access was not granted to colleague@firm.test: That address is not in your organization.",
+            ),
+        ).toBeInTheDocument();
+        expect(createTabularReview).toHaveBeenCalledTimes(1);
+        expect(push).not.toHaveBeenCalled();
+
+        // Pressing Create again is the user's retry of the sharing, not of the
+        // review: a second review here is the duplicate this fix exists for.
+        fireEvent.click(createButton());
+        await waitFor(() =>
+            expect(grantTabularReviewAccess).toHaveBeenCalledTimes(2),
+        );
+        expect(createTabularReview).toHaveBeenCalledTimes(1);
+    });
+
+    it("navigates once the retried grant succeeds", async () => {
+        createTabularReview.mockResolvedValue(createdReview);
+        grantTabularReviewAccess.mockRejectedValueOnce(
+            new MikeApiError({ message: "Rate limited", status: 429 }),
+        );
+        grantTabularReviewAccess.mockResolvedValue({});
+
+        const create = await openDialogAndReachCreate();
+        fireEvent.click(create);
+        expect(
+            await screen.findByText(/Review created, but access was not granted/),
+        ).toBeInTheDocument();
+
+        fireEvent.click(createButton());
+        await waitFor(() =>
+            expect(push).toHaveBeenCalledWith("/tabular-reviews/review-1"),
+        );
+        expect(createTabularReview).toHaveBeenCalledTimes(1);
+    });
+
+    it("reports one refusal per recipient without losing the others", async () => {
+        createTabularReview.mockResolvedValue(createdReview);
+        grantTabularReviewAccess.mockRejectedValue(
+            new MikeApiError({ message: "No such user.", status: 404 }),
+        );
+
+        render(<TabularReviewsPage />);
+        fireEvent.click(
+            screen.getByRole("button", { name: "New tabular review" }),
+        );
+        fireEvent.change(await screen.findByLabelText("Review name"), {
+            target: { value: "Diligence" },
+        });
+        fireEvent.click(screen.getByRole("button", { name: "Next" }));
+        fireEvent.click(
+            screen.getByRole("button", { name: "add two recipients" }),
+        );
+        fireEvent.click(screen.getByRole("button", { name: "Next" }));
+        fireEvent.click(createButton());
+
+        // One refusal must not abandon the recipients behind it: the loop used
+        // to stop at the first throw, so the second address was never tried
+        // and never named.
+        expect(
+            await screen.findByText(
+                "Review created, but access was not granted to colleague@firm.test, partner@firm.test: No such user.",
+            ),
+        ).toBeInTheDocument();
+        expect(grantTabularReviewAccess).toHaveBeenCalledTimes(2);
+        expect(grantTabularReviewAccess).toHaveBeenCalledWith(
+            "review-1",
+            "partner@firm.test",
+            "editor",
+        );
+    });
+
+    it("refetches the list when a partially created review is dismissed", async () => {
+        // The page only puts a new review on screen through the navigation a
+        // successful create performs, so a review created behind a refused
+        // grant was invisible until a reload.
+        createTabularReview.mockResolvedValue(createdReview);
+        grantTabularReviewAccess.mockRejectedValue(
+            new MikeApiError({ message: "No such user.", status: 404 }),
+        );
+
+        const create = await openDialogAndReachCreate();
+        fireEvent.click(create);
+        await screen.findByText(/Review created, but access was not granted/);
+
+        fireEvent.click(screen.getByRole("button", { name: "Close" }));
+        expect(retry).toHaveBeenCalledTimes(1);
+    });
+
+    it("does not refetch when the dialog is dismissed with nothing created", async () => {
+        render(<TabularReviewsPage />);
+        fireEvent.click(
+            screen.getByRole("button", { name: "New tabular review" }),
+        );
+        await screen.findByLabelText("Review name");
+
+        fireEvent.click(screen.getByRole("button", { name: "Close" }));
+
+        expect(retry).not.toHaveBeenCalled();
+    });
+
+    it("cannot be dismissed while the review is being created", async () => {
+        // Leaving mid-create strands the only account of what happened to it.
+        createTabularReview.mockReturnValue(new Promise(() => {}));
+
+        const create = await openDialogAndReachCreate();
+        fireEvent.click(create);
+        await waitFor(() => expect(createTabularReview).toHaveBeenCalled());
+
+        fireEvent.click(screen.getByRole("button", { name: "Close" }));
+
+        expect(screen.getByRole("dialog")).toBeInTheDocument();
+        expect(retry).not.toHaveBeenCalled();
+    });
+});

--- a/frontend/src/app/(pages)/tabular-reviews/page.tsx
+++ b/frontend/src/app/(pages)/tabular-reviews/page.tsx
@@ -27,6 +27,7 @@ import {
     type AccessContact,
 } from "@/app/components/popups/PermissionDeniedPopup";
 import { can, roleFrom } from "@/app/lib/permissions";
+import { userFacingApiError } from "@/app/lib/userFacingError";
 import { WarningPopup } from "@/app/components/popups/WarningPopup";
 import { ConfirmPopup } from "@/app/components/popups/ConfirmPopup";
 import { useAuth } from "@/app/contexts/AuthContext";
@@ -87,6 +88,10 @@ export default function TabularReviewsPage() {
     const [projects, setProjects] = useState<Project[]>([]);
     const [creating, setCreating] = useState(false);
     const [newTROpen, setNewTROpen] = useState(false);
+    // Holds the review created by the open New review dialog so a retry after
+    // a failed access grant does not create a second one. Cleared when the
+    // dialog closes, whether it finished or was cancelled.
+    const createdReviewRef = useRef<TabularReview | null>(null);
     const [detailsReview, setDetailsReview] = useState<TabularReview | null>(
         null,
     );
@@ -260,24 +265,56 @@ export default function TabularReviewsPage() {
             email: string;
             role: import("@/app/lib/mikeApi").AccessAssignmentRole;
         }[],
-    ) => {
+    ): Promise<string | void> => {
         setCreating(true);
         try {
-            const review = await createTabularReview({
-                title,
-                document_ids: documentIds ?? [],
-                columns_config: columnsConfig ?? [],
-                document_grouping: documentGrouping,
-                model,
-                ...(projectId && { project_id: projectId }),
-            });
+            // A grant that fails after the review exists used to throw out of
+            // here, so the modal said "Could not create the review." and a
+            // second Create made a SECOND review. The created row is held
+            // until the modal closes, so a retry re-runs only the grants.
+            const review =
+                createdReviewRef.current ??
+                (await createTabularReview({
+                    title,
+                    document_ids: documentIds ?? [],
+                    columns_config: columnsConfig ?? [],
+                    document_grouping: documentGrouping,
+                    model,
+                    ...(projectId && { project_id: projectId }),
+                }));
+            createdReviewRef.current = review;
+
+            // Sequential, one try per recipient: these are a handful of
+            // addresses, and one refusal should be reported with its own
+            // message rather than losing the others. The endpoint upserts,
+            // so retrying after a partial failure is safe.
+            const grantFailures: { email: string; detail: string }[] = [];
             for (const assignment of accessAssignments) {
-                await grantTabularReviewAccess(
-                    review.id,
-                    assignment.email,
-                    assignment.role,
-                );
+                try {
+                    await grantTabularReviewAccess(
+                        review.id,
+                        assignment.email,
+                        assignment.role,
+                    );
+                } catch (error: unknown) {
+                    grantFailures.push({
+                        email: assignment.email,
+                        detail: userFacingApiError(error, "the request failed"),
+                    });
+                }
             }
+            if (grantFailures.length > 0) {
+                // The review exists, so say so — and stay on the dialog rather
+                // than navigating away from the only place that knows the
+                // sharing did not happen. Same wording as NewProjectModal.
+                return `Review created, but access was not granted to ${grantFailures
+                    .map((failure) => failure.email)
+                    .join(", ")}: ${grantFailures[0].detail}`;
+            }
+
+            // Handed over: the navigation below shows the review, so the
+            // dialog's close must not ask the list to refetch for it.
+            createdReviewRef.current = null;
             router.push(
                 projectId
                     ? `/projects/${projectId}/tabular-reviews/${review.id}`
@@ -840,7 +877,20 @@ export default function TabularReviewsPage() {
 
             <NewTRModal
                 open={newTROpen}
-                onClose={() => setNewTROpen(false)}
+                onClose={() => {
+                    // The dialog's own reset runs through here, so this is the
+                    // one place that has to forget the held review.
+                    //
+                    // A review created behind a refused grant never reached
+                    // the list — the page only adds it on the navigation that
+                    // a successful create performs — so refetch on the way out
+                    // instead of leaving it invisible until a reload.
+                    const createdWithoutHandover =
+                        createdReviewRef.current !== null;
+                    createdReviewRef.current = null;
+                    setNewTROpen(false);
+                    if (createdWithoutHandover) retry();
+                }}
                 onAdd={handleNewReview}
                 projects={projects}
             />

--- a/frontend/src/app/components/assistant/ChatAccessModal.test.tsx
+++ b/frontend/src/app/components/assistant/ChatAccessModal.test.tsx
@@ -1,59 +1,100 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { useEffect, useState } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { Chat } from "@/app/components/shared/types";
+import { MikeApiError } from "@/app/lib/mikeApi";
+import { userFacingApiError } from "@/app/lib/userFacingError";
 import { ChatAccessModal } from "./ChatAccessModal";
 
-const { getChatAccess, grantChatAccess, revokeChatAccess } = vi.hoisted(() => ({
-    getChatAccess: vi.fn(),
-    grantChatAccess: vi.fn(),
-    revokeChatAccess: vi.fn(),
-}));
+const { getChatAccess, getChatPeople, grantChatAccess, revokeChatAccess } =
+    vi.hoisted(() => ({
+        getChatAccess: vi.fn(),
+        getChatPeople: vi.fn(),
+        grantChatAccess: vi.fn(),
+        revokeChatAccess: vi.fn(),
+    }));
 
 vi.mock("@/app/contexts/AuthContext", () => ({
     useAuth: () => ({ user: { email: "me@example.com" } }),
 }));
 
-vi.mock("@/app/lib/mikeApi", () => ({
+// importOriginal so MikeApiError stays the real class — userFacingApiError
+// picks the server's own wording with an `instanceof` test.
+vi.mock("@/app/lib/mikeApi", async (importOriginal) => ({
+    ...(await importOriginal<typeof import("@/app/lib/mikeApi")>()),
     getChatAccess: (...args: unknown[]) => getChatAccess(...args),
-    getChatPeople: vi.fn(),
+    getChatPeople: (...args: unknown[]) => getChatPeople(...args),
     grantChatAccess: (...args: unknown[]) => grantChatAccess(...args),
     revokeChatAccess: (...args: unknown[]) => revokeChatAccess(...args),
 }));
 
+// A faithful miniature of AccessModal: it CALLS fetchAccess and renders the
+// rejection through userFacingApiError, exactly as the real one does. That
+// call is the modal's error channel, and ChatAccessModal now routes the
+// owner-only grants request through it — a stub that never called
+// fetchAccess would test nothing about either.
 vi.mock("@/app/components/modals/AccessModal", () => ({
     AccessModal: (props: {
         breadcrumb: string[];
         currentUserEmail?: string | null;
+        resource: { id: string } | null;
+        fetchAccess: (id: string) => Promise<unknown>;
         access: {
             canManage: boolean;
             onGrant: (email: string, role: "editor") => Promise<void>;
             onRevoke: (email: string) => Promise<void>;
         };
-    }) => (
-        <div>
-            <span>{props.breadcrumb.join(" / ")}</span>
-            <span data-testid="current-email">{props.currentUserEmail}</span>
-            <span data-testid="can-manage">
-                {String(props.access.canManage)}
-            </span>
-            <button
-                type="button"
-                onClick={() =>
-                    void props.access.onGrant("colleague@example.com", "editor")
+    }) => {
+        const [error, setError] = useState<string | null>(null);
+        const resourceId = props.resource?.id ?? null;
+        const fetchAccess = props.fetchAccess;
+        useEffect(() => {
+            if (!resourceId) return;
+            let cancelled = false;
+            void fetchAccess(resourceId).catch((cause: unknown) => {
+                if (!cancelled) {
+                    setError(
+                        userFacingApiError(
+                            cause,
+                            "Could not load access details.",
+                        ),
+                    );
                 }
-            >
-                Grant
-            </button>
-            <button
-                type="button"
-                onClick={() =>
-                    void props.access.onRevoke("colleague@example.com")
-                }
-            >
-                Revoke
-            </button>
-        </div>
-    ),
+            });
+            return () => {
+                cancelled = true;
+            };
+        }, [fetchAccess, resourceId]);
+        return (
+            <div>
+                <span>{props.breadcrumb.join(" / ")}</span>
+                <span data-testid="current-email">{props.currentUserEmail}</span>
+                <span data-testid="can-manage">
+                    {String(props.access.canManage)}
+                </span>
+                <span data-testid="access-error">{error}</span>
+                <button
+                    type="button"
+                    onClick={() =>
+                        void props.access.onGrant(
+                            "colleague@example.com",
+                            "editor",
+                        )
+                    }
+                >
+                    Grant
+                </button>
+                <button
+                    type="button"
+                    onClick={() =>
+                        void props.access.onRevoke("colleague@example.com")
+                    }
+                >
+                    Revoke
+                </button>
+            </div>
+        );
+    },
 }));
 
 function chat(overrides: Partial<Chat> = {}): Chat {
@@ -69,6 +110,7 @@ function chat(overrides: Partial<Chat> = {}): Chat {
 
 beforeEach(() => {
     vi.clearAllMocks();
+    getChatPeople.mockResolvedValue({ owner: null, members: [] });
     getChatAccess.mockResolvedValue({
         scope: "direct",
         org_id: null,
@@ -119,5 +161,53 @@ describe("ChatAccessModal", () => {
 
         expect(screen.getByTestId("can-manage")).toHaveTextContent("false");
         expect(getChatAccess).not.toHaveBeenCalled();
+    });
+
+    it("tells an owner when the access load failed", async () => {
+        // The failure used to land in a `.catch` that was a comment: `access`
+        // stayed null, `canManage && access !== null` fell to false, and the
+        // owner got a modal that was read-only for no stated reason —
+        // indistinguishable from genuinely not being allowed to manage it.
+        getChatAccess.mockRejectedValue(
+            new MikeApiError({
+                message: "Access details are unavailable",
+                status: 409,
+            }),
+        );
+
+        render(
+            <ChatAccessModal
+                open
+                chat={chat({ is_owner: true })}
+                onClose={vi.fn()}
+            />,
+        );
+
+        await waitFor(() =>
+            expect(screen.getByTestId("access-error")).toHaveTextContent(
+                "Access details are unavailable",
+            ),
+        );
+        // Still fail-closed: nothing may be granted from a modal that does
+        // not know the current grants.
+        expect(screen.getByTestId("can-manage")).toHaveTextContent("false");
+    });
+
+    it("falls back to generic wording for a non-4xx access failure", async () => {
+        getChatAccess.mockRejectedValue(new Error("network"));
+
+        render(
+            <ChatAccessModal
+                open
+                chat={chat({ is_owner: true })}
+                onClose={vi.fn()}
+            />,
+        );
+
+        await waitFor(() =>
+            expect(screen.getByTestId("access-error")).toHaveTextContent(
+                "Could not load access details.",
+            ),
+        );
     });
 });

--- a/frontend/src/app/components/assistant/ChatAccessModal.test.tsx
+++ b/frontend/src/app/components/assistant/ChatAccessModal.test.tsx
@@ -15,7 +15,7 @@ const { getChatAccess, getChatPeople, grantChatAccess, revokeChatAccess } =
     }));
 
 vi.mock("@/app/contexts/AuthContext", () => ({
-    useAuth: () => ({ user: { email: "me@example.com" } }),
+    useAuth: () => ({ user: { id: "user-1", email: "me@example.com" } }),
 }));
 
 // importOriginal so MikeApiError stays the real class — userFacingApiError
@@ -28,39 +28,51 @@ vi.mock("@/app/lib/mikeApi", async (importOriginal) => ({
     revokeChatAccess: (...args: unknown[]) => revokeChatAccess(...args),
 }));
 
-// A faithful miniature of AccessModal: it CALLS fetchAccess and renders the
-// rejection through userFacingApiError, exactly as the real one does. That
-// call is the modal's error channel, and ChatAccessModal now routes the
-// owner-only grants request through it — a stub that never called
-// fetchAccess would test nothing about either.
+// A faithful miniature of AccessModal: it CALLS fetchAccess, renders the
+// roster it resolves with, and renders a rejection through userFacingApiError
+// exactly as the real one does — plus the `access.error` line the real modal
+// shows beside the roster. Both channels matter here: the roster and the
+// owner-only grants are separate permissions, and a stub that collapsed them
+// would test neither.
 vi.mock("@/app/components/modals/AccessModal", () => ({
     AccessModal: (props: {
         breadcrumb: string[];
         currentUserEmail?: string | null;
+        currentUserId?: string | null;
         resource: { id: string } | null;
         fetchAccess: (id: string) => Promise<unknown>;
         access: {
             canManage: boolean;
+            error?: string | null;
             onGrant: (email: string, role: "editor") => Promise<void>;
             onRevoke: (email: string) => Promise<void>;
         };
     }) => {
         const [error, setError] = useState<string | null>(null);
+        const [members, setMembers] = useState<string | null>(null);
         const resourceId = props.resource?.id ?? null;
         const fetchAccess = props.fetchAccess;
         useEffect(() => {
             if (!resourceId) return;
             let cancelled = false;
-            void fetchAccess(resourceId).catch((cause: unknown) => {
-                if (!cancelled) {
-                    setError(
-                        userFacingApiError(
-                            cause,
-                            "Could not load access details.",
-                        ),
-                    );
-                }
-            });
+            void fetchAccess(resourceId)
+                .then((people) => {
+                    if (cancelled) return;
+                    const roster = people as {
+                        members?: { email: string }[];
+                    } | null;
+                    setMembers(String(roster?.members?.length ?? 0));
+                })
+                .catch((cause: unknown) => {
+                    if (!cancelled) {
+                        setError(
+                            userFacingApiError(
+                                cause,
+                                "Could not load access details.",
+                            ),
+                        );
+                    }
+                });
             return () => {
                 cancelled = true;
             };
@@ -69,10 +81,18 @@ vi.mock("@/app/components/modals/AccessModal", () => ({
             <div>
                 <span>{props.breadcrumb.join(" / ")}</span>
                 <span data-testid="current-email">{props.currentUserEmail}</span>
+                <span data-testid="current-id">
+                    {String(props.currentUserId)}
+                </span>
                 <span data-testid="can-manage">
                     {String(props.access.canManage)}
                 </span>
-                <span data-testid="access-error">{error}</span>
+                <span data-testid="member-count">
+                    {members ?? "unresolved"}
+                </span>
+                <span data-testid="access-error">
+                    {error ?? props.access.error}
+                </span>
                 <button
                     type="button"
                     onClick={() =>
@@ -193,6 +213,80 @@ describe("ChatAccessModal", () => {
         expect(screen.getByTestId("can-manage")).toHaveTextContent("false");
     });
 
+    it("passes the signed-in user's id so their own row stays read-only", async () => {
+        // The editor identifies "you" by id first and email second; this was
+        // the one caller that sent no id, so a roster row with a null email
+        // let the owner aim Remove at themselves.
+        render(
+            <ChatAccessModal
+                open
+                chat={chat({ is_owner: true })}
+                onClose={vi.fn()}
+            />,
+        );
+
+        expect(screen.getByTestId("current-id")).toHaveTextContent("user-1");
+    });
+
+    it("keeps the roster when the owner-only grants fetch is refused", async () => {
+        // The two requests answer to different permissions. Chained, a 403 on
+        // the grants call rejected the roster with it and the modal claimed
+        // "No one has access yet" about a chat that plainly has people on it.
+        getChatPeople.mockResolvedValue({
+            owner: { user_id: "user-1", email: "me@example.com" },
+            members: [
+                { user_id: "user-2", email: "a@example.com", role: "editor" },
+                { user_id: "user-3", email: "b@example.com", role: "viewer" },
+            ],
+        });
+        getChatAccess.mockRejectedValue(
+            new MikeApiError({
+                message: "You do not have access to manage this chat",
+                status: 403,
+            }),
+        );
+
+        render(
+            <ChatAccessModal
+                open
+                chat={chat({ is_owner: true })}
+                onClose={vi.fn()}
+            />,
+        );
+
+        await waitFor(() =>
+            expect(screen.getByTestId("member-count")).toHaveTextContent("2"),
+        );
+        expect(screen.getByTestId("access-error")).toHaveTextContent(
+            "You do not have access to manage this chat",
+        );
+        // Fail closed on management, without lying about the roster.
+        expect(screen.getByTestId("can-manage")).toHaveTextContent("false");
+    });
+
+    it("still reports a roster failure through the modal's error channel", async () => {
+        getChatPeople.mockRejectedValue(
+            new MikeApiError({ message: "Chat not found", status: 404 }),
+        );
+
+        render(
+            <ChatAccessModal
+                open
+                chat={chat({ is_owner: true })}
+                onClose={vi.fn()}
+            />,
+        );
+
+        await waitFor(() =>
+            expect(screen.getByTestId("access-error")).toHaveTextContent(
+                "Chat not found",
+            ),
+        );
+        expect(screen.getByTestId("member-count")).toHaveTextContent(
+            "unresolved",
+        );
+    });
+
     it("falls back to generic wording for a non-4xx access failure", async () => {
         getChatAccess.mockRejectedValue(new Error("network"));
 
@@ -206,7 +300,7 @@ describe("ChatAccessModal", () => {
 
         await waitFor(() =>
             expect(screen.getByTestId("access-error")).toHaveTextContent(
-                "Could not load access details.",
+                "Sharing details could not be loaded, so access cannot be changed here.",
             ),
         );
     });

--- a/frontend/src/app/components/assistant/ChatAccessModal.tsx
+++ b/frontend/src/app/components/assistant/ChatAccessModal.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useState } from "react";
 import { AccessModal } from "@/app/components/modals/AccessModal";
 import { useAuth } from "@/app/contexts/AuthContext";
 import {
@@ -34,23 +34,29 @@ export function ChatAccessModal({ open, chat, onClose }: Props) {
         setAccessState({ chatId: chat.id, value: nextAccess });
     }, [chat.id]);
 
-    useEffect(() => {
-        if (!open || !canManage) return;
-        let cancelled = false;
-        getChatAccess(chat.id)
-            .then((nextAccess) => {
-                if (!cancelled) {
-                    setAccessState({ chatId: chat.id, value: nextAccess });
-                }
-            })
-            .catch(() => {
-                // The people roster remains useful if the management-only
-                // access request fails. Controls stay disabled until it succeeds.
-            });
-        return () => {
-            cancelled = true;
-        };
-    }, [canManage, chat.id, open]);
+    /**
+     * Load the roster and, for a manager, the grants — as one request from
+     * AccessModal's point of view, so both share its error channel.
+     *
+     * The owner-only grant fetch used to run in its own effect whose
+     * `.catch` was a comment. When it failed, `access` stayed null,
+     * `canManage && access !== null` fell to false, and the owner got a
+     * modal that was silently read-only with nothing on screen saying why —
+     * indistinguishable from genuinely not being allowed to manage it.
+     * Rejecting here instead routes the failure into the modal's own error
+     * line (userFacingApiError, so a 4xx shows the server's wording).
+     */
+    const loadPeople = useCallback(
+        async (chatId: string) => {
+            const people = await getChatPeople(chatId);
+            if (canManage) {
+                const nextAccess = await getChatAccess(chatId);
+                setAccessState({ chatId, value: nextAccess });
+            }
+            return people;
+        },
+        [canManage],
+    );
 
     return (
         <AccessModal
@@ -60,7 +66,7 @@ export function ChatAccessModal({ open, chat, onClose }: Props) {
                 id: chat.id,
                 owner_display_name: chat.creator_display_name ?? null,
             }}
-            fetchAccess={getChatPeople}
+            fetchAccess={loadPeople}
             currentUserEmail={user?.email ?? null}
             breadcrumb={[
                 "Assistant",

--- a/frontend/src/app/components/assistant/ChatAccessModal.tsx
+++ b/frontend/src/app/components/assistant/ChatAccessModal.tsx
@@ -11,6 +11,7 @@ import {
     type ContentAccess,
 } from "@/app/lib/mikeApi";
 import { can, roleFrom } from "@/app/lib/permissions";
+import { userFacingApiError } from "@/app/lib/userFacingError";
 import type { Chat } from "@/app/components/shared/types";
 
 interface Props {
@@ -25,6 +26,7 @@ export function ChatAccessModal({ open, chat, onClose }: Props) {
         chatId: string;
         value: ContentAccess;
     } | null>(null);
+    const [accessError, setAccessError] = useState<string | null>(null);
     const access =
         accessState?.chatId === chat.id ? accessState.value : null;
     const canManage = can(roleFrom(chat), "access.manage");
@@ -35,23 +37,42 @@ export function ChatAccessModal({ open, chat, onClose }: Props) {
     }, [chat.id]);
 
     /**
-     * Load the roster and, for a manager, the grants — as one request from
-     * AccessModal's point of view, so both share its error channel.
+     * Load the roster, and for a manager the grants as well.
      *
-     * The owner-only grant fetch used to run in its own effect whose
-     * `.catch` was a comment. When it failed, `access` stayed null,
-     * `canManage && access !== null` fell to false, and the owner got a
-     * modal that was silently read-only with nothing on screen saying why —
-     * indistinguishable from genuinely not being allowed to manage it.
-     * Rejecting here instead routes the failure into the modal's own error
-     * line (userFacingApiError, so a 4xx shows the server's wording).
+     * The owner-only grant fetch used to run in its own effect whose `.catch`
+     * was a comment. When it failed, `access` stayed null, `canManage &&
+     * access !== null` fell to false, and the owner got a modal that was
+     * silently read-only with nothing on screen saying why — so it moved in
+     * here to share the modal's error line.
+     *
+     * Chained, though, the two requests became one: `canManage` is derived
+     * from the row the CLIENT holds, which can be more generous than the
+     * server's answer (a stale sidebar row, an access change in another tab).
+     * The grants call then 403s, the whole promise rejects, the roster is
+     * discarded with it, and the modal tells somebody who can plainly see the
+     * chat that "No one has access yet" — a false statement, and the worse
+     * one of the two failures. The roster stands on its own now; a refused
+     * grants fetch drops management and says so beside the people it could
+     * still load.
      */
     const loadPeople = useCallback(
         async (chatId: string) => {
             const people = await getChatPeople(chatId);
-            if (canManage) {
+            if (!canManage) {
+                setAccessError(null);
+                return people;
+            }
+            try {
                 const nextAccess = await getChatAccess(chatId);
                 setAccessState({ chatId, value: nextAccess });
+                setAccessError(null);
+            } catch (cause) {
+                setAccessError(
+                    userFacingApiError(
+                        cause,
+                        "Sharing details could not be loaded, so access cannot be changed here.",
+                    ),
+                );
             }
             return people;
         },
@@ -68,6 +89,11 @@ export function ChatAccessModal({ open, chat, onClose }: Props) {
             }}
             fetchAccess={loadPeople}
             currentUserEmail={user?.email ?? null}
+            // The one caller that omitted this. The editor keeps the viewer's
+            // own row read-only by id first and email second, and a roster row
+            // for the signed-in user can arrive with a null email — which left
+            // the owner able to aim Remove at themselves.
+            currentUserId={user?.id ?? null}
             breadcrumb={[
                 "Assistant",
                 chat.title?.trim() || "Untitled chat",
@@ -82,6 +108,7 @@ export function ChatAccessModal({ open, chat, onClose }: Props) {
                     null,
                 ownerLabel: "Owners",
                 canManage: canManage && access !== null,
+                error: accessError,
                 onGrant: async (email, role) => {
                     await grantChatAccess(chat.id, email, role);
                     await refreshAccess();

--- a/frontend/src/app/components/assistant/ChatInput.canSend.test.tsx
+++ b/frontend/src/app/components/assistant/ChatInput.canSend.test.tsx
@@ -57,7 +57,7 @@ function mockProfile() {
     } as unknown as ReturnType<typeof useUserProfile>);
 }
 
-function renderInput(canSend: boolean, onSubmit = vi.fn()) {
+function renderInput(canSend: boolean | null, onSubmit = vi.fn()) {
     render(
         <ChatInput
             onSubmit={onSubmit}
@@ -117,6 +117,33 @@ describe("ChatInput canSend gating", () => {
         fireEvent.drop(window, { dataTransfer });
 
         expect(uploadProjectDocument).not.toHaveBeenCalled();
+    });
+
+    it("stays neutral while the caller's standing is unknown", () => {
+        // null is "not known yet", not "not allowed". The composer is closed
+        // the same way, but accusing an owner of viewer status for the length
+        // of a fetch — which is what every cold load did — is a wrong
+        // statement, not a loading state.
+        renderInput(null);
+
+        const textarea = screen.getByPlaceholderText("Loading…");
+        expect(textarea).toBeDisabled();
+        expect(
+            screen.queryByPlaceholderText(
+                "Viewing only — sending needs edit access",
+            ),
+        ).toBeNull();
+        expect(
+            screen.getByRole("button", { name: "Send message" }),
+        ).toBeDisabled();
+    });
+
+    it("does not submit on Enter while the standing is unknown", () => {
+        const onSubmit = renderInput(null);
+        const textarea = screen.getByRole("combobox");
+
+        fireEvent.keyDown(textarea, { key: "Enter" });
+        expect(onSubmit).not.toHaveBeenCalled();
     });
 
     it("keeps the default composer when canSend is omitted", () => {

--- a/frontend/src/app/components/assistant/ChatInput.tsx
+++ b/frontend/src/app/components/assistant/ChatInput.tsx
@@ -89,8 +89,14 @@ interface Props {
      * Whether the caller may write into this chat. False renders a read-only
      * composer — sending, attaching, and drop-uploads stay off, matching
      * what the server would refuse for a project viewer.
+     *
+     * `null` means the answer has not arrived. The composer is closed exactly
+     * as for `false`, but the placeholder stays neutral: telling an owner
+     * "Viewing only — sending needs edit access" for the length of a fetch,
+     * on every cold load, is a wrong statement about their access, not a
+     * loading state.
      */
-    canSend?: boolean;
+    canSend?: boolean | null;
     hideAddDocButton?: boolean;
     hideWorkflowButton?: boolean;
     projectName?: string;
@@ -669,9 +675,11 @@ export const ChatInput = forwardRef<ChatInputHandle, Props>(function ChatInput(
                             rows={1}
                             disabled={!canSend}
                             placeholder={
-                                canSend
-                                    ? "How can I help?"
-                                    : "Viewing only — sending needs edit access"
+                                canSend === null
+                                    ? "Loading…"
+                                    : canSend
+                                      ? "How can I help?"
+                                      : "Viewing only — sending needs edit access"
                             }
                             value={value}
                             onChange={handleChange}

--- a/frontend/src/app/components/assistant/ChatView.citations.test.tsx
+++ b/frontend/src/app/components/assistant/ChatView.citations.test.tsx
@@ -1,0 +1,188 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { Chat, Citation, Message } from "@/app/components/shared/types";
+import { MikeApiError } from "@/app/lib/mikeApi";
+import { ChatView } from "./ChatView";
+import { PageChromeContext } from "@/app/contexts/PageChromeContext";
+
+// A chat can be shared without the documents behind it. For a shared
+// STANDALONE chat that is the normal case: the recipient holds no grant on
+// the single-documents, so GET /single-documents/:id/versions answers 404,
+// the panel document resolved to null, and openCitation returned — no tab,
+// no message, nothing. Every citation pill in a shared chat was a dead
+// control. The fix is not to widen access; it is to say what happened.
+
+const { listDocumentVersions } = vi.hoisted(() => ({
+    listDocumentVersions: vi.fn(),
+}));
+
+vi.mock("@/app/lib/mikeApi", async (importOriginal) => ({
+    ...(await importOriginal<typeof import("@/app/lib/mikeApi")>()),
+    listDocumentVersions: (...args: unknown[]) => listDocumentVersions(...args),
+}));
+
+vi.mock("next/navigation", () => ({ useRouter: () => ({ push: vi.fn() }) }));
+vi.mock("@/app/contexts/SidebarContext", () => ({
+    useSidebar: () => ({ setSidebarOpen: vi.fn() }),
+}));
+vi.mock("@/app/contexts/ChatHistoryContext", () => ({
+    useChatHistoryContext: () => ({
+        chats: [],
+        renameChat: vi.fn(),
+        deleteChat: vi.fn(),
+        setCurrentChatId: vi.fn(),
+        setNewChatMessages: vi.fn(),
+    }),
+}));
+vi.mock("./ChatInput", () => ({ ChatInput: () => <div>Chat input</div> }));
+vi.mock("./UserMessage", () => ({ UserMessage: () => null }));
+vi.mock("./AssistantWorkflowModal", () => ({
+    AssistantWorkflowModal: () => null,
+}));
+vi.mock("./ChatAccessModal", () => ({ ChatAccessModal: () => null }));
+// Keep the tab helpers (ChatView computes tab ids with them) and stub only
+// the panel itself; rendering a real document viewer is DocPanel's business,
+// not this file's.
+vi.mock("./AssistantSidePanel", async (importOriginal) => ({
+    ...(await importOriginal<typeof import("./AssistantSidePanel")>()),
+    AssistantSidePanel: ({ tabs }: { tabs: { id: string }[] }) => (
+        <div data-testid="panel-tabs">{tabs.length}</div>
+    ),
+}));
+
+// Stand in for the citation pill: one button that fires the callback
+// ChatView wires to openCitation.
+vi.mock("./AssistantMessage", () => ({
+    AssistantMessage: ({
+        citations,
+        onCitationClick,
+    }: {
+        citations?: Citation[];
+        onCitationClick?: (citation: Citation) => void;
+    }) => (
+        <button
+            type="button"
+            onClick={() => citations?.[0] && onCitationClick?.(citations[0])}
+        >
+            citation pill
+        </button>
+    ),
+}));
+
+class ResizeObserverMock {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+}
+
+const chat: Chat = {
+    id: "chat-1",
+    project_id: null,
+    user_id: "someone-else",
+    title: "Quarterly filing",
+    created_at: new Date().toISOString(),
+    is_owner: false,
+    access_role: "editor",
+};
+
+const citation: Citation = {
+    type: "citation_data",
+    kind: "document",
+    ref: 1,
+    doc_id: "doc-1",
+    document_id: "doc-1",
+    filename: "agreement.docx",
+    page: 1,
+    quote: "the quoted clause",
+    document: {
+        document_id: "doc-1",
+        title: "agreement.docx",
+        type: "docx",
+        metadata: [],
+        quotes: [{ quote: "the quoted clause", target: { page: 1 } }],
+        version_id: null,
+        version_number: null,
+    },
+};
+
+const messages: Message[] = [
+    { id: "m1", role: "assistant", content: "answer", citations: [citation] },
+];
+
+function renderView() {
+    render(
+        <PageChromeContext.Provider value={{ mobileActionsContainer: null }}>
+            <ChatView
+                chatId="chat-1"
+                chat={chat}
+                messages={messages}
+                isResponseLoading={false}
+                handleChat={vi.fn().mockResolvedValue("chat-1")}
+                cancel={vi.fn()}
+                canSend
+            />
+        </PageChromeContext.Provider>,
+    );
+}
+
+beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubGlobal("ResizeObserver", ResizeObserverMock);
+    Object.defineProperty(HTMLElement.prototype, "scrollTo", {
+        configurable: true,
+        value: vi.fn(),
+    });
+});
+
+describe("ChatView citation on a chat shared without its documents", () => {
+    it("explains a refused document instead of doing nothing", async () => {
+        listDocumentVersions.mockRejectedValue(
+            new MikeApiError({ message: "Not found", status: 404 }),
+        );
+        renderView();
+
+        fireEvent.click(screen.getByRole("button", { name: "citation pill" }));
+
+        expect(
+            await screen.findByText("Document not shared"),
+        ).toBeInTheDocument();
+        expect(
+            screen.getByText(
+                "The person who shared this chat has not shared its documents.",
+            ),
+        ).toBeInTheDocument();
+    });
+
+    it("stays quiet when the lookup merely failed", async () => {
+        // A transport failure says nothing about the caller's access, so it
+        // must not be reported as one.
+        listDocumentVersions.mockRejectedValue(new Error("network"));
+        renderView();
+
+        fireEvent.click(screen.getByRole("button", { name: "citation pill" }));
+
+        await waitFor(() => expect(listDocumentVersions).toHaveBeenCalled());
+        expect(screen.queryByText("Document not shared")).not.toBeInTheDocument();
+    });
+
+    it("opens the citation normally when the versions are readable", async () => {
+        listDocumentVersions.mockResolvedValue({
+            current_version_id: "v1",
+            versions: [
+                {
+                    id: "v1",
+                    version_number: 1,
+                    source: "upload",
+                    created_at: "2026-08-18T00:00:00Z",
+                    filename: "agreement.docx",
+                },
+            ],
+        });
+        renderView();
+
+        fireEvent.click(screen.getByRole("button", { name: "citation pill" }));
+
+        expect(await screen.findByTestId("panel-tabs")).toHaveTextContent("1");
+        expect(screen.queryByText("Document not shared")).not.toBeInTheDocument();
+    });
+});

--- a/frontend/src/app/components/assistant/ChatView.citations.test.tsx
+++ b/frontend/src/app/components/assistant/ChatView.citations.test.tsx
@@ -56,16 +56,38 @@ vi.mock("./AssistantMessage", () => ({
     AssistantMessage: ({
         citations,
         onCitationClick,
+        onOpenDocument,
     }: {
         citations?: Citation[];
         onCitationClick?: (citation: Citation) => void;
+        onOpenDocument?: (args: {
+            documentId: string;
+            filename: string;
+            versionId: string | null;
+            versionNumber: number | null;
+        }) => void;
     }) => (
-        <button
-            type="button"
-            onClick={() => citations?.[0] && onCitationClick?.(citations[0])}
-        >
-            citation pill
-        </button>
+        <>
+            <button
+                type="button"
+                onClick={() => citations?.[0] && onCitationClick?.(citations[0])}
+            >
+                citation pill
+            </button>
+            <button
+                type="button"
+                onClick={() =>
+                    onOpenDocument?.({
+                        documentId: "doc-1",
+                        filename: "agreement.docx",
+                        versionId: null,
+                        versionNumber: null,
+                    })
+                }
+            >
+                download card
+            </button>
+        </>
     ),
 }));
 
@@ -109,12 +131,12 @@ const messages: Message[] = [
     { id: "m1", role: "assistant", content: "answer", citations: [citation] },
 ];
 
-function renderView() {
+function renderView(overrides: Partial<Chat> = {}) {
     render(
         <PageChromeContext.Provider value={{ mobileActionsContainer: null }}>
             <ChatView
                 chatId="chat-1"
-                chat={chat}
+                chat={{ ...chat, ...overrides }}
                 messages={messages}
                 isResponseLoading={false}
                 handleChat={vi.fn().mockResolvedValue("chat-1")}
@@ -153,9 +175,10 @@ describe("ChatView citation on a chat shared without its documents", () => {
         ).toBeInTheDocument();
     });
 
-    it("stays quiet when the lookup merely failed", async () => {
+    it("does not call a failed lookup a refusal", async () => {
         // A transport failure says nothing about the caller's access, so it
-        // must not be reported as one.
+        // must not be reported as one — but it is still worth saying, or the
+        // pill looks broken.
         listDocumentVersions.mockRejectedValue(new Error("network"));
         renderView();
 
@@ -163,6 +186,58 @@ describe("ChatView citation on a chat shared without its documents", () => {
 
         await waitFor(() => expect(listDocumentVersions).toHaveBeenCalled());
         expect(screen.queryByText("Document not shared")).not.toBeInTheDocument();
+        expect(
+            await screen.findByText(
+                "This document could not be opened. Please try again.",
+            ),
+        ).toBeInTheDocument();
+    });
+
+    // 404 has two readers. The chat's OWNER gets it when the document they
+    // cited has since been deleted, and telling them somebody withheld their
+    // own file names a culprit who does not exist.
+    it("tells the chat's owner the document is gone, not withheld", async () => {
+        listDocumentVersions.mockRejectedValue(
+            new MikeApiError({ message: "Not found", status: 404 }),
+        );
+        renderView({ is_owner: true, access_role: "owner" });
+
+        fireEvent.click(screen.getByRole("button", { name: "citation pill" }));
+
+        expect(
+            await screen.findByText("This document is no longer available."),
+        ).toBeInTheDocument();
+        expect(
+            screen.queryByText("Document not shared"),
+        ).not.toBeInTheDocument();
+    });
+
+    // The download card asked the same question and threw the answer away:
+    // clicking a card for a missing document did nothing whatsoever.
+    it("explains a refused document from the download card too", async () => {
+        listDocumentVersions.mockRejectedValue(
+            new MikeApiError({ message: "Not found", status: 404 }),
+        );
+        renderView();
+
+        fireEvent.click(screen.getByRole("button", { name: "download card" }));
+
+        expect(
+            await screen.findByText("Document not shared"),
+        ).toBeInTheDocument();
+    });
+
+    it("tells the owner a download card's document is gone", async () => {
+        listDocumentVersions.mockRejectedValue(
+            new MikeApiError({ message: "Not found", status: 404 }),
+        );
+        renderView({ is_owner: true, access_role: "owner" });
+
+        fireEvent.click(screen.getByRole("button", { name: "download card" }));
+
+        expect(
+            await screen.findByText("This document is no longer available."),
+        ).toBeInTheDocument();
     });
 
     it("opens the citation normally when the versions are readable", async () => {

--- a/frontend/src/app/components/assistant/ChatView.tsx
+++ b/frontend/src/app/components/assistant/ChatView.tsx
@@ -35,7 +35,10 @@ import { useSidebar } from "@/app/contexts/SidebarContext";
 import { useChatHistoryContext } from "@/app/contexts/ChatHistoryContext";
 import { usePageChrome } from "@/app/contexts/PageChromeContext";
 import { invalidateDocxBytes } from "@/app/hooks/useFetchDocxBytes";
-import { resolvePanelDocumentVersion } from "./panelDocumentVersion";
+import {
+    resolvePanelDocumentVersion,
+    resolvePanelDocumentVersionResult,
+} from "./panelDocumentVersion";
 import { LIQUID_GLASS_TRANSLUCENT_ACTION_CLASS } from "@/app/components/ui/liquid-surface";
 import { HeaderButtonUI, HeaderButtonsUI } from "@/shared/ui/HeaderButtonsUI";
 import { HeaderActionsMenu } from "@/app/components/shared/HeaderActionsMenu";
@@ -66,8 +69,12 @@ interface Props {
      * Whether the caller may write in this chat. The server serves the
      * standing on GET /chat/:id; surfaces that know it must pass it, so a
      * read-only caller gets the disabled composer instead of a 403 on send.
+     *
+     * `null` is the third answer: not known yet. It closes the composer like
+     * `false` does, but says nothing about the caller's access, so the page
+     * does not accuse an owner of being a viewer for the length of a fetch.
      */
-    canSend?: boolean;
+    canSend?: boolean | null;
 }
 
 const ASSISTANT_PANEL_TRANSITION_MS = 500;
@@ -107,6 +114,11 @@ export function ChatView({
     const [actionGate, setActionGate] = useState<{
         action: string;
         requiredRole: "owner" | "editor";
+        /** Overrides the role-derived heading/body for refusals that are
+         *  not about the caller's role on THIS chat — the shared-chat
+         *  citation case, where the documents were simply not shared. */
+        title?: string;
+        message?: string;
     } | null>(null);
     const [actionError, setActionError] = useState<{
         title: string;
@@ -283,10 +295,28 @@ export function ChatView({
     const openCitation = useCallback(
         async (citation: Citation, options?: { showQuotes?: boolean }) => {
             const showQuotes = options?.showQuotes ?? true;
-            const document = await resolvePanelDocumentVersion(
+            const resolution = await resolvePanelDocumentVersionResult(
                 panelDocumentFromCitation(citation, showQuotes),
             );
-            if (!document) return;
+            if (resolution.status !== "resolved") {
+                // A chat can be shared without its documents, and that is the
+                // common case for a standalone chat: the recipient's version
+                // lookup 404s. Silently returning made every citation pill a
+                // dead control with no hint why. Widening the document grant
+                // is the server's business, not this click's; saying so is
+                // the whole fix.
+                if (resolution.status === "denied") {
+                    setActionGate({
+                        action: "open this document",
+                        requiredRole: "editor",
+                        title: "Document not shared",
+                        message:
+                            "The person who shared this chat has not shared its documents.",
+                    });
+                }
+                return;
+            }
+            const document = resolution.document;
             if (!showQuotes) {
                 upsertTab({
                     kind: "document",
@@ -1060,10 +1090,18 @@ export function ChatView({
                 />
             ) : null}
 
+            {/* TODO(contacts): GET /chat/:id (backend/src/routes/chat.ts)
+                serves chat + is_owner + access_role and no ranked contact
+                list, so there is nothing to thread into `contacts` here and
+                the "Ask …" line cannot render on chat surfaces. Needs a
+                server change (the shape project detail already returns as
+                `admin_contacts`) before this popup can name anybody. */}
             <PermissionDeniedPopup
                 open={!!actionGate}
                 action={actionGate?.action}
                 requiredRole={actionGate?.requiredRole}
+                title={actionGate?.title}
+                message={actionGate?.message}
                 onClose={() => setActionGate(null)}
             />
 

--- a/frontend/src/app/components/assistant/ChatView.tsx
+++ b/frontend/src/app/components/assistant/ChatView.tsx
@@ -35,10 +35,7 @@ import { useSidebar } from "@/app/contexts/SidebarContext";
 import { useChatHistoryContext } from "@/app/contexts/ChatHistoryContext";
 import { usePageChrome } from "@/app/contexts/PageChromeContext";
 import { invalidateDocxBytes } from "@/app/hooks/useFetchDocxBytes";
-import {
-    resolvePanelDocumentVersion,
-    resolvePanelDocumentVersionResult,
-} from "./panelDocumentVersion";
+import { resolvePanelDocumentVersionResult } from "./panelDocumentVersion";
 import { LIQUID_GLASS_TRANSLUCENT_ACTION_CLASS } from "@/app/components/ui/liquid-surface";
 import { HeaderButtonUI, HeaderButtonsUI } from "@/shared/ui/HeaderButtonsUI";
 import { HeaderActionsMenu } from "@/app/components/shared/HeaderActionsMenu";
@@ -289,6 +286,45 @@ export function ChatView({
     );
 
     /**
+     * Say why a document behind this chat would not open.
+     *
+     * A chat can be shared without its documents, and that is the common case
+     * for a standalone chat: the recipient's version lookup answers 403/404.
+     * Silently returning made every citation pill a dead control with no hint
+     * why. But 404 has a second reading, and the sharing sentence is a lie in
+     * it: the chat's OWNER sees the same status when the document they cited
+     * has since been deleted, and telling them somebody withheld their own
+     * file explains nothing and points at nobody. Role decides which of the
+     * two the reader is looking at.
+     *
+     * Everything else — network, 5xx, a document with no versions at all —
+     * is not about access and gets the plain failure notice rather than a
+     * permission popup.
+     */
+    const reportUnresolvedDocument = useCallback(
+        (status: "denied" | "unavailable") => {
+            if (status === "denied" && activeChatRole !== "owner") {
+                setActionGate({
+                    action: "open this document",
+                    requiredRole: "editor",
+                    title: "Document not shared",
+                    message:
+                        "The person who shared this chat has not shared its documents.",
+                });
+                return;
+            }
+            setActionError({
+                title: "Document unavailable",
+                message:
+                    status === "denied"
+                        ? "This document is no longer available."
+                        : "This document could not be opened. Please try again.",
+            });
+        },
+        [activeChatRole],
+    );
+
+    /**
      * Open a tab showing a single citation quote. Called from
      * AssistantMessage when the user clicks a numbered citation pill.
      */
@@ -299,21 +335,7 @@ export function ChatView({
                 panelDocumentFromCitation(citation, showQuotes),
             );
             if (resolution.status !== "resolved") {
-                // A chat can be shared without its documents, and that is the
-                // common case for a standalone chat: the recipient's version
-                // lookup 404s. Silently returning made every citation pill a
-                // dead control with no hint why. Widening the document grant
-                // is the server's business, not this click's; saying so is
-                // the whole fix.
-                if (resolution.status === "denied") {
-                    setActionGate({
-                        action: "open this document",
-                        requiredRole: "editor",
-                        title: "Document not shared",
-                        message:
-                            "The person who shared this chat has not shared its documents.",
-                    });
-                }
+                reportUnresolvedDocument(resolution.status);
                 return;
             }
             const document = resolution.document;
@@ -332,7 +354,7 @@ export function ChatView({
                 citation,
             });
         },
-        [upsertTab],
+        [reportUnresolvedDocument, upsertTab],
     );
 
     const openCase = useCallback(
@@ -385,7 +407,11 @@ export function ChatView({
             versionId: string | null;
             versionNumber: number | null;
         }) => {
-            const document = await resolvePanelDocumentVersion({
+            // The download card's click is the same question the citation
+            // pill asks, and it was answered with a bare `return`: a card
+            // whose document was deleted, or never shared, did nothing at all
+            // when clicked. Same resolution, same words.
+            const resolution = await resolvePanelDocumentVersionResult({
                 document_id: args.documentId,
                 title: args.filename,
                 type: panelDocumentType(args.filename),
@@ -394,14 +420,18 @@ export function ChatView({
                 version_id: args.versionId,
                 version_number: args.versionNumber,
             });
-            if (!document) return;
+            if (resolution.status !== "resolved") {
+                reportUnresolvedDocument(resolution.status);
+                return;
+            }
+            const document = resolution.document;
             upsertTab({
                 kind: "document",
                 id: assistantSidePanelTabId(document),
                 document,
             });
         },
-        [upsertTab],
+        [reportUnresolvedDocument, upsertTab],
     );
 
     const [resolvedEditStatuses, setResolvedEditStatuses] = useState<

--- a/frontend/src/app/components/assistant/panelDocumentVersion.test.ts
+++ b/frontend/src/app/components/assistant/panelDocumentVersion.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it, vi } from "vitest";
 import type { PanelDocument } from "../shared/types";
-import { resolvePanelDocumentVersion } from "./panelDocumentVersion";
+import { MikeApiError } from "@/app/lib/mikeApi";
+import {
+    resolvePanelDocumentVersion,
+    resolvePanelDocumentVersionResult,
+} from "./panelDocumentVersion";
 
 const document: PanelDocument = {
     document_id: "document-1",
@@ -65,5 +69,93 @@ describe("resolvePanelDocumentVersion", () => {
             version_id: "version-2",
             version_number: 2,
         });
+    });
+});
+
+describe("resolvePanelDocumentVersionResult", () => {
+    // A chat can be shared without its documents. For a shared STANDALONE
+    // chat the recipient holds no grant on the single-documents behind it, so
+    // GET /single-documents/:id/versions answers 403/404 — and folding that
+    // into the same `null` as "no versions came back" is what turned citation
+    // pills into dead controls. The two answers have to be distinguishable
+    // here, because only one of them is worth telling the reader about.
+    it("reports a 404 from the versions endpoint as denied", async () => {
+        const loadVersions = vi
+            .fn()
+            .mockRejectedValue(
+                new MikeApiError({ message: "Not found", status: 404 }),
+            );
+
+        await expect(
+            resolvePanelDocumentVersionResult(document, loadVersions),
+        ).resolves.toEqual({ status: "denied" });
+    });
+
+    it("reports a 403 from the versions endpoint as denied", async () => {
+        const loadVersions = vi
+            .fn()
+            .mockRejectedValue(
+                new MikeApiError({ message: "Forbidden", status: 403 }),
+            );
+
+        await expect(
+            resolvePanelDocumentVersionResult(document, loadVersions),
+        ).resolves.toEqual({ status: "denied" });
+    });
+
+    it("does not call a transport failure a refusal", async () => {
+        // A 500 or a dropped connection says nothing about the caller's
+        // access; claiming "not shared with you" there would be a lie.
+        const loadVersions = vi.fn().mockRejectedValue(new Error("network"));
+
+        await expect(
+            resolvePanelDocumentVersionResult(document, loadVersions),
+        ).resolves.toEqual({ status: "unavailable" });
+    });
+
+    it("does not call a 500 a refusal either", async () => {
+        const loadVersions = vi
+            .fn()
+            .mockRejectedValue(
+                new MikeApiError({ message: "Server error", status: 500 }),
+            );
+
+        await expect(
+            resolvePanelDocumentVersionResult(document, loadVersions),
+        ).resolves.toEqual({ status: "unavailable" });
+    });
+
+    it("reports an empty version list as unavailable, not denied", async () => {
+        const loadVersions = vi
+            .fn()
+            .mockResolvedValue({ current_version_id: null, versions: [] });
+
+        await expect(
+            resolvePanelDocumentVersionResult(document, loadVersions),
+        ).resolves.toEqual({ status: "unavailable" });
+    });
+
+    it("resolves without a request when the version is already known", async () => {
+        const loadVersions = vi.fn();
+
+        await expect(
+            resolvePanelDocumentVersionResult(
+                { ...document, version_id: "version-9" },
+                loadVersions,
+            ),
+        ).resolves.toMatchObject({ status: "resolved" });
+        expect(loadVersions).not.toHaveBeenCalled();
+    });
+
+    it("keeps the null-returning wrapper for callers that cannot act on the reason", async () => {
+        const loadVersions = vi
+            .fn()
+            .mockRejectedValue(
+                new MikeApiError({ message: "Not found", status: 404 }),
+            );
+
+        await expect(
+            resolvePanelDocumentVersion(document, loadVersions),
+        ).resolves.toBeNull();
     });
 });

--- a/frontend/src/app/components/assistant/panelDocumentVersion.test.ts
+++ b/frontend/src/app/components/assistant/panelDocumentVersion.test.ts
@@ -1,10 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import type { PanelDocument } from "../shared/types";
 import { MikeApiError } from "@/app/lib/mikeApi";
-import {
-    resolvePanelDocumentVersion,
-    resolvePanelDocumentVersionResult,
-} from "./panelDocumentVersion";
+import { resolvePanelDocumentVersionResult } from "./panelDocumentVersion";
 
 const document: PanelDocument = {
     document_id: "document-1",
@@ -16,7 +13,7 @@ const document: PanelDocument = {
     version_number: null,
 };
 
-describe("resolvePanelDocumentVersion", () => {
+describe("resolvePanelDocumentVersionResult version selection", () => {
     it("resolves an unversioned panel link to the current version", async () => {
         const loadVersions = vi.fn().mockResolvedValue({
             current_version_id: "version-3",
@@ -32,10 +29,10 @@ describe("resolvePanelDocumentVersion", () => {
         });
 
         await expect(
-            resolvePanelDocumentVersion(document, loadVersions),
+            resolvePanelDocumentVersionResult(document, loadVersions),
         ).resolves.toMatchObject({
-            version_id: "version-3",
-            version_number: 3,
+            status: "resolved",
+            document: { version_id: "version-3", version_number: 3 },
         });
     });
 
@@ -61,13 +58,13 @@ describe("resolvePanelDocumentVersion", () => {
         });
 
         await expect(
-            resolvePanelDocumentVersion(
+            resolvePanelDocumentVersionResult(
                 { ...document, version_number: 2 },
                 loadVersions,
             ),
         ).resolves.toMatchObject({
-            version_id: "version-2",
-            version_number: 2,
+            status: "resolved",
+            document: { version_id: "version-2", version_number: 2 },
         });
     });
 });
@@ -147,15 +144,4 @@ describe("resolvePanelDocumentVersionResult", () => {
         expect(loadVersions).not.toHaveBeenCalled();
     });
 
-    it("keeps the null-returning wrapper for callers that cannot act on the reason", async () => {
-        const loadVersions = vi
-            .fn()
-            .mockRejectedValue(
-                new MikeApiError({ message: "Not found", status: 404 }),
-            );
-
-        await expect(
-            resolvePanelDocumentVersion(document, loadVersions),
-        ).resolves.toBeNull();
-    });
 });

--- a/frontend/src/app/components/assistant/panelDocumentVersion.ts
+++ b/frontend/src/app/components/assistant/panelDocumentVersion.ts
@@ -1,6 +1,7 @@
 import type { PanelDocument } from "../shared/types";
 import {
     listDocumentVersions,
+    MikeApiError,
     type DocumentVersion,
 } from "@/app/lib/mikeApi";
 
@@ -9,32 +10,83 @@ type VersionList = {
     versions: DocumentVersion[];
 };
 
+/**
+ * Why this has three answers instead of two.
+ *
+ * A chat can be shared without its documents: the recipient of a shared
+ * STANDALONE chat holds no grant on the single-documents behind it, so
+ * GET /single-documents/:id/versions answers 403/404 for them. Collapsing
+ * that into the same `null` as "the version list came back empty" is what
+ * made citation pills dead controls — the click resolved nothing and the
+ * caller returned, with no tab, no error and nothing said.
+ *
+ * "denied" is that case and only that case; "unavailable" is every other
+ * failure (network, 5xx, a document with no versions at all), which is not
+ * something to tell the reader about their access.
+ */
+export type PanelDocumentResolution =
+    | { status: "resolved"; document: PanelDocument }
+    | { status: "denied" }
+    | { status: "unavailable" };
+
+function isAccessRefusal(error: unknown): boolean {
+    return (
+        error instanceof MikeApiError &&
+        (error.status === 403 || error.status === 404)
+    );
+}
+
+export async function resolvePanelDocumentVersionResult(
+    document: PanelDocument,
+    loadVersions: (documentId: string) => Promise<VersionList> =
+        listDocumentVersions,
+): Promise<PanelDocumentResolution> {
+    if (document.type === "case" || document.version_id)
+        return { status: "resolved", document };
+
+    let result: VersionList;
+    try {
+        result = await loadVersions(document.document_id);
+    } catch (error) {
+        return isAccessRefusal(error)
+            ? { status: "denied" }
+            : { status: "unavailable" };
+    }
+
+    const version =
+        (document.version_number != null
+            ? result.versions.find(
+                  (candidate) =>
+                      candidate.version_number === document.version_number,
+              )
+            : undefined) ??
+        result.versions.find(
+            (candidate) => candidate.id === result.current_version_id,
+        );
+    if (!version) return { status: "unavailable" };
+    return {
+        status: "resolved",
+        document: {
+            ...document,
+            version_id: version.id,
+            version_number: version.version_number,
+        },
+    };
+}
+
+/**
+ * The document, or null when it could not be resolved for any reason.
+ * Callers that need to tell a refusal apart from a failure should use
+ * `resolvePanelDocumentVersionResult` directly.
+ */
 export async function resolvePanelDocumentVersion(
     document: PanelDocument,
     loadVersions: (documentId: string) => Promise<VersionList> =
         listDocumentVersions,
 ): Promise<PanelDocument | null> {
-    if (document.type === "case" || document.version_id) return document;
-
-    try {
-        const result = await loadVersions(document.document_id);
-        const version =
-            (document.version_number != null
-                ? result.versions.find(
-                      (candidate) =>
-                          candidate.version_number === document.version_number,
-                  )
-                : undefined) ??
-            result.versions.find(
-                (candidate) => candidate.id === result.current_version_id,
-            );
-        if (!version) return null;
-        return {
-            ...document,
-            version_id: version.id,
-            version_number: version.version_number,
-        };
-    } catch {
-        return null;
-    }
+    const resolution = await resolvePanelDocumentVersionResult(
+        document,
+        loadVersions,
+    );
+    return resolution.status === "resolved" ? resolution.document : null;
 }

--- a/frontend/src/app/components/assistant/panelDocumentVersion.ts
+++ b/frontend/src/app/components/assistant/panelDocumentVersion.ts
@@ -23,6 +23,11 @@ type VersionList = {
  * "denied" is that case and only that case; "unavailable" is every other
  * failure (network, 5xx, a document with no versions at all), which is not
  * something to tell the reader about their access.
+ *
+ * "denied" is a status, not a sentence. 404 is also what the chat's own OWNER
+ * gets once the document they cited has been deleted, and only the caller
+ * knows which of the two readers it is holding — so the caller decides the
+ * wording from the role it already has, and this module stays out of it.
  */
 export type PanelDocumentResolution =
     | { status: "resolved"; document: PanelDocument }
@@ -74,19 +79,8 @@ export async function resolvePanelDocumentVersionResult(
     };
 }
 
-/**
- * The document, or null when it could not be resolved for any reason.
- * Callers that need to tell a refusal apart from a failure should use
- * `resolvePanelDocumentVersionResult` directly.
- */
-export async function resolvePanelDocumentVersion(
-    document: PanelDocument,
-    loadVersions: (documentId: string) => Promise<VersionList> =
-        listDocumentVersions,
-): Promise<PanelDocument | null> {
-    const resolution = await resolvePanelDocumentVersionResult(
-        document,
-        loadVersions,
-    );
-    return resolution.status === "resolved" ? resolution.document : null;
-}
+// There used to be a `resolvePanelDocumentVersion` wrapper here that threw
+// the reason away and returned `PanelDocument | null`. Its last caller was
+// the download-card click, and "null" is precisely why that click did nothing
+// visible when a document was missing. Every caller now has a reason to give,
+// so the lossy wrapper is gone rather than left as the easier option.

--- a/frontend/src/app/components/documents/DocTable.gating.test.tsx
+++ b/frontend/src/app/components/documents/DocTable.gating.test.tsx
@@ -1,0 +1,77 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { can, type Capability, type ProjectRole } from "@/app/lib/permissions";
+import { DocTable } from "./DocTable";
+
+// What this file pins: the empty state's Upload is the last Upload in the
+// table that stayed live for a viewer. Every other entry point had been
+// gated, so the one affordance a project with no documents actually shows was
+// also the only one that looked available to somebody who cannot use it.
+
+vi.mock("next/navigation", () => ({
+    useRouter: () => ({ push: vi.fn(), replace: vi.fn() }),
+}));
+vi.mock("@/app/contexts/AuthContext", () => ({
+    useAuth: () => ({ user: { id: "me", email: "me@firm.test" } }),
+}));
+
+const operations = {
+    uploadDocuments: vi.fn(),
+    refreshCollection: vi.fn(async () => {}),
+    createFolder: vi.fn(),
+    resolveFolderPath: vi.fn(),
+    renameFolder: vi.fn(),
+    deleteFolder: vi.fn(async () => {}),
+    moveFolder: vi.fn(),
+    moveDocument: vi.fn(),
+    renameDocument: vi.fn(),
+};
+
+function renderAs(role: ProjectRole) {
+    return render(
+        <DocTable
+            scopeKey="project:p1"
+            documents={[]}
+            setDocuments={vi.fn()}
+            folders={[]}
+            setFolders={vi.fn()}
+            loading={false}
+            search=""
+            operations={operations as never}
+            emptyStateTitle="Documents"
+            canDo={(capability: Capability) => can(role, capability)}
+        />,
+    );
+}
+
+beforeEach(() => {
+    vi.clearAllMocks();
+    window.matchMedia = vi.fn().mockImplementation((query: string) => ({
+        matches: false,
+        media: query,
+        onchange: null,
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+    }));
+});
+
+describe("DocTable empty-state upload", () => {
+    it("refuses a viewer at the button", () => {
+        renderAs("viewer");
+
+        const upload = screen.getByRole("button", { name: "Upload" });
+        expect(upload).toBeDisabled();
+        expect(upload).toHaveAttribute("aria-disabled", "true");
+    });
+
+    it("leaves it live for an editor", () => {
+        renderAs("editor");
+
+        const upload = screen.getByRole("button", { name: "Upload" });
+        expect(upload).toBeEnabled();
+        expect(upload).not.toHaveAttribute("aria-disabled");
+    });
+});

--- a/frontend/src/app/components/documents/DocTable.tsx
+++ b/frontend/src/app/components/documents/DocTable.tsx
@@ -4061,6 +4061,29 @@ export function DocTable({
                                                     <PillButton
                                                         tone="black"
                                                         size="sm"
+                                                        // Uploading here is
+                                                        // editor-tier, and the
+                                                        // empty state was the
+                                                        // one Upload that
+                                                        // still looked live to
+                                                        // a viewer.
+                                                        disabled={
+                                                            !allowed(
+                                                                "content.edit",
+                                                            )
+                                                        }
+                                                        aria-disabled={
+                                                            !allowed(
+                                                                "content.edit",
+                                                            ) || undefined
+                                                        }
+                                                        title={
+                                                            allowed(
+                                                                "content.edit",
+                                                            )
+                                                                ? undefined
+                                                                : "Only an editor can add documents"
+                                                        }
                                                         onClick={(event) => {
                                                             event.stopPropagation();
                                                             openAddDocuments();
@@ -4499,7 +4522,22 @@ export function DocTable({
                                                         ? handleDownloadSelectedDocs
                                                         : undefined
                                                 }
+                                                newSubfolderDisabled={!allowed("docs.organize")}
                                                 onNewSubfolder={menuFolderAppliesToSelection ? undefined : () => {
+                                                    // The name prompt itself is
+                                                    // only offered to a role
+                                                    // that may create the
+                                                    // folder; the submit gate
+                                                    // in handleCreateFolder
+                                                    // stays as the backstop.
+                                                    if (
+                                                        !requireCapability(
+                                                            "docs.organize",
+                                                            "create folders",
+                                                            "editor",
+                                                        )
+                                                    )
+                                                        return;
                                                     setCreatingFolderIn(contextMenu.folderId);
                                                     setNewFolderName("");
                                                     if (contextMenu.folderId) {

--- a/frontend/src/app/components/modals/AccessEditor.test.tsx
+++ b/frontend/src/app/components/modals/AccessEditor.test.tsx
@@ -1,0 +1,200 @@
+import type { ComponentProps } from "react";
+import { describe, expect, it, vi } from "vitest";
+import { render, screen, within } from "@testing-library/react";
+import {
+    AccessEditor,
+    OrganizationAccessEditor,
+    type AccessRow,
+} from "./AccessEditor";
+
+const ROWS: AccessRow[] = [
+    {
+        key: "me",
+        user_id: "user-me",
+        email: "me@firm.example",
+        display_name: "Me",
+        role: "owner",
+    },
+    {
+        key: "other",
+        user_id: "user-other",
+        email: "other@firm.example",
+        display_name: "Other Counsel",
+        role: "viewer",
+    },
+];
+
+function renderEditor(
+    overrides: Partial<ComponentProps<typeof AccessEditor>> = {},
+) {
+    return render(
+        <AccessEditor
+            scope="direct"
+            rows={ROWS}
+            canManage
+            newRole="editor"
+            onNewRoleChange={vi.fn()}
+            onAdd={vi.fn()}
+            onRoleChange={vi.fn()}
+            onRemove={vi.fn()}
+            {...overrides}
+        />,
+    );
+}
+
+describe("AccessEditor — the viewer's own grant", () => {
+    it("renders your own row read-only while leaving other rows editable", () => {
+        // Removing yourself is one unconfirmed click away from locking
+        // yourself out, and re-roling yourself is refused by the server.
+        renderEditor({ currentUserEmail: "  Me@Firm.Example  " });
+
+        expect(screen.getByText("You")).toBeInTheDocument();
+        expect(
+            screen.queryByRole("button", { name: "Role for me@firm.example" }),
+        ).not.toBeInTheDocument();
+        expect(
+            screen.queryByRole("button", {
+                name: "Actions for me@firm.example",
+            }),
+        ).not.toBeInTheDocument();
+
+        const ownRow = screen
+            .getByText("me@firm.example")
+            .closest<HTMLElement>('[role="listitem"]');
+        expect(within(ownRow!).getByText("Owner")).toBeInTheDocument();
+
+        expect(
+            screen.getByRole("button", { name: "Role for other@firm.example" }),
+        ).toBeInTheDocument();
+        expect(
+            screen.getByRole("button", {
+                name: "Actions for other@firm.example",
+            }),
+        ).toBeInTheDocument();
+    });
+
+    it("recognises your row by user id when no email is threaded through", () => {
+        renderEditor({ currentUserId: "user-me" });
+
+        expect(screen.getByText("You")).toBeInTheDocument();
+        expect(
+            screen.queryByRole("button", { name: "Role for me@firm.example" }),
+        ).not.toBeInTheDocument();
+        expect(
+            screen.queryByRole("button", {
+                name: "Actions for me@firm.example",
+            }),
+        ).not.toBeInTheDocument();
+        expect(
+            screen.getByRole("button", { name: "Role for other@firm.example" }),
+        ).toBeInTheDocument();
+    });
+
+    it("leaves every row interactive when the viewer cannot be identified", () => {
+        renderEditor();
+
+        expect(screen.queryByText("You")).not.toBeInTheDocument();
+        expect(
+            screen.getByRole("button", { name: "Role for me@firm.example" }),
+        ).toBeInTheDocument();
+        expect(
+            screen.getByRole("button", { name: "Actions for me@firm.example" }),
+        ).toBeInTheDocument();
+    });
+});
+
+describe("AccessEditor — failures and empty states", () => {
+    it("shows the error to somebody who cannot manage access", () => {
+        // The message used to live inside the add form, which is only
+        // rendered to a manager in the direct scope, so a failed revoke or
+        // re-role anywhere else was silent.
+        renderEditor({
+            canManage: false,
+            onAdd: undefined,
+            error: "Could not remove access.",
+        });
+
+        expect(screen.getByRole("alert")).toHaveTextContent(
+            "Could not remove access.",
+        );
+    });
+
+    it("does not claim nobody has access when access is inherited", () => {
+        renderEditor({ scope: "project", rows: [], canManage: false });
+
+        expect(
+            screen.getByText(/Access is inherited from the project/),
+        ).toBeInTheDocument();
+        expect(
+            screen.queryByText("No one has access yet."),
+        ).not.toBeInTheDocument();
+    });
+});
+
+describe("OrganizationAccessEditor — deny list", () => {
+    it("opens the deny list, with its count, once the roster loads", () => {
+        const props = {
+            members: [],
+            organizationName: "Elite Law LLP",
+            onAssign: vi.fn(),
+            onRemove: vi.fn(),
+        };
+        const { rerender } = render(
+            <OrganizationAccessEditor {...props} assignments={[]} loading />,
+        );
+
+        expect(
+            screen.getByRole("button", { name: "Deny list" }),
+        ).toHaveAttribute("aria-expanded", "false");
+
+        // Assignments arrive with the roster, after mount, so a plain
+        // useState initialiser would never see them.
+        rerender(
+            <OrganizationAccessEditor
+                {...props}
+                loading={false}
+                assignments={[
+                    {
+                        key: "denied-1",
+                        user_id: "denied-1",
+                        email: "walled@firm.example",
+                        display_name: "Walled Off",
+                        role: "deny",
+                    },
+                    {
+                        key: "denied-2",
+                        user_id: "denied-2",
+                        email: "conflicted@firm.example",
+                        display_name: "Conflicted",
+                        role: "deny",
+                    },
+                ]}
+            />,
+        );
+
+        const toggle = screen.getByRole("button", { name: "Deny list (2)" });
+        expect(toggle).toHaveAttribute("aria-expanded", "true");
+        const denyList = screen.getByRole("list", { name: "Deny list entries" });
+        expect(
+            within(denyList).getByText("walled@firm.example"),
+        ).toBeInTheDocument();
+        expect(
+            within(denyList).getByText("conflicted@firm.example"),
+        ).toBeInTheDocument();
+    });
+
+    it("leaves an empty deny list collapsed and uncounted", () => {
+        render(
+            <OrganizationAccessEditor
+                members={[]}
+                assignments={[]}
+                onAssign={vi.fn()}
+                onRemove={vi.fn()}
+            />,
+        );
+
+        expect(
+            screen.getByRole("button", { name: "Deny list" }),
+        ).toHaveAttribute("aria-expanded", "false");
+    });
+});

--- a/frontend/src/app/components/modals/AccessEditor.test.tsx
+++ b/frontend/src/app/components/modals/AccessEditor.test.tsx
@@ -1,6 +1,6 @@
 import type { ComponentProps } from "react";
 import { describe, expect, it, vi } from "vitest";
-import { render, screen, within } from "@testing-library/react";
+import { fireEvent, render, screen, within } from "@testing-library/react";
 import {
     AccessEditor,
     OrganizationAccessEditor,
@@ -181,6 +181,91 @@ describe("OrganizationAccessEditor — deny list", () => {
         expect(
             within(denyList).getByText("conflicted@firm.example"),
         ).toBeInTheDocument();
+    });
+
+    it("stays collapsed after the reader closes it and the roster reloads", () => {
+        // Every grant and revoke re-reads the roster, and each re-read used to
+        // re-run the auto-expand: a deny list the reader had deliberately
+        // collapsed sprang open again after their next change.
+        const assignments = [
+            {
+                key: "denied-1",
+                user_id: "denied-1",
+                email: "walled@firm.example",
+                display_name: "Walled Off",
+                role: "deny" as const,
+            },
+        ];
+        const props = {
+            members: [],
+            assignments,
+            organizationName: "Elite Law LLP",
+            onAssign: vi.fn(),
+            onRemove: vi.fn(),
+        };
+        const { rerender } = render(
+            <OrganizationAccessEditor {...props} loading />,
+        );
+        rerender(<OrganizationAccessEditor {...props} loading={false} />);
+
+        const toggle = screen.getByRole("button", { name: "Deny list (1)" });
+        expect(toggle).toHaveAttribute("aria-expanded", "true");
+        fireEvent.click(toggle);
+        expect(
+            screen.getByRole("button", { name: "Deny list (1)" }),
+        ).toHaveAttribute("aria-expanded", "false");
+
+        // A refetch: loading goes back up and settles again.
+        rerender(<OrganizationAccessEditor {...props} loading />);
+        rerender(<OrganizationAccessEditor {...props} loading={false} />);
+
+        expect(
+            screen.getByRole("button", { name: "Deny list (1)" }),
+        ).toHaveAttribute("aria-expanded", "false");
+    });
+
+    it("keeps the caller out of the owner and deny pickers", () => {
+        // The server refuses either override aimed at the caller ("You cannot
+        // share a project with yourself"), so their own name in these pickers
+        // was an action that could only fail.
+        render(
+            <OrganizationAccessEditor
+                members={[
+                    {
+                        key: "me",
+                        user_id: "user-me",
+                        email: "me@firm.example",
+                        display_name: "Me",
+                        role: "editor",
+                    },
+                    {
+                        key: "other",
+                        user_id: "user-other",
+                        email: "other@firm.example",
+                        display_name: "Other Counsel",
+                        role: "editor",
+                    },
+                ]}
+                assignments={[]}
+                currentUserId="user-me"
+                currentUserEmail="me@firm.example"
+                onAssign={vi.fn()}
+                onRemove={vi.fn()}
+            />,
+        );
+
+        const ownerSearch = screen.getByRole("searchbox", {
+            name: "Project owners",
+        });
+        fireEvent.focus(ownerSearch);
+        fireEvent.change(ownerSearch, { target: { value: "firm.example" } });
+        const ownerMatches = screen.getByRole("listbox", {
+            name: "Project owners matches",
+        });
+        expect(
+            within(ownerMatches).getByText("Other Counsel"),
+        ).toBeInTheDocument();
+        expect(within(ownerMatches).queryByText("Me")).not.toBeInTheDocument();
     });
 
     it("leaves an empty deny list collapsed and uncounted", () => {

--- a/frontend/src/app/components/modals/AccessEditor.tsx
+++ b/frontend/src/app/components/modals/AccessEditor.tsx
@@ -427,7 +427,6 @@ export function OrganizationAccessEditor({
         assignment: OrganizationAccessAssignment,
     ) => Promise<unknown> | unknown;
 }) {
-    const [denyExpanded, setDenyExpanded] = useState(false);
     const assignedKeys = new Set(
         assignments.map(
             (assignment) =>
@@ -457,6 +456,28 @@ export function OrganizationAccessEditor({
     const deniedAssignments = assignments.filter(
         (assignment) => assignment.role === "deny",
     );
+    const denyCount = deniedAssignments.length;
+    // An existing deny list is a security decision somebody needs to see, so
+    // the section opens itself when there is anything in it. The assignments
+    // arrive with the roster, after mount, so the mount-time initialiser is
+    // not enough on its own — re-derive it whenever a load finishes, the
+    // render-phase form of "adjust state when a prop changes".
+    const [denyState, setDenyState] = useState({
+        loading,
+        expanded: denyCount > 0,
+    });
+    if (denyState.loading !== loading) {
+        setDenyState({
+            loading,
+            expanded: loading ? denyState.expanded : denyCount > 0,
+        });
+    }
+    const denyExpanded = denyState.expanded;
+    const toggleDenyExpanded = () =>
+        setDenyState((current) => ({
+            ...current,
+            expanded: !current.expanded,
+        }));
     const resourceNoun = ownerLabel.toLowerCase().startsWith("workflow")
         ? "workflow"
         : "project";
@@ -502,12 +523,14 @@ export function OrganizationAccessEditor({
                             type="button"
                             aria-expanded={denyExpanded}
                             aria-controls="organization-deny-list-content"
-                            onClick={() =>
-                                setDenyExpanded((expanded) => !expanded)
-                            }
+                            onClick={toggleDenyExpanded}
                             className="flex items-center gap-1.5 rounded-lg text-left text-sm font-medium text-gray-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40"
                         >
-                            <span>Deny list</span>
+                            <span>
+                                {denyCount > 0
+                                    ? `Deny list (${denyCount})`
+                                    : "Deny list"}
+                            </span>
                             <ChevronDown
                                 aria-hidden="true"
                                 className={`h-3.5 w-3.5 text-gray-400 transition-transform ${denyExpanded ? "rotate-180" : ""}`}
@@ -554,6 +577,7 @@ export function AccessEditor({
     loading = false,
     canManage,
     currentUserEmail,
+    currentUserId,
     busy = false,
     pendingEmail = null,
     newRole,
@@ -569,6 +593,7 @@ export function AccessEditor({
     loading?: boolean;
     canManage: boolean;
     currentUserEmail?: string | null;
+    currentUserId?: string | null;
     busy?: boolean;
     pendingEmail?: string | null;
     newRole: ProjectRole;
@@ -586,6 +611,7 @@ export function AccessEditor({
 }) {
     const roleOptions = PROJECT_ROLES;
     const normalizedCurrentEmail = currentUserEmail?.trim().toLowerCase();
+    const normalizedCurrentUserId = currentUserId?.trim() || null;
 
     return (
         <div className="flex min-h-0 flex-1 flex-col gap-4">
@@ -666,11 +692,13 @@ export function AccessEditor({
                         }
                         className="bg-white focus-within:bg-white"
                     />
-                    {error ? <p className="text-xs text-red-500">{error}</p> : null}
                 </section>
             ) : null}
 
-            {scope !== "direct" && error ? (
+            {/* One alert for every scope: the add form is only rendered to a
+                manager in the direct scope, so an error nested inside it was
+                invisible when a re-role or a revoke failed anywhere else. */}
+            {error ? (
                 <p role="alert" className="text-xs text-red-500">
                     {error}
                 </p>
@@ -709,9 +737,14 @@ export function AccessEditor({
                         ))}
                     </div>
                 ) : rows.length === 0 ? (
-                    <div className="flex min-h-0 flex-1 items-center justify-center text-sm text-gray-400">
-                        No one has access yet.
-                    </div>
+                    // In the inherited scope the note above already explains
+                    // where access comes from; "No one has access yet"
+                    // underneath it reads as a contradiction.
+                    scope === "project" ? null : (
+                        <div className="flex min-h-0 flex-1 items-center justify-center text-sm text-gray-400">
+                            No one has access yet.
+                        </div>
+                    )
                 ) : (
                     <div
                         role="list"
@@ -721,9 +754,15 @@ export function AccessEditor({
                             const rowKey =
                                 entry.key ?? entry.user_id ?? entry.email ?? "unknown";
                             const email = entry.email ?? "";
+                            // Either identifier is enough; when neither is
+                            // known the row stays interactive rather than
+                            // guessing which grant belongs to the viewer.
                             const isYou =
-                                !!normalizedCurrentEmail &&
-                                email.toLowerCase() === normalizedCurrentEmail;
+                                (!!normalizedCurrentUserId &&
+                                    entry.user_id === normalizedCurrentUserId) ||
+                                (!!normalizedCurrentEmail &&
+                                    email.toLowerCase() ===
+                                        normalizedCurrentEmail);
                             const name = isYou
                                 ? "You"
                                 : entry.display_name?.trim() || "—";
@@ -741,6 +780,12 @@ export function AccessEditor({
                                         label={email || name}
                                         editable={
                                             !entry.isCreator &&
+                                            // Re-roling yourself is refused by
+                                            // the server ("You cannot share a
+                                            // project with yourself"), so the
+                                            // picker only ever produced an
+                                            // error.
+                                            !isYou &&
                                             canManage &&
                                             scope !== "project" &&
                                             !!onRoleChange
@@ -751,7 +796,11 @@ export function AccessEditor({
                                         options={roleOptions}
                                     />
                                     <div className="relative h-6 w-6">
+                                        {/* No Remove on your own grant: one
+                                            unconfirmed click would lock the
+                                            viewer out of the resource. */}
                                         {!entry.isCreator &&
+                                        !isYou &&
                                         canManage &&
                                         scope === "direct" &&
                                         onRemove ? (

--- a/frontend/src/app/components/modals/AccessEditor.tsx
+++ b/frontend/src/app/components/modals/AccessEditor.tsx
@@ -409,6 +409,8 @@ export function OrganizationAccessEditor({
     loading = false,
     disabled = false,
     error,
+    currentUserId,
+    currentUserEmail,
     onAssign,
     onRemove,
 }: {
@@ -419,6 +421,14 @@ export function OrganizationAccessEditor({
     loading?: boolean;
     disabled?: boolean;
     error?: string | null;
+    /**
+     * Who is looking. Both identifiers, because a roster row can arrive with
+     * one and not the other — and the server refuses either override aimed at
+     * the caller ("You cannot share a project with yourself"), so offering
+     * their own name in these pickers only ever produced that error.
+     */
+    currentUserId?: string | null;
+    currentUserEmail?: string | null;
     onAssign: (
         member: AccessRow,
         role: "owner" | "deny",
@@ -436,8 +446,16 @@ export function OrganizationAccessEditor({
                 "",
         ),
     );
+    const selfEmail = currentUserEmail?.trim().toLowerCase() ?? null;
+    const isSelf = (member: AccessRow) =>
+        (!!currentUserId && member.user_id === currentUserId) ||
+        (!!selfEmail && member.email?.trim().toLowerCase() === selfEmail);
     const availableMembers = members.filter((member) => {
         if (member.isCreator || !member.email) return false;
+        // Neither override can be aimed at the caller: the server answers
+        // "You cannot share a project with yourself", so their own row in
+        // these pickers was an action that could only fail.
+        if (isSelf(member)) return false;
         return !assignedKeys.has(
             member.user_id ?? member.email.toLowerCase(),
         );
@@ -460,16 +478,26 @@ export function OrganizationAccessEditor({
     // An existing deny list is a security decision somebody needs to see, so
     // the section opens itself when there is anything in it. The assignments
     // arrive with the roster, after mount, so the mount-time initialiser is
-    // not enough on its own — re-derive it whenever a load finishes, the
-    // render-phase form of "adjust state when a prop changes".
+    // not enough on its own — re-derive it when the load finishes.
+    //
+    // Once only, though. Every grant and revoke re-reads the roster, and each
+    // of those re-runs this: a deny list the user had deliberately collapsed
+    // sprang open again after their next change, and again after the one
+    // after that. Opening it the first time is the point being made; after
+    // that the section is theirs.
     const [denyState, setDenyState] = useState({
         loading,
         expanded: denyCount > 0,
+        autoExpanded: denyCount > 0,
     });
     if (denyState.loading !== loading) {
+        const settled = !loading;
+        const shouldAutoExpand =
+            settled && !denyState.autoExpanded && denyCount > 0;
         setDenyState({
             loading,
-            expanded: loading ? denyState.expanded : denyCount > 0,
+            expanded: shouldAutoExpand ? true : denyState.expanded,
+            autoExpanded: denyState.autoExpanded || (settled && denyCount > 0),
         });
     }
     const denyExpanded = denyState.expanded;

--- a/frontend/src/app/components/modals/AccessModal.test.tsx
+++ b/frontend/src/app/components/modals/AccessModal.test.tsx
@@ -540,6 +540,80 @@ describe("AccessModal — per-recipient roles", () => {
         expect(creatorRow).not.toBeNull();
         expect(within(creatorRow!).getByText("Owner")).toBeInTheDocument();
     });
+
+    it("gives the signed-in manager no way to remove or re-role themselves", async () => {
+        // The viewer's own grant row offered a Remove action — one click,
+        // no confirmation, instant self-lockout — and a role picker whose
+        // every option the server refuses.
+        render(
+            <AccessModal
+                open
+                onClose={vi.fn()}
+                resource={PROJECT}
+                fetchAccess={() =>
+                    Promise.resolve({
+                        owner: {
+                            user_id: "u1",
+                            email: "creator@firm.example",
+                            display_name: "Creator",
+                            role: "owner" as const,
+                        },
+                        members: [
+                            {
+                                email: "me@firm.example",
+                                display_name: "Me",
+                                role: "owner" as const,
+                            },
+                            {
+                                email: "counsel@outside.example",
+                                display_name: null,
+                                role: "viewer" as const,
+                            },
+                        ],
+                    })
+                }
+                currentUserEmail="me@firm.example"
+                breadcrumb={["Projects", "Matter", "Access"]}
+                access={{
+                    grants: [
+                        { email: "me@firm.example", role: "owner" },
+                        { email: "counsel@outside.example", role: "viewer" },
+                    ],
+                    orgId: null,
+                    canManage: true,
+                    onGrant: vi.fn() as never,
+                    onRevoke: vi.fn(),
+                }}
+            />,
+        );
+
+        const ownRow = (await screen.findByText("You")).closest<HTMLElement>(
+            '[role="listitem"]',
+        );
+        expect(ownRow).not.toBeNull();
+        expect(
+            within(ownRow!).queryByRole("button", {
+                name: "Actions for me@firm.example",
+            }),
+        ).not.toBeInTheDocument();
+        expect(
+            within(ownRow!).queryByRole("button", {
+                name: "Role for me@firm.example",
+            }),
+        ).not.toBeInTheDocument();
+        expect(within(ownRow!).getByText("Owner")).toBeInTheDocument();
+
+        expect(
+            screen.getByRole("button", {
+                name: "Actions for counsel@outside.example",
+            }),
+        ).toBeInTheDocument();
+        expect(
+            screen.getByRole("button", {
+                name: "Role for counsel@outside.example",
+            }),
+        ).toBeInTheDocument();
+    });
 });
 
 describe("OrganizationAccessEditor — row actions", () => {
@@ -584,7 +658,10 @@ describe("OrganizationAccessEditor — row actions", () => {
             expect.objectContaining({ email: "owner@firm.example" }),
         );
 
-        await user.click(screen.getByRole("button", { name: "Deny list" }));
+        // The deny list opens itself because it has an entry, and says so.
+        expect(
+            screen.getByRole("button", { name: "Deny list (1)" }),
+        ).toHaveAttribute("aria-expanded", "true");
         const denyList = screen.getByRole("list", {
             name: "Deny list entries",
         });

--- a/frontend/src/app/components/modals/AccessModal.tsx
+++ b/frontend/src/app/components/modals/AccessModal.tsx
@@ -39,6 +39,7 @@ interface Props {
     resource: SharedResource | null;
     fetchAccess: (id: string) => Promise<ProjectPeople>;
     currentUserEmail?: string | null;
+    currentUserId?: string | null;
     breadcrumb: string[];
     access: AccessControls;
 }
@@ -49,6 +50,7 @@ export function AccessModal({
     resource,
     fetchAccess,
     currentUserEmail,
+    currentUserId,
     breadcrumb,
     access,
 }: Props) {
@@ -213,6 +215,12 @@ export function AccessModal({
         setError(null);
         try {
             await access.onGrant(email, newRole);
+        } catch (cause) {
+            // A refused grant used to escape as an unhandled rejection with no
+            // message; the sibling changeRole/remove paths already report.
+            setError(
+                userFacingApiError(cause, "Could not add this user. Try again."),
+            );
         } finally {
             setBusy(false);
         }
@@ -355,6 +363,7 @@ export function AccessModal({
                     loading={accessLoading || loadedRosterKey !== rosterKey}
                     canManage={canManage}
                     currentUserEmail={currentUserEmail}
+                    currentUserId={currentUserId}
                     busy={busy}
                     pendingEmail={pendingEmail}
                     newRole={newRole}

--- a/frontend/src/app/components/modals/AccessModal.tsx
+++ b/frontend/src/app/components/modals/AccessModal.tsx
@@ -29,6 +29,14 @@ export interface AccessControls {
     inheritedFromProjectId?: string | null;
     canManage: boolean;
     ownerLabel?: string;
+    /**
+     * A failure the owner of this modal wants shown beside the roster rather
+     * than in place of it — a refused grants fetch, say, which leaves the
+     * people list perfectly loadable but management impossible. It shares the
+     * editor's error line with the modal's own action failures; an in-flight
+     * action's message wins, because it is the newer answer.
+     */
+    error?: string | null;
     onGrant: (email: string, role: AccessAssignmentRole) => Promise<void>;
     onRevoke: (email: string) => Promise<void>;
 }
@@ -335,11 +343,13 @@ export function AccessModal({
                                 : null
                         }
                         ownerLabel={access.ownerLabel}
+                        currentUserId={currentUserId}
+                        currentUserEmail={currentUserEmail}
                         loading={
                             accessLoading || loadedRosterKey !== rosterKey
                         }
                         disabled={!canManage || busy}
-                        error={error}
+                        error={error ?? access.error ?? null}
                         onAssign={(member, role) =>
                             changeRole(member, role)
                         }
@@ -372,7 +382,7 @@ export function AccessModal({
                     validateEmail={validateEmail}
                     onRoleChange={changeRole}
                     onRemove={scope === "direct" ? remove : undefined}
-                    error={error}
+                    error={error ?? access.error ?? null}
                 />
             </div>
         </Modal>

--- a/frontend/src/app/components/modals/CreateAccessStep.tsx
+++ b/frontend/src/app/components/modals/CreateAccessStep.tsx
@@ -222,6 +222,7 @@ export function CreateAccessStep({
                 loading={loading}
                 canManage={!inheritedFromProject}
                 currentUserEmail={currentUserEmail}
+                currentUserId={currentUserId}
                 newRole={newRole}
                 onNewRoleChange={setNewRole}
                 onAdd={!inheritedFromProject ? addDirect : undefined}

--- a/frontend/src/app/components/organizations/OrganizationModals.test.tsx
+++ b/frontend/src/app/components/organizations/OrganizationModals.test.tsx
@@ -1,0 +1,184 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MikeApiError, type Org } from "@/app/lib/mikeApi";
+import {
+  InviteOrganizationMemberModal,
+  OrganizationSettingsModal,
+} from "./OrganizationModals";
+
+// What this file pins:
+//
+//   1. A success notice that is quietly contradicted by the list beside it.
+//      The invitation was sent; the follow-up refresh failed into a console
+//      line; the pending list stayed as it was — so "Invitation sent" read as
+//      "…and nothing happened".
+//   2. The delete confirmation was reset on FAILURE and not on success, so
+//      after a delete that worked it stayed open over a page navigating away,
+//      with a live Delete button aimed at an organization that is now gone.
+//   3. A refused delete announced itself as "Organization settings not saved",
+//      which describes the rename this modal also does.
+
+const mocks = vi.hoisted(() => ({
+  createOrgInvitation: vi.fn(),
+  cancelOrgInvitation: vi.fn(),
+  resendOrgInvitation: vi.fn(),
+  updateOrg: vi.fn(),
+  deleteOrg: vi.fn(),
+  createOrg: vi.fn(),
+}));
+
+vi.mock("@/app/lib/mikeApi", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/app/lib/mikeApi")>()),
+  createOrgInvitation: mocks.createOrgInvitation,
+  cancelOrgInvitation: mocks.cancelOrgInvitation,
+  resendOrgInvitation: mocks.resendOrgInvitation,
+  updateOrg: mocks.updateOrg,
+  deleteOrg: mocks.deleteOrg,
+  createOrg: mocks.createOrg,
+}));
+
+const org: Org = {
+  id: "org-1",
+  name: "Elite Law LLP",
+  created_by: "me",
+  role: "admin",
+} as Org;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  window.matchMedia = vi.fn().mockImplementation((query: string) => ({
+    matches: true,
+    media: query,
+    onchange: null,
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  }));
+  mocks.createOrgInvitation.mockResolvedValue({});
+  mocks.cancelOrgInvitation.mockResolvedValue(undefined);
+  mocks.resendOrgInvitation.mockResolvedValue(undefined);
+  mocks.deleteOrg.mockResolvedValue(undefined);
+});
+
+async function typeInvitation(user: ReturnType<typeof userEvent.setup>) {
+  await waitFor(() => {
+    const dialog = screen.getByRole("dialog");
+    expect(dialog.contains(document.activeElement)).toBe(true);
+  });
+  await user.type(
+    screen.getByPlaceholderText("Invite by email…"),
+    "new@firm.example",
+  );
+  await user.click(screen.getByRole("button", { name: "Add" }));
+}
+
+describe("InviteOrganizationMemberModal", () => {
+  it("keeps the success notice and admits the list is stale", async () => {
+    const user = userEvent.setup();
+    render(
+      <InviteOrganizationMemberModal
+        open
+        org={org}
+        invitations={[]}
+        onClose={vi.fn()}
+        onChanged={() => Promise.reject(new Error("refresh failed"))}
+      />,
+    );
+
+    await typeInvitation(user);
+
+    await waitFor(() => expect(mocks.createOrgInvitation).toHaveBeenCalled());
+    expect(
+      await screen.findByText(
+        "Invitation sent to new@firm.example. The list below may be out of date — reload to see the current one.",
+      ),
+    ).toBeInTheDocument();
+    // The mutation succeeded, so it is still not reported as a failure.
+    expect(
+      screen.queryByText("Invitation action failed"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("says only that the invitation was sent when the refresh lands", async () => {
+    const user = userEvent.setup();
+    render(
+      <InviteOrganizationMemberModal
+        open
+        org={org}
+        invitations={[]}
+        onClose={vi.fn()}
+        onChanged={vi.fn()}
+      />,
+    );
+
+    await typeInvitation(user);
+
+    expect(
+      await screen.findByText("Invitation sent to new@firm.example."),
+    ).toBeInTheDocument();
+  });
+});
+
+describe("OrganizationSettingsModal", () => {
+  it("closes the confirmation once the delete succeeds", async () => {
+    const user = userEvent.setup();
+    const onDeleted = vi.fn();
+    render(
+      <OrganizationSettingsModal
+        open
+        org={org}
+        onClose={vi.fn()}
+        onUpdated={vi.fn()}
+        onDeleted={onDeleted}
+      />,
+    );
+
+    await user.click(
+      screen.getByRole("button", { name: "Delete organization" }),
+    );
+    expect(screen.getByText("Delete Elite Law LLP?")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Delete" }));
+
+    await waitFor(() => expect(onDeleted).toHaveBeenCalledTimes(1));
+    expect(screen.queryByText("Delete Elite Law LLP?")).not.toBeInTheDocument();
+    expect(mocks.deleteOrg).toHaveBeenCalledTimes(1);
+  });
+
+  it("names the failure a failed delete, not unsaved settings", async () => {
+    const user = userEvent.setup();
+    mocks.deleteOrg.mockRejectedValue(
+      new MikeApiError({
+        message: "Move or delete this organization's projects first",
+        status: 409,
+      }),
+    );
+    render(
+      <OrganizationSettingsModal
+        open
+        org={org}
+        onClose={vi.fn()}
+        onUpdated={vi.fn()}
+        onDeleted={vi.fn()}
+      />,
+    );
+
+    await user.click(
+      screen.getByRole("button", { name: "Delete organization" }),
+    );
+    await user.click(screen.getByRole("button", { name: "Delete" }));
+
+    expect(
+      await screen.findByText("Organization not deleted"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("Move or delete this organization's projects first"),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText("Organization settings not saved"),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/app/components/organizations/OrganizationModals.tsx
+++ b/frontend/src/app/components/organizations/OrganizationModals.tsx
@@ -30,6 +30,20 @@ function friendlyError(error: unknown, fallback: string) {
   return userFacingApiError(error, fallback);
 }
 
+/**
+ * A refresh runs *after* its mutation has already succeeded, so a failing
+ * refresh must never be reported as a failed mutation. Callers await this
+ * outside their mutation's try block; the stale list corrects itself on the
+ * next load.
+ */
+async function refreshQuietly(onChanged: () => Promise<void> | void) {
+  try {
+    await onChanged();
+  } catch (error) {
+    console.error("Failed to refresh organization data", error);
+  }
+}
+
 export function CreateOrganizationModal({
   open,
   onClose,
@@ -93,7 +107,13 @@ export function CreateOrganizationModal({
     <>
       <Modal
         open={open}
-        onClose={onClose}
+        // A create in flight owns the organization's fate: dismissing the
+        // modal (Escape, backdrop, close button) mid-request would strand the
+        // result with nowhere to report it.
+        onClose={() => {
+          if (creating) return;
+          onClose();
+        }}
         breadcrumbs={["Organizations", "New organization"]}
         primaryAction={{
           label: createdOrg
@@ -233,13 +253,13 @@ export function InviteOrganizationMemberModal({
     setNotice(null);
     try {
       await createOrgInvitation(org.id, email, role);
-      setNotice(`Invitation sent to ${email}.`);
-      await onChanged();
-      return true;
     } catch (err) {
       setError(friendlyError(err, "Could not send the invitation."));
       return false;
     }
+    setNotice(`Invitation sent to ${email}.`);
+    await refreshQuietly(onChanged);
+    return true;
   }
 
   async function runInvitationAction(
@@ -249,6 +269,7 @@ export function InviteOrganizationMemberModal({
     setBusyId(invitation.id);
     setError(null);
     setNotice(null);
+    let changed = false;
     try {
       if (action === "resend") {
         await resendOrgInvitation(org.id, invitation.id);
@@ -257,12 +278,13 @@ export function InviteOrganizationMemberModal({
         await cancelOrgInvitation(org.id, invitation.id);
         setNotice(`Invitation to ${invitation.email} cancelled.`);
       }
-      await onChanged();
+      changed = true;
     } catch (err) {
       setError(friendlyError(err, `Could not ${action} the invitation.`));
     } finally {
       setBusyId(null);
     }
+    if (changed) await refreshQuietly(onChanged);
   }
 
   return (
@@ -396,8 +418,15 @@ export function OrganizationSettingsModal({
     if (!open) return;
     setName(org.name);
     setError(null);
-    setConfirmDelete(false);
   }, [open, org.name]);
+
+  useEffect(() => {
+    // The confirmation renders in its own portal, so it must retire with the
+    // modal: otherwise it keeps floating over the page after Escape or a
+    // backdrop click, with a live "Delete" button still wired to this org.
+    if (open) return;
+    setConfirmDelete(false);
+  }, [open]);
 
   async function save() {
     if (!trimmedName || !changed || saving) return;
@@ -480,7 +509,7 @@ export function OrganizationSettingsModal({
         </div>
       </Modal>
       <ConfirmPopup
-        open={confirmDelete}
+        open={open && confirmDelete}
         title={`Delete ${org.name}?`}
         message="This removes the empty organization, its memberships and invitations."
         confirmLabel="Delete"

--- a/frontend/src/app/components/organizations/OrganizationModals.tsx
+++ b/frontend/src/app/components/organizations/OrganizationModals.tsx
@@ -33,16 +33,28 @@ function friendlyError(error: unknown, fallback: string) {
 /**
  * A refresh runs *after* its mutation has already succeeded, so a failing
  * refresh must never be reported as a failed mutation. Callers await this
- * outside their mutation's try block; the stale list corrects itself on the
- * next load.
+ * outside their mutation's try block.
+ *
+ * Quiet is not the same as invisible, though: it returns whether the refresh
+ * worked, because the list on screen is now a claim about the server that the
+ * page cannot back up. "Invitation sent" beside an unchanged list reads as
+ * "…and nothing happened", which is precisely wrong.
  */
-async function refreshQuietly(onChanged: () => Promise<void> | void) {
+async function refreshQuietly(
+  onChanged: () => Promise<void> | void,
+): Promise<boolean> {
   try {
     await onChanged();
+    return true;
   } catch (error) {
     console.error("Failed to refresh organization data", error);
+    return false;
   }
 }
+
+/** Appended to a success notice whose follow-up refresh did not land. */
+const STALE_LIST_NOTICE =
+  "The list below may be out of date — reload to see the current one.";
 
 export function CreateOrganizationModal({
   open,
@@ -258,7 +270,11 @@ export function InviteOrganizationMemberModal({
       return false;
     }
     setNotice(`Invitation sent to ${email}.`);
-    await refreshQuietly(onChanged);
+    // The invitation really was sent, so the notice stands — but if the list
+    // behind this modal could not be re-read, say that rather than let the
+    // unchanged list quietly contradict the notice.
+    if (!(await refreshQuietly(onChanged)))
+      setNotice(`Invitation sent to ${email}. ${STALE_LIST_NOTICE}`);
     return true;
   }
 
@@ -270,21 +286,24 @@ export function InviteOrganizationMemberModal({
     setError(null);
     setNotice(null);
     let changed = false;
+    let successNotice: string | null = null;
     try {
       if (action === "resend") {
         await resendOrgInvitation(org.id, invitation.id);
-        setNotice(`Invitation resent to ${invitation.email}.`);
+        successNotice = `Invitation resent to ${invitation.email}.`;
       } else {
         await cancelOrgInvitation(org.id, invitation.id);
-        setNotice(`Invitation to ${invitation.email} cancelled.`);
+        successNotice = `Invitation to ${invitation.email} cancelled.`;
       }
+      setNotice(successNotice);
       changed = true;
     } catch (err) {
       setError(friendlyError(err, `Could not ${action} the invitation.`));
     } finally {
       setBusyId(null);
     }
-    if (changed) await refreshQuietly(onChanged);
+    if (changed && !(await refreshQuietly(onChanged)) && successNotice)
+      setNotice(`${successNotice} ${STALE_LIST_NOTICE}`);
   }
 
   return (
@@ -407,7 +426,13 @@ export function OrganizationSettingsModal({
   const [saving, setSaving] = useState(false);
   const [deleting, setDeleting] = useState(false);
   const [confirmDelete, setConfirmDelete] = useState(false);
-  const [error, setError] = useState<string | null>(null);
+  // Two different failures shared one heading: a refused delete was announced
+  // as "Organization settings not saved", which describes the rename this
+  // modal also does and not the thing that actually failed.
+  const [error, setError] = useState<{
+    title: string;
+    message: string;
+  } | null>(null);
   const trimmedName = name.trim();
   const changed = useMemo(
     () => trimmedName !== org.name,
@@ -435,7 +460,10 @@ export function OrganizationSettingsModal({
     try {
       onUpdated(await updateOrg(org.id, trimmedName));
     } catch (err) {
-      setError(friendlyError(err, "Could not update the organization."));
+      setError({
+        title: "Organization settings not saved",
+        message: friendlyError(err, "Could not update the organization."),
+      });
     } finally {
       setSaving(false);
     }
@@ -447,13 +475,22 @@ export function OrganizationSettingsModal({
     setError(null);
     try {
       await deleteOrg(org.id);
-      onDeleted();
-    } catch (err) {
-      setError(friendlyError(err, "Could not delete the organization."));
+      // The confirmation was reset on failure and not on success, so after a
+      // delete that worked it stayed open — over a page now navigating away,
+      // with a live Delete button still aimed at an organization that no
+      // longer exists. Close it, and leave `deleting` set so the button
+      // cannot fire a second time during the navigation.
       setConfirmDelete(false);
-    } finally {
-      setDeleting(false);
+      onDeleted();
+      return;
+    } catch (err) {
+      setError({
+        title: "Organization not deleted",
+        message: friendlyError(err, "Could not delete the organization."),
+      });
+      setConfirmDelete(false);
     }
+    setDeleting(false);
   }
 
   return (
@@ -515,13 +552,16 @@ export function OrganizationSettingsModal({
         confirmLabel="Delete"
         confirmVariant="danger"
         confirmStatus={deleting ? "loading" : "idle"}
-        onCancel={() => setConfirmDelete(false)}
+        onCancel={() => {
+          if (deleting) return;
+          setConfirmDelete(false);
+        }}
         onConfirm={() => void remove()}
       />
       <WarningPopup
         open={open && error !== null}
-        title="Organization settings not saved"
-        message={error}
+        title={error?.title ?? "Organization settings not saved"}
+        message={error?.message ?? null}
         onClose={() => setError(null)}
       />
     </>

--- a/frontend/src/app/components/organizations/OrganizationWorkspace.test.tsx
+++ b/frontend/src/app/components/organizations/OrganizationWorkspace.test.tsx
@@ -177,6 +177,7 @@ describe("OrganizationWorkspace", () => {
       screen.getByRole("button", { name: "Change role for William Chen" }),
     );
     await user.click(screen.getByRole("menuitem", { name: "Member" }));
+    await user.click(screen.getByRole("button", { name: "Continue" }));
 
     expect(
       await screen.findByText("An organization must keep at least one admin."),
@@ -225,9 +226,15 @@ describe("OrganizationWorkspace", () => {
       screen.getByRole("menuitem", { name: "Remove all selected" }),
     );
 
+    // The refusal is about the route, not about admin arithmetic: leaving is
+    // a different action, and saying "must keep at least one admin" was wrong
+    // however many admins the organization had.
     expect(
-      await screen.findByText("An organization must keep at least one admin."),
+      await screen.findByText("Use Leave organization to remove yourself."),
     ).toBeInTheDocument();
+    expect(
+      screen.queryByText("An organization must keep at least one admin."),
+    ).not.toBeInTheDocument();
     expect(mocks.removeOrgMember).not.toHaveBeenCalled();
   });
 
@@ -248,6 +255,113 @@ describe("OrganizationWorkspace", () => {
     expect(screen.getByLabelText("Organization name")).toHaveValue(
       "Elite Law LLP",
     );
+  });
+
+  it("drops admin-only controls as soon as an admin demotes themselves", async () => {
+    const user = userEvent.setup();
+    mocks.updateOrgMember.mockResolvedValue({});
+    render(<OrganizationWorkspace orgId="org-1" />);
+    await screen.findByText("William Chen");
+
+    await user.click(
+      screen.getByRole("button", { name: "Change role for William Chen" }),
+    );
+    await user.click(screen.getByRole("menuitem", { name: "Member" }));
+
+    // Losing your own admin rights is confirmed before it happens.
+    expect(screen.getByText("Give up admin access?")).toBeInTheDocument();
+    expect(mocks.updateOrgMember).not.toHaveBeenCalled();
+    await user.click(screen.getByRole("button", { name: "Continue" }));
+
+    await waitFor(() =>
+      expect(mocks.updateOrgMember).toHaveBeenCalledWith(
+        "org-1",
+        "me",
+        "member",
+      ),
+    );
+    // org.role has to follow the membership row, or the page keeps offering
+    // admin actions that now 403 until a reload.
+    await waitFor(() =>
+      expect(
+        screen.queryByRole("button", { name: "Organization settings" }),
+      ).not.toBeInTheDocument(),
+    );
+    expect(
+      screen.queryByRole("button", { name: "Change role for Jane Lee" }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByRole("button", {
+        name: "Only organization admins can add members",
+      }),
+    ).toBeDisabled();
+    expect(mocks.getOrg).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps the delete confirmation from outliving its settings modal", async () => {
+    const user = userEvent.setup();
+    render(<OrganizationWorkspace orgId="org-1" />);
+    await screen.findByText("William Chen");
+
+    await user.click(
+      screen.getByRole("button", { name: "Organization settings" }),
+    );
+    await user.click(
+      screen.getByRole("menuitem", { name: "Organization settings" }),
+    );
+    await user.click(
+      screen.getByRole("button", { name: "Delete organization" }),
+    );
+    expect(screen.getByText("Delete Elite Law LLP?")).toBeInTheDocument();
+
+    // Escape dismisses the modal; the confirmation lives in its own portal
+    // and would otherwise stay behind with a live Delete button.
+    await user.keyboard("{Escape}");
+
+    expect(screen.queryByText("Delete Elite Law LLP?")).not.toBeInTheDocument();
+    expect(mocks.deleteOrg).not.toHaveBeenCalled();
+  });
+
+  it("does not report a sent invitation as failed when the refresh rejects", async () => {
+    const user = userEvent.setup();
+    mocks.createOrgInvitation.mockResolvedValue({});
+    mocks.listOrgInvitations
+      .mockResolvedValueOnce([])
+      .mockRejectedValue(new Error("refresh failed"));
+    render(<OrganizationWorkspace orgId="org-1" />);
+    await screen.findByText("William Chen");
+
+    await user.click(screen.getByRole("button", { name: "Add member" }));
+    // ModalUI settles focus a frame after the dialog opens (the auto-focused
+    // field keeps it, else the first control); typing across that handoff
+    // loses the tail of the address, so wait for focus to land in the dialog.
+    await waitFor(() => {
+      const dialog = screen.getByRole("dialog");
+      expect(document.activeElement).not.toBe(document.body);
+      expect(dialog.contains(document.activeElement)).toBe(true);
+    });
+    await user.type(
+      screen.getByPlaceholderText("Invite by email…"),
+      "new@firm.example",
+    );
+    await user.click(screen.getByRole("button", { name: "Add" }));
+
+    await waitFor(() =>
+      expect(mocks.createOrgInvitation).toHaveBeenCalledWith(
+        "org-1",
+        "new@firm.example",
+        "member",
+      ),
+    );
+    expect(
+      await screen.findByText("Invitation sent to new@firm.example."),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText("Could not send the invitation."),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByText("Invitation action failed"),
+    ).not.toBeInTheDocument();
   });
 
   it("lets members browse resources but does not load administrative invitations", async () => {

--- a/frontend/src/app/components/organizations/OrganizationWorkspace.test.tsx
+++ b/frontend/src/app/components/organizations/OrganizationWorkspace.test.tsx
@@ -364,6 +364,77 @@ describe("OrganizationWorkspace", () => {
     ).not.toBeInTheDocument();
   });
 
+  it("re-reads invitations and the roster when the Add member modal opens", async () => {
+    // An invitation is accepted in the recipient's browser, so this page never
+    // hears about it. Opening Add member used to redisplay the list loaded at
+    // page load, which still called the new colleague "Pending" — and the
+    // People table behind it still did not have them at all.
+    const user = userEvent.setup();
+    const invitation = {
+      id: "i1",
+      org_id: "org-1",
+      email: "newjoiner@firm.example",
+      role: "member" as const,
+      invited_by: "me",
+      expires_at: "2026-09-30T00:00:00Z",
+      created_at: "2026-09-01T00:00:00Z",
+      accepted_at: null,
+      declined_at: null,
+      cancelled_at: null,
+    };
+    const joiner = {
+      id: "m3",
+      user_id: "u3",
+      display_name: "New Joiner",
+      email: "newjoiner@firm.example",
+      role: "member",
+      created_at: "2026-09-02T00:00:00Z",
+    };
+    mocks.listOrgInvitations
+      .mockResolvedValueOnce([{ ...invitation, status: "pending" }])
+      .mockResolvedValue([
+        {
+          ...invitation,
+          status: "accepted",
+          accepted_at: "2026-09-02T00:00:00Z",
+        },
+      ]);
+    const initialMembers = [
+      {
+        id: "m1",
+        user_id: "me",
+        display_name: "William Chen",
+        email: "me@firm.example",
+        role: "admin",
+        created_at: "2026-08-30T00:00:00Z",
+      },
+    ];
+    mocks.listOrgMembers
+      .mockResolvedValueOnce(initialMembers)
+      .mockResolvedValue([...initialMembers, joiner]);
+
+    render(<OrganizationWorkspace orgId="org-1" />);
+    await screen.findByText("William Chen");
+    expect(screen.queryByText("New Joiner")).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Add member" }));
+
+    await waitFor(() =>
+      expect(mocks.listOrgInvitations).toHaveBeenCalledTimes(2),
+    );
+    // The accepted invitation is no longer pending, so its row is gone...
+    await waitFor(() =>
+      expect(
+        screen.queryByRole("button", {
+          name: "Cancel invitation to newjoiner@firm.example",
+        }),
+      ).not.toBeInTheDocument(),
+    );
+    expect(screen.queryByText("Pending invitations")).not.toBeInTheDocument();
+    // ...and the same person is now on the roster without a reload.
+    expect(screen.getByText("New Joiner")).toBeInTheDocument();
+  });
+
   it("lets members browse resources but does not load administrative invitations", async () => {
     mocks.role = "member";
     const user = userEvent.setup();

--- a/frontend/src/app/components/organizations/OrganizationWorkspace.test.tsx
+++ b/frontend/src/app/components/organizations/OrganizationWorkspace.test.tsx
@@ -435,6 +435,93 @@ describe("OrganizationWorkspace", () => {
     expect(screen.getByText("New Joiner")).toBeInTheDocument();
   });
 
+  it("ignores a stale roster response that answers after a newer one", async () => {
+    // Two readers write this roster — the page load and the refresh that runs
+    // whenever the Add member modal opens or closes — and nothing ordered
+    // them. Whichever response landed LAST won: a three-person roster was
+    // seen collapsing to one when the older answer came back second.
+    const user = userEvent.setup();
+    const chen = {
+      id: "m1",
+      user_id: "me",
+      display_name: "William Chen",
+      email: "me@firm.example",
+      role: "admin",
+      created_at: "2026-08-30T00:00:00Z",
+    };
+    const lee = {
+      id: "m2",
+      user_id: "u2",
+      display_name: "Jane Lee",
+      email: "jane@firm.example",
+      role: "member",
+      created_at: "2026-09-01T00:00:00Z",
+    };
+    const joiner = {
+      id: "m3",
+      user_id: "u3",
+      display_name: "New Joiner",
+      email: "newjoiner@firm.example",
+      role: "member",
+      created_at: "2026-09-02T00:00:00Z",
+    };
+    const stale: { release: (members: unknown[]) => void } = {
+      release: () => {},
+    };
+    mocks.listOrgMembers
+      // The page load.
+      .mockResolvedValueOnce([chen, lee])
+      // Opening the modal: this read is overtaken and must not be applied.
+      .mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            stale.release = resolve;
+          }),
+      )
+      // Closing it: the newest answer, and the one the table must keep.
+      .mockResolvedValue([chen, lee, joiner]);
+
+    render(<OrganizationWorkspace orgId="org-1" />);
+    await screen.findByText("William Chen");
+
+    await user.click(screen.getByRole("button", { name: "Add member" }));
+    await screen.findByRole("dialog");
+    await user.keyboard("{Escape}");
+
+    // The close path re-reads BOTH lists, not the roster alone.
+    await waitFor(() => expect(screen.getByText("New Joiner")).toBeInTheDocument());
+    expect(mocks.listOrgInvitations.mock.calls.length).toBeGreaterThan(2);
+
+    // Now the overtaken read finally answers, with the roster as it was.
+    stale.release([chen]);
+    await waitFor(() =>
+      expect(mocks.listOrgMembers).toHaveBeenCalledTimes(3),
+    );
+    expect(screen.getByText("New Joiner")).toBeInTheDocument();
+    expect(screen.getByText("Jane Lee")).toBeInTheDocument();
+  });
+
+  it("says so when refreshing the people lists fails", async () => {
+    // A console line is not a user interface. The admin was left reading a
+    // roster that had quietly stopped tracking the server.
+    const user = userEvent.setup();
+    render(<OrganizationWorkspace orgId="org-1" />);
+    await screen.findByText("William Chen");
+    // The page loaded; it is the refresh behind the modal that fails.
+    mocks.listOrgMembers.mockRejectedValue(new Error("network"));
+
+    await user.click(screen.getByRole("button", { name: "Add member" }));
+
+    expect(
+      await screen.findByText("Organization action failed"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "This organization's people could not be refreshed. Reload to see the current list.",
+      ),
+    ).toBeInTheDocument();
+  });
+
   it("lets members browse resources but does not load administrative invitations", async () => {
     mocks.role = "member";
     const user = userEvent.setup();

--- a/frontend/src/app/components/organizations/OrganizationWorkspace.tsx
+++ b/frontend/src/app/components/organizations/OrganizationWorkspace.tsx
@@ -125,6 +125,10 @@ export function OrganizationWorkspace({ orgId }: { orgId: string }) {
   const [removeSelectedOpen, setRemoveSelectedOpen] = useState(false);
   const [removingSelected, setRemovingSelected] = useState(false);
   const [removeMember, setRemoveMember] = useState<OrgMember | null>(null);
+  const [pendingSelfRoleChange, setPendingSelfRoleChange] = useState<{
+    member: OrgMember;
+    role: OrgRole;
+  } | null>(null);
 
   const load = useCallback(async () => {
     setLoading(true);
@@ -163,6 +167,20 @@ export function OrganizationWorkspace({ orgId }: { orgId: string }) {
 
   const isAdmin = org?.role === "admin";
 
+  /**
+   * Demoting yourself is the one role change that rewrites what this page is
+   * allowed to do, so it is confirmed before it runs rather than silently
+   * pulling the admin controls out from under the click.
+   */
+  function requestRoleChange(member: OrgMember, role: OrgRole) {
+    if (!isAdmin || member.role === role || busyMemberId) return;
+    if (member.user_id === user?.id && role !== "admin") {
+      setPendingSelfRoleChange({ member, role });
+      return;
+    }
+    void changeRole(member, role);
+  }
+
   async function changeRole(member: OrgMember, role: OrgRole) {
     if (!isAdmin || member.role === role || busyMemberId) return;
     setBusyMemberId(member.user_id);
@@ -174,6 +192,14 @@ export function OrganizationWorkspace({ orgId }: { orgId: string }) {
           row.user_id === member.user_id ? { ...row, role } : row,
         ),
       );
+      // The membership row is not the only place this role lives: `org.role`
+      // gates every admin-only control and request on the page. Without this
+      // the demoted admin keeps a UI they no longer have rights for, and each
+      // action 403s until a reload.
+      if (member.user_id === user?.id) {
+        setOrg((current) => (current ? { ...current, role } : current));
+        if (role !== "admin") setInvitations([]);
+      }
     } catch (error) {
       setActionError(userFacingApiError(error, "Could not change that role."));
     } finally {
@@ -215,7 +241,7 @@ export function OrganizationWorkspace({ orgId }: { orgId: string }) {
       selectedMemberIds.includes(member.id),
     );
     if (selectedMembers.some((member) => member.user_id === user?.id)) {
-      setActionError("An organization must keep at least one admin.");
+      setActionError("Use Leave organization to remove yourself.");
       return;
     }
     setRemoveSelectedOpen(true);
@@ -342,7 +368,7 @@ export function OrganizationWorkspace({ orgId }: { orgId: string }) {
           isAdmin={isAdmin}
           busyMemberId={busyMemberId}
           onRetry={load}
-          onRoleChange={changeRole}
+          onRoleChange={requestRoleChange}
           onRemove={setRemoveMember}
         />
       ) : activeTab === "projects" ? (
@@ -422,6 +448,19 @@ export function OrganizationWorkspace({ orgId }: { orgId: string }) {
         onConfirm={() => void confirmRemoveMember()}
       />
       <ConfirmPopup
+        open={pendingSelfRoleChange !== null}
+        title="Give up admin access?"
+        message="You will lose admin access to this organization and can no longer manage its people, settings or invitations."
+        confirmLabel="Continue"
+        confirmStatus={busyMemberId ? "loading" : "idle"}
+        onCancel={() => setPendingSelfRoleChange(null)}
+        onConfirm={() => {
+          const pending = pendingSelfRoleChange;
+          setPendingSelfRoleChange(null);
+          if (pending) void changeRole(pending.member, pending.role);
+        }}
+      />
+      <ConfirmPopup
         open={removeSelectedOpen}
         title="Remove selected people?"
         message={`${selectedMemberIds.length} selected ${selectedMemberIds.length === 1 ? "member" : "members"} will lose access to this organization.`}
@@ -463,7 +502,7 @@ function PeopleTable({
   isAdmin: boolean;
   busyMemberId: string | null;
   onRetry: () => Promise<void>;
-  onRoleChange: (member: OrgMember, role: OrgRole) => Promise<void>;
+  onRoleChange: (member: OrgMember, role: OrgRole) => void;
   onRemove: (member: OrgMember) => void;
 }) {
   const [roleFilter, setRoleFilter] = useState<OrgRole | null>(null);
@@ -658,7 +697,7 @@ function PeopleTable({
                     label={label}
                     editable={isAdmin}
                     disabled={busyMemberId === member.user_id}
-                    onChange={(role) => void onRoleChange(member, role)}
+                    onChange={(role) => onRoleChange(member, role)}
                   />
                 </TableCell>
                 <TableCell className="w-36">

--- a/frontend/src/app/components/organizations/OrganizationWorkspace.tsx
+++ b/frontend/src/app/components/organizations/OrganizationWorkspace.tsx
@@ -4,6 +4,7 @@ import {
   useCallback,
   useEffect,
   useMemo,
+  useRef,
   useState,
   type Dispatch,
   type SetStateAction,
@@ -130,9 +131,39 @@ export function OrganizationWorkspace({ orgId }: { orgId: string }) {
     role: OrgRole;
   } | null>(null);
 
+  /**
+   * Which read of each list is the current one.
+   *
+   * Two independent readers write these lists — the full `load` and the
+   * `refreshPeople` that runs whenever the Add-member modal opens or closes —
+   * and nothing ordered them. Opening the modal on a still-loading page fires
+   * both, and whichever response arrives LAST wins regardless of which was
+   * asked first: a three-person roster was seen collapsing to one, because
+   * the older answer landed second. Every read takes a ticket and applies its
+   * result only while that ticket is still the newest, so a slow answer to an
+   * old question is discarded instead of overwriting a newer one.
+   */
+  const membersRequestRef = useRef(0);
+  const invitationsRequestRef = useRef(0);
+
+  /**
+   * `member_count` is derived from the roster, so it moves with it or not at
+   * all — writing the count from a read whose rows were discarded would put
+   * the header and the table into two different truths.
+   */
+  const applyMembers = useCallback((ticket: number, next: OrgMember[]) => {
+    if (ticket !== membersRequestRef.current) return;
+    setMembers(next);
+    setOrg((current) =>
+      current ? { ...current, member_count: next.length } : current,
+    );
+  }, []);
+
   const load = useCallback(async () => {
     setLoading(true);
     setLoadError(null);
+    const membersTicket = ++membersRequestRef.current;
+    const invitationsTicket = ++invitationsRequestRef.current;
     try {
       const nextOrg = await getOrg(orgId);
       const [nextMembers, nextResources, nextInvitations] = await Promise.all([
@@ -142,10 +173,11 @@ export function OrganizationWorkspace({ orgId }: { orgId: string }) {
           ? listOrgInvitations(orgId)
           : Promise.resolve([] as OrgInvitation[]),
       ]);
-      setOrg({ ...nextOrg, member_count: nextMembers.length });
-      setMembers(nextMembers);
+      setOrg(nextOrg);
+      applyMembers(membersTicket, nextMembers);
       setResources(nextResources);
-      setInvitations(nextInvitations);
+      if (invitationsTicket === invitationsRequestRef.current)
+        setInvitations(nextInvitations);
     } catch (error) {
       console.error("Failed to load organization", error);
       setLoadError(
@@ -154,20 +186,20 @@ export function OrganizationWorkspace({ orgId }: { orgId: string }) {
     } finally {
       setLoading(false);
     }
-  }, [orgId]);
+  }, [applyMembers, orgId]);
 
   const refreshInvitations = useCallback(async () => {
     if (org?.role !== "admin") return;
-    setInvitations(await listOrgInvitations(orgId));
+    const ticket = ++invitationsRequestRef.current;
+    const nextInvitations = await listOrgInvitations(orgId);
+    if (ticket !== invitationsRequestRef.current) return;
+    setInvitations(nextInvitations);
   }, [org?.role, orgId]);
 
   const refreshMembers = useCallback(async () => {
-    const nextMembers = await listOrgMembers(orgId);
-    setMembers(nextMembers);
-    setOrg((current) =>
-      current ? { ...current, member_count: nextMembers.length } : current,
-    );
-  }, [orgId]);
+    const ticket = ++membersRequestRef.current;
+    applyMembers(ticket, await listOrgMembers(orgId));
+  }, [applyMembers, orgId]);
 
   /**
    * An invitation is accepted somewhere else entirely — in the recipient's
@@ -177,18 +209,28 @@ export function OrganizationWorkspace({ orgId }: { orgId: string }) {
    * People roster. Reading only the invitations, which is what the Add member
    * modal used to do, left the roster a reload behind.
    *
-   * Neither refresh is the user's action, so a failure is logged rather than
-   * reported, and one failing does not cancel the other.
+   * One failing does not cancel the other — but neither is it swallowed. A
+   * console line is not a user interface: the admin was left reading a roster
+   * that had silently stopped tracking the server, with the page looking
+   * exactly as it does when the refresh worked. It says so now, in the same
+   * place every other failed action on this page speaks.
    */
   const refreshPeople = useCallback(async () => {
     const results = await Promise.allSettled([
       refreshInvitations(),
       refreshMembers(),
     ]);
-    for (const result of results) {
-      if (result.status === "rejected")
-        console.error("Failed to refresh organization people", result.reason);
-    }
+    const failure = results.find(
+      (result): result is PromiseRejectedResult => result.status === "rejected",
+    );
+    if (!failure) return;
+    console.error("Failed to refresh organization people", failure.reason);
+    setActionError(
+      userFacingApiError(
+        failure.reason,
+        "This organization's people could not be refreshed. Reload to see the current list.",
+      ),
+    );
   }, [refreshInvitations, refreshMembers]);
 
   useEffect(() => {
@@ -447,12 +489,12 @@ export function OrganizationWorkspace({ orgId }: { orgId: string }) {
             invitations={invitations}
             onClose={() => {
               setInviteOpen(false);
-              // An invitation accepted while the modal was open changes the
-              // roster behind it, so the table the admin returns to is re-read
-              // rather than left as it was at page load.
-              void refreshMembers().catch((error) => {
-                console.error("Failed to refresh organization members", error);
-              });
+              // An invitation sent or accepted while the modal was open
+              // changes BOTH lists behind it — a new invitation is pending, an
+              // accepted one is gone and its sender is now on the roster — so
+              // the admin returns to a re-read of both, not of the roster
+              // alone with a stale "Pending invitations" beside it.
+              void refreshPeople();
             }}
             onChanged={refreshPeople}
           />

--- a/frontend/src/app/components/organizations/OrganizationWorkspace.tsx
+++ b/frontend/src/app/components/organizations/OrganizationWorkspace.tsx
@@ -161,6 +161,36 @@ export function OrganizationWorkspace({ orgId }: { orgId: string }) {
     setInvitations(await listOrgInvitations(orgId));
   }, [org?.role, orgId]);
 
+  const refreshMembers = useCallback(async () => {
+    const nextMembers = await listOrgMembers(orgId);
+    setMembers(nextMembers);
+    setOrg((current) =>
+      current ? { ...current, member_count: nextMembers.length } : current,
+    );
+  }, [orgId]);
+
+  /**
+   * An invitation is accepted somewhere else entirely — in the recipient's
+   * browser — so nothing on this page hears about it. Both lists it lands in
+   * therefore have to be re-read together whenever the admin looks: the
+   * invitation leaves "Pending invitations" and the same person appears on the
+   * People roster. Reading only the invitations, which is what the Add member
+   * modal used to do, left the roster a reload behind.
+   *
+   * Neither refresh is the user's action, so a failure is logged rather than
+   * reported, and one failing does not cancel the other.
+   */
+  const refreshPeople = useCallback(async () => {
+    const results = await Promise.allSettled([
+      refreshInvitations(),
+      refreshMembers(),
+    ]);
+    for (const result of results) {
+      if (result.status === "rejected")
+        console.error("Failed to refresh organization people", result.reason);
+    }
+  }, [refreshInvitations, refreshMembers]);
+
   useEffect(() => {
     void load();
   }, [load]);
@@ -324,7 +354,12 @@ export function OrganizationWorkspace({ orgId }: { orgId: string }) {
                 ? "Add member"
                 : "Only organization admins can add members",
               disabled: !isAdmin,
-              onClick: () => setInviteOpen(true),
+              onClick: () => {
+                setInviteOpen(true);
+                // The modal shows the invitation list this page loaded, which
+                // by now may name people who have already accepted.
+                void refreshPeople();
+              },
             },
             isAdmin
               ? {
@@ -410,8 +445,16 @@ export function OrganizationWorkspace({ orgId }: { orgId: string }) {
             open={inviteOpen}
             org={org}
             invitations={invitations}
-            onClose={() => setInviteOpen(false)}
-            onChanged={refreshInvitations}
+            onClose={() => {
+              setInviteOpen(false);
+              // An invitation accepted while the modal was open changes the
+              // roster behind it, so the table the admin returns to is re-read
+              // rather than left as it was at page load.
+              void refreshMembers().catch((error) => {
+                console.error("Failed to refresh organization members", error);
+              });
+            }}
+            onChanged={refreshPeople}
           />
           <OrganizationSettingsModal
             open={settingsOpen}

--- a/frontend/src/app/components/organizations/OrganizationsOverview.test.tsx
+++ b/frontend/src/app/components/organizations/OrganizationsOverview.test.tsx
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import { MikeApiError } from "@/app/lib/mikeApi";
 import { OrganizationsOverview } from "./OrganizationsOverview";
 
 const mocks = vi.hoisted(() => ({
@@ -16,7 +17,11 @@ const mocks = vi.hoisted(() => ({
 vi.mock("next/navigation", () => ({
   useRouter: () => ({ push: mocks.push }),
 }));
-vi.mock("@/app/lib/mikeApi", () => ({
+// Spread the real module: userFacingApiError resolves MikeApiError from this
+// same module, so a bare object mock leaves its `instanceof` check with an
+// undefined right-hand side.
+vi.mock("@/app/lib/mikeApi", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/app/lib/mikeApi")>()),
   listOrgs: mocks.listOrgs,
   listMyOrgInvitations: mocks.listMyOrgInvitations,
   createOrg: mocks.createOrg,
@@ -73,6 +78,20 @@ beforeEach(() => {
   mocks.listMyOrgInvitations.mockResolvedValue([]);
 });
 
+/**
+ * ModalUI settles focus on the frame after the dialog opens: the control
+ * React auto-focused keeps it, otherwise the first focusable control gets it.
+ * Typing before that handoff lands the tail of the text on whichever control
+ * wins, so wait until focus has left <body> and sits inside the dialog.
+ */
+async function settleModalFocus() {
+  await waitFor(() => {
+    const dialog = screen.getByRole("dialog");
+    expect(document.activeElement).not.toBe(document.body);
+    expect(dialog.contains(document.activeElement)).toBe(true);
+  });
+}
+
 describe("OrganizationsOverview", () => {
   it("renders organizations through the shared table columns and opens a row", async () => {
     const user = userEvent.setup();
@@ -108,6 +127,7 @@ describe("OrganizationsOverview", () => {
     expect(
       await screen.findByText(/You can also add people later/),
     ).toBeInTheDocument();
+    await settleModalFocus();
     await user.type(screen.getByLabelText("Organization name"), "New Chambers");
     await user.type(
       screen.getByPlaceholderText("Add member by email…"),
@@ -164,6 +184,78 @@ describe("OrganizationsOverview", () => {
     );
     expect(
       await screen.findByRole("button", { name: "Invites" }),
+    ).toBeInTheDocument();
+  });
+
+  it("reports a failed invitations fetch instead of claiming there are none", async () => {
+    const user = userEvent.setup();
+    mocks.listMyOrgInvitations
+      .mockRejectedValueOnce(
+        new MikeApiError({ status: 503, message: "upstream down" }),
+      )
+      .mockResolvedValue([INVITATION]);
+    render(<OrganizationsOverview />);
+    await screen.findByText("Elite Law LLP");
+
+    await user.click(screen.getByRole("button", { name: "Invites" }));
+    expect(
+      screen.getByText("Could not load your invitations."),
+    ).toBeInTheDocument();
+    // The old swallowed catch rendered this instead, which reads as "nobody
+    // invited you" rather than "we could not check".
+    expect(
+      screen.queryByText("You have no active organization invitations."),
+    ).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Try again" }));
+    expect(await screen.findByText("Inviting Chambers")).toBeInTheDocument();
+  });
+
+  it("keeps a partly failed creation from vanishing when the modal is closed", async () => {
+    const user = userEvent.setup();
+    const created = { ...ORG, id: "org-2", name: "New Chambers" };
+    mocks.createOrg.mockResolvedValue(created);
+    mocks.createOrgInvitation.mockRejectedValue(new Error("invite failed"));
+    render(<OrganizationsOverview />);
+    await screen.findByText("Elite Law LLP");
+
+    await user.click(screen.getByRole("button", { name: "New organization" }));
+    await settleModalFocus();
+    await user.type(screen.getByLabelText("Organization name"), "New Chambers");
+    await user.type(
+      screen.getByPlaceholderText("Add member by email…"),
+      "jane@firm.example",
+    );
+    await user.click(screen.getByRole("button", { name: "Add" }));
+    await user.click(screen.getByRole("button", { name: "Create" }));
+
+    expect(
+      await screen.findByText("Some invitations were not sent"),
+    ).toBeInTheDocument();
+    expect(mocks.push).not.toHaveBeenCalled();
+
+    // The organization exists on the server but never reached onCreated, so
+    // dismissal has to refetch or the row stays invisible until a reload.
+    mocks.listOrgs.mockResolvedValue([ORG, created]);
+    await user.click(screen.getByRole("button", { name: "Close" }));
+    expect(await screen.findByText("New Chambers")).toBeInTheDocument();
+  });
+
+  it("refuses to dismiss the create modal while the request is in flight", async () => {
+    const user = userEvent.setup();
+    mocks.createOrg.mockReturnValue(new Promise(() => {}));
+    render(<OrganizationsOverview />);
+    await screen.findByText("Elite Law LLP");
+
+    await user.click(screen.getByRole("button", { name: "New organization" }));
+    await settleModalFocus();
+    await user.type(screen.getByLabelText("Organization name"), "New Chambers");
+    await user.click(screen.getByRole("button", { name: "Create" }));
+    await waitFor(() => expect(mocks.createOrg).toHaveBeenCalled());
+
+    await user.keyboard("{Escape}");
+    expect(
+      screen.getByRole("dialog", { name: "New organization" }),
     ).toBeInTheDocument();
   });
 });

--- a/frontend/src/app/components/organizations/OrganizationsOverview.test.tsx
+++ b/frontend/src/app/components/organizations/OrganizationsOverview.test.tsx
@@ -197,7 +197,12 @@ describe("OrganizationsOverview", () => {
     render(<OrganizationsOverview />);
     await screen.findByText("Elite Law LLP");
 
-    await user.click(screen.getByRole("button", { name: "Invites" }));
+    // The tab itself has to say so: an unopened "Invites" looked identical
+    // whether the inbox was empty or the fetch had failed, and only one of
+    // those is worth a click.
+    await user.click(
+      screen.getByRole("button", { name: "Invites (unavailable)" }),
+    );
     expect(
       screen.getByText("Could not load your invitations."),
     ).toBeInTheDocument();
@@ -209,6 +214,51 @@ describe("OrganizationsOverview", () => {
 
     await user.click(screen.getByRole("button", { name: "Try again" }));
     expect(await screen.findByText("Inviting Chambers")).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Invites (1)" }),
+    ).toBeInTheDocument();
+  });
+
+  it("shows the server's own wording when the organizations fetch is refused", async () => {
+    // The invitations half of the same load already did this; the orgs half
+    // threw the server's sentence away for a hardcoded one.
+    mocks.listOrgs.mockRejectedValue(
+      new MikeApiError({
+        status: 403,
+        message: "Your account is not permitted to list organizations",
+      }),
+    );
+    render(<OrganizationsOverview />);
+
+    expect(
+      await screen.findByText(
+        "Your account is not permitted to list organizations",
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it("keeps a failing reload from being reported as a failed answer", async () => {
+    // The re-read is bookkeeping that runs after the server has already
+    // accepted, so it sits outside the try: a failure there must not become
+    // "Could not answer that invitation" about an invitation that was taken.
+    const user = userEvent.setup();
+    mocks.listMyOrgInvitations.mockResolvedValueOnce([INVITATION]);
+    mocks.acceptOrgInvitation.mockResolvedValue(undefined);
+    render(<OrganizationsOverview />);
+
+    await user.click(
+      await screen.findByRole("button", { name: "Invites (1)" }),
+    );
+    mocks.listOrgs.mockRejectedValue(new Error("network"));
+    mocks.listMyOrgInvitations.mockRejectedValue(new Error("network"));
+    await user.click(screen.getByRole("button", { name: "Accept" }));
+
+    await waitFor(() =>
+      expect(mocks.acceptOrgInvitation).toHaveBeenCalledWith("invite-1"),
+    );
+    expect(
+      screen.queryByText("Could not answer that invitation."),
+    ).not.toBeInTheDocument();
   });
 
   it("keeps a partly failed creation from vanishing when the modal is closed", async () => {

--- a/frontend/src/app/components/organizations/OrganizationsOverview.tsx
+++ b/frontend/src/app/components/organizations/OrganizationsOverview.tsx
@@ -60,6 +60,7 @@ export function OrganizationsOverview() {
   const [orgs, setOrgs] = useState<Org[] | null>(null);
   const [invitations, setInvitations] = useState<OrgInvitation[]>([]);
   const [loadError, setLoadError] = useState<string | null>(null);
+  const [invitationsError, setInvitationsError] = useState<string | null>(null);
   const [createOpen, setCreateOpen] = useState(false);
   const [activeFilter, setActiveFilter] =
     useState<OrganizationFilter>("managed");
@@ -70,19 +71,35 @@ export function OrganizationsOverview() {
   const [answeringId, setAnsweringId] = useState<string | null>(null);
   const [invitationError, setInvitationError] = useState<string | null>(null);
 
+  // The two lists fail independently: a broken invitations fetch must not
+  // blank the organizations table, and — the reason this is not a swallowed
+  // `.catch(() => [])` — it must not masquerade as "you have no invitations"
+  // either. Each side keeps its own error so each can offer its own retry.
   const load = useCallback(async () => {
-    try {
-      const [nextOrgs, nextInvitations] = await Promise.all([
-        listOrgs(),
-        listMyOrgInvitations().catch(() => [] as OrgInvitation[]),
-      ]);
-      setOrgs(nextOrgs);
-      setInvitations(nextInvitations);
+    const [orgsResult, invitationsResult] = await Promise.allSettled([
+      listOrgs(),
+      listMyOrgInvitations(),
+    ]);
+    if (orgsResult.status === "fulfilled") {
+      setOrgs(orgsResult.value);
       setLoadError(null);
-    } catch (error) {
-      console.error("Failed to load organizations", error);
+    } else {
+      console.error("Failed to load organizations", orgsResult.reason);
       setLoadError("Could not load organizations.");
       setOrgs([]);
+    }
+    if (invitationsResult.status === "fulfilled") {
+      setInvitations(invitationsResult.value);
+      setInvitationsError(null);
+    } else {
+      console.error("Failed to load invitations", invitationsResult.reason);
+      setInvitations([]);
+      setInvitationsError(
+        userFacingApiError(
+          invitationsResult.reason,
+          "Could not load your invitations.",
+        ),
+      );
     }
   }, []);
 
@@ -179,6 +196,20 @@ export function OrganizationsOverview() {
             {[1, 2, 3].map((row) => (
               <SkeletonLine key={row} className="h-7 w-full" />
             ))}
+          </div>
+        ) : invitationsError ? (
+          <div className="mx-4 mb-3 flex min-h-0 flex-1 items-center justify-center md:mx-8">
+            <EmptyState
+              icon={<OrganizationSkeuoIcon />}
+              title="Invitations"
+              description={invitationsError}
+              tone="error"
+              action={
+                <PillButton tone="black" size="sm" onClick={() => void load()}>
+                  Try again
+                </PillButton>
+              }
+            />
           </div>
         ) : invitations.length === 0 ? (
           <div className="mx-4 mb-3 flex min-h-0 flex-1 items-center justify-center md:mx-8">
@@ -380,7 +411,14 @@ export function OrganizationsOverview() {
 
       <CreateOrganizationModal
         open={createOpen}
-        onClose={() => setCreateOpen(false)}
+        // A partly failed creation ("created, but some invitations could not
+        // be sent") leaves the modal open on a real organization that never
+        // reached onCreated. Refetching on dismissal is what makes that
+        // organization appear here instead of only after a reload.
+        onClose={() => {
+          setCreateOpen(false);
+          void load();
+        }}
         onCreated={(org) => {
           setCreateOpen(false);
           router.push(`/organizations/${org.id}`);

--- a/frontend/src/app/components/organizations/OrganizationsOverview.tsx
+++ b/frontend/src/app/components/organizations/OrganizationsOverview.tsx
@@ -85,7 +85,14 @@ export function OrganizationsOverview() {
       setLoadError(null);
     } else {
       console.error("Failed to load organizations", orgsResult.reason);
-      setLoadError("Could not load organizations.");
+      // The invitations half of this same function already routes its
+      // failure through userFacingApiError, which shows the server's own
+      // wording for a 4xx. A hardcoded sentence here threw that away, so the
+      // two halves of one screen answered the same kind of failure
+      // differently — and the more useful answer was the one discarded.
+      setLoadError(
+        userFacingApiError(orgsResult.reason, "Could not load organizations."),
+      );
       setOrgs([]);
     }
     if (invitationsResult.status === "fulfilled") {
@@ -113,15 +120,20 @@ export function OrganizationsOverview() {
     try {
       if (accept) await acceptOrgInvitation(invitation.id);
       else await declineOrgInvitation(invitation.id);
-      await load();
     } catch (error) {
       setInvitationError(
         userFacingApiError(error, "Could not answer that invitation."),
       );
-      await load();
     } finally {
       setAnsweringId(null);
     }
+    // Outside the try, and on both paths. Inside it, a re-read that failed
+    // would have been reported as "Could not answer that invitation" about an
+    // invitation the server had just accepted — the reload is bookkeeping,
+    // not the user's action. Both paths need it: an accepted invitation moves
+    // to the organizations list, and a refusal is often a refusal because
+    // somebody answered it somewhere else already.
+    await load();
   }
 
   const loading = orgs === null;
@@ -133,13 +145,18 @@ export function OrganizationsOverview() {
       { id: "joined", label: "Joined" },
       {
         id: "invites",
-        label:
-          invitations.length > 0
+        // A failed fetch and an empty inbox both left this reading plain
+        // "Invites", so the one state worth opening the tab for looked
+        // exactly like the one that is not. Plain text in the label, not a
+        // badge: this is a status, not a control.
+        label: invitationsError
+          ? "Invites (unavailable)"
+          : invitations.length > 0
             ? `Invites (${invitations.length})`
             : "Invites",
       },
     ],
-    [invitations.length],
+    [invitations.length, invitationsError],
   );
   const visibleOrgs = useMemo(() => {
     if (activeFilter === "invites") return [];

--- a/frontend/src/app/components/popups/ConfirmPopup.test.tsx
+++ b/frontend/src/app/components/popups/ConfirmPopup.test.tsx
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import { ConfirmPopup } from "./ConfirmPopup";
 
 describe("ConfirmPopup", () => {
@@ -34,5 +34,67 @@ describe("ConfirmPopup", () => {
     expect(screen.getByRole("button", { name: "Delete" })).toHaveClass(
       "bg-gray-950/88",
     );
+  });
+
+  it("announces itself as a dialog named by its title", () => {
+    render(
+      <ConfirmPopup
+        open
+        title="Remove members?"
+        message="They lose access."
+        onConfirm={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    );
+
+    expect(
+      screen.getByRole("dialog", { name: "Remove members?" }),
+    ).toBeInTheDocument();
+  });
+
+  it("still has a name when it asks without a title", () => {
+    render(<ConfirmPopup open message="Sure?" onConfirm={vi.fn()} onCancel={vi.fn()} />);
+
+    expect(
+      screen.getByRole("dialog", { name: "Confirm action" }),
+    ).toBeInTheDocument();
+  });
+
+  it("cancels on Escape", () => {
+    // It took the keyboard's attention and answered only to the mouse.
+    const onCancel = vi.fn();
+    const onConfirm = vi.fn();
+    render(
+      <ConfirmPopup
+        open
+        title="Remove members?"
+        onConfirm={onConfirm}
+        onCancel={onCancel}
+      />,
+    );
+
+    fireEvent.keyDown(document, { key: "Escape" });
+
+    expect(onCancel).toHaveBeenCalledTimes(1);
+    expect(onConfirm).not.toHaveBeenCalled();
+  });
+
+  it("does not answer Escape once closed", () => {
+    const onCancel = vi.fn();
+    const { rerender } = render(
+      <ConfirmPopup open title="Remove?" onConfirm={vi.fn()} onCancel={onCancel} />,
+    );
+    rerender(
+      <ConfirmPopup
+        open={false}
+        title="Remove?"
+        onConfirm={vi.fn()}
+        onCancel={onCancel}
+      />,
+    );
+
+    fireEvent.keyDown(document, { key: "Escape" });
+
+    expect(onCancel).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/app/components/popups/ConfirmPopup.tsx
+++ b/frontend/src/app/components/popups/ConfirmPopup.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { createPortal } from "react-dom";
-import type { ReactNode } from "react";
+import { useEffect, useId, type ReactNode } from "react";
 import { Loader2, Trash2 } from "lucide-react";
 import { PillButton } from "@/app/components/ui/pill-button";
 import { cn } from "@/app/lib/utils";
@@ -36,6 +36,29 @@ export function ConfirmPopup({
   confirmDisabled = false,
   className,
 }: ConfirmPopupProps) {
+  const titleId = useId();
+
+  /**
+   * Escape cancels.
+   *
+   * This popup asks a question and takes the keyboard's attention while it is
+   * up, but it answered only to the mouse: there was no way to decline it
+   * without finding and clicking Cancel, which is the one thing every other
+   * dismissable surface in the app does with Escape. It is also announced as
+   * a dialog now — a bare `div` gave screen readers a heading and two buttons
+   * that appeared from nowhere, with nothing saying they belong together or
+   * that an answer is being asked for.
+   */
+  useEffect(() => {
+    if (!open) return;
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key !== "Escape") return;
+      onCancel();
+    };
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [open, onCancel]);
+
   if (!open) return null;
   const confirmBusy = confirmStatus === "loading";
   const resolvedConfirmDisabled = confirmDisabled || confirmStatus !== "idle";
@@ -62,13 +85,18 @@ export function ConfirmPopup({
   return createPortal(
     <div className="pointer-events-none fixed inset-x-0 bottom-5 z-[230] flex justify-center px-4">
       <div
+        role="dialog"
+        aria-labelledby={title ? titleId : undefined}
+        aria-label={title ? undefined : "Confirm action"}
         className={cn(
           `pointer-events-auto w-[min(92vw,520px)] rounded-2xl px-4 py-3 text-sm ${LIQUID_GLASS_FLOAT_CLASS} backdrop-blur-2xl`,
           className,
         )}
       >
         {title && (
-          <div className="text-sm font-medium text-gray-950 mb-3">{title}</div>
+          <div id={titleId} className="text-sm font-medium text-gray-950 mb-3">
+            {title}
+          </div>
         )}
         {message && (
           <div className={cn("text-xs text-gray-700", title && "mt-1")}>

--- a/frontend/src/app/components/projects/NewProjectModal.test.tsx
+++ b/frontend/src/app/components/projects/NewProjectModal.test.tsx
@@ -14,6 +14,7 @@ import {
     listOrgMembers,
     listOrgs,
     lookupUserByEmail,
+    uploadProjectDocuments,
 } from "@/app/lib/mikeApi";
 import { NewProjectModal } from "./NewProjectModal";
 
@@ -30,6 +31,7 @@ vi.mock("@/app/lib/mikeApi", async (importOriginal) => ({
     grantProjectAccess: vi.fn(),
     addDocumentToProject: vi.fn(),
     uploadProjectDocument: vi.fn(),
+    uploadProjectDocuments: vi.fn(),
     listOrgs: vi.fn(),
     listOrgMembers: vi.fn(),
     lookupUserByEmail: vi.fn(),
@@ -115,6 +117,7 @@ describe("NewProjectModal sharing", () => {
         vi.mocked(listOrgMembers).mockResolvedValue([]);
         vi.mocked(createProject).mockResolvedValue(CREATED as never);
         vi.mocked(grantProjectAccess).mockResolvedValue({} as never);
+        vi.mocked(uploadProjectDocuments).mockResolvedValue([]);
         vi.mocked(lookupUserByEmail).mockImplementation(async (email) => ({
             exists: true,
             email,
@@ -485,5 +488,107 @@ describe("NewProjectModal sharing", () => {
             "blocked@elite.test",
             "deny",
         );
+    });
+
+    async function attachPendingFile(filename: string) {
+        const fileInput = document.querySelector(
+            'input[type="file"]',
+        ) as HTMLInputElement;
+        expect(fileInput).not.toBeNull();
+        fireEvent.change(fileInput, {
+            target: { files: [new File(["contents"], filename)] },
+        });
+        await screen.findByRole("button", { name: /Upload \(1\)/ });
+    }
+
+    it("uploads an attached file once when a refused grant is retried", async () => {
+        // The grant refusal used to return with the pending files still
+        // queued, so the retry — which correctly skipped creation — re-ran the
+        // upload and the project ended up with the same document twice.
+        const user = userEvent.setup({ delay: null });
+        const onCreated = vi.fn();
+        render(
+            <NewProjectModal open onClose={vi.fn()} onCreated={onCreated} />,
+        );
+        vi.mocked(grantProjectAccess).mockRejectedValueOnce(
+            new MikeApiError({ status: 403, message: "Not allowed" }),
+        );
+        vi.mocked(uploadProjectDocuments).mockResolvedValue([
+            {
+                clientId: "c1",
+                filename: "brief.pdf",
+                status: "completed",
+                result: null,
+                errorCode: null,
+            },
+        ]);
+
+        await fillAndAdd(user, "counsel@firm.test", "editor");
+        await user.click(screen.getByRole("button", { name: "Next" }));
+        await attachPendingFile("brief.pdf");
+
+        await user.click(
+            screen.getByRole("button", { name: "Create project" }),
+        );
+        expect(
+            await screen.findByText(
+                /Project created, but access was not granted to counsel@firm\.test/,
+            ),
+        ).toBeInTheDocument();
+        // Grants run first, so a refusal leaves no upload to redo.
+        expect(uploadProjectDocuments).not.toHaveBeenCalled();
+
+        await user.click(
+            screen.getByRole("button", { name: "Create project" }),
+        );
+        await waitFor(() => expect(onCreated).toHaveBeenCalled());
+        expect(createProject).toHaveBeenCalledTimes(1);
+        expect(uploadProjectDocuments).toHaveBeenCalledTimes(1);
+    });
+
+    it("tells the caller to refetch when a created project is never handed over", async () => {
+        const user = userEvent.setup({ delay: null });
+        const onClose = vi.fn();
+        const onCreated = vi.fn();
+        render(<NewProjectModal open onClose={onClose} onCreated={onCreated} />);
+        vi.mocked(grantProjectAccess).mockRejectedValue(
+            new MikeApiError({ status: 403, message: "Not allowed" }),
+        );
+
+        await fillAndAdd(user, "counsel@firm.test", "editor");
+        await submit(user);
+        await screen.findByText(/Project created, but access was not granted/);
+
+        await user.click(screen.getByRole("button", { name: "Close" }));
+        expect(onCreated).not.toHaveBeenCalled();
+        expect(onClose).toHaveBeenCalledWith(true);
+    });
+
+    it("cannot be dismissed while the project is being created", async () => {
+        const user = userEvent.setup({ delay: null });
+        const onClose = vi.fn();
+        // Never settles: the create is still in flight when the user tries to
+        // leave, and dismissing then would strand the outcome.
+        vi.mocked(createProject).mockReturnValue(new Promise(() => {}) as never);
+        render(<NewProjectModal open onClose={onClose} onCreated={vi.fn()} />);
+
+        await user.type(screen.getByPlaceholderText("Add project name"), "P");
+        await submit(user);
+        await waitFor(() => expect(createProject).toHaveBeenCalled());
+
+        await user.click(screen.getByRole("button", { name: "Close" }));
+        fireEvent.keyDown(document, { key: "Escape" });
+        expect(onClose).not.toHaveBeenCalled();
+    });
+
+    it("says so when the organization list cannot be loaded", async () => {
+        vi.mocked(listOrgs).mockRejectedValue(
+            new MikeApiError({ status: 500, message: "boom" }),
+        );
+        render(<NewProjectModal open onClose={vi.fn()} onCreated={vi.fn()} />);
+
+        expect(
+            await screen.findByText("Your organizations could not be loaded."),
+        ).toBeInTheDocument();
     });
 });

--- a/frontend/src/app/components/projects/NewProjectModal.test.tsx
+++ b/frontend/src/app/components/projects/NewProjectModal.test.tsx
@@ -581,6 +581,99 @@ describe("NewProjectModal sharing", () => {
         expect(onClose).not.toHaveBeenCalled();
     });
 
+    it("keeps two files that happen to share a name", async () => {
+        // The picker deduplicated by NAME, so the second `contract.pdf` — a
+        // normal thing to attach from two different folders — was dropped
+        // without a word.
+        const user = userEvent.setup({ delay: null });
+        renderModal();
+
+        await user.type(screen.getByPlaceholderText("Add project name"), "P");
+        await user.click(screen.getByRole("button", { name: "Next" }));
+        await user.click(screen.getByRole("button", { name: "Next" }));
+
+        const input = document.querySelector(
+            'input[type="file"]',
+        ) as HTMLInputElement;
+        // Two separate picks, as a user attaching from two folders makes
+        // them: the name test compared each new file against the ones
+        // already staged, so the second one never arrived.
+        fireEvent.change(input, {
+            target: { files: [new File(["a"], "contract.pdf")] },
+        });
+        fireEvent.change(input, {
+            target: { files: [new File(["b"], "contract.pdf")] },
+        });
+
+        expect(
+            await screen.findByRole("button", { name: /Upload \(2\)/ }),
+        ).toBeInTheDocument();
+
+        await user.click(
+            screen.getByRole("button", { name: "Create project" }),
+        );
+
+        await waitFor(() => expect(uploadProjectDocuments).toHaveBeenCalled());
+        const [, sentFiles] = vi.mocked(uploadProjectDocuments).mock.calls[0];
+        expect(sentFiles).toHaveLength(2);
+        // Each carries its own id, so an outcome can be traced back to the
+        // File that produced it rather than to a name they share.
+        expect(sentFiles[0].clientId).toBeTruthy();
+        expect(sentFiles[0].clientId).not.toBe(sentFiles[1].clientId);
+    });
+
+    it("says the attached files are still pending when a grant is refused", async () => {
+        // Grants run before the attachments, so a refusal there means nothing
+        // the user picked has been sent — an error that mentions only the
+        // sharing reads as though the files went in.
+        const user = userEvent.setup({ delay: null });
+        renderModal();
+        vi.mocked(grantProjectAccess).mockRejectedValue(
+            new MikeApiError({ status: 403, message: "Not allowed" }),
+        );
+
+        await fillAndAdd(user, "counsel@firm.test", "editor");
+        await user.click(screen.getByRole("button", { name: "Next" }));
+        const input = document.querySelector(
+            'input[type="file"]',
+        ) as HTMLInputElement;
+        fireEvent.change(input, {
+            target: { files: [new File(["a"], "a.pdf"), new File(["b"], "b.pdf")] },
+        });
+        await user.click(
+            await screen.findByRole("button", { name: "Create project" }),
+        );
+
+        expect(
+            await screen.findByText(
+                /The 2 selected files are still pending and will be attached when you try again\./,
+            ),
+        ).toBeInTheDocument();
+        expect(uploadProjectDocuments).not.toHaveBeenCalled();
+    });
+
+    it("retires Back once the project exists", async () => {
+        // The retry reuses the created project, so a Personal → organization
+        // switch on the second attempt left the project where it was and
+        // applied the new organization's overrides to it.
+        const user = userEvent.setup({ delay: null });
+        renderModal();
+        vi.mocked(grantProjectAccess).mockRejectedValue(
+            new MikeApiError({ status: 403, message: "Not allowed" }),
+        );
+
+        await fillAndAdd(user, "counsel@firm.test", "editor");
+        await user.click(screen.getByRole("button", { name: "Next" }));
+        expect(screen.getByRole("button", { name: "Back" })).toBeEnabled();
+
+        await user.click(
+            await screen.findByRole("button", { name: "Create project" }),
+        );
+        await screen.findByText(/Project created, but access was not granted/);
+
+        expect(screen.getByRole("button", { name: "Back" })).toBeDisabled();
+    });
+
     it("says so when the organization list cannot be loaded", async () => {
         vi.mocked(listOrgs).mockRejectedValue(
             new MikeApiError({ status: 500, message: "boom" }),

--- a/frontend/src/app/components/projects/NewProjectModal.tsx
+++ b/frontend/src/app/components/projects/NewProjectModal.tsx
@@ -31,7 +31,12 @@ const PERSONAL_WORKSPACE = "__personal__";
 
 interface Props {
     open: boolean;
-    onClose: () => void;
+    /**
+     * Dismissal. `createdWithoutHandover` is true when the project exists but
+     * a later step failed, so it never reached `onCreated` — the caller has to
+     * refetch or the new project stays invisible until a reload.
+     */
+    onClose: (createdWithoutHandover?: boolean) => void;
     onCreated: (project: Project) => void;
 }
 
@@ -50,6 +55,7 @@ export function NewProjectModal({ open, onClose, onCreated }: Props) {
     const [pendingFiles, setPendingFiles] = useState<File[]>([]);
     const [loading, setLoading] = useState(false);
     const [error, setError] = useState("");
+    const [orgLoadError, setOrgLoadError] = useState("");
     // A project created with only some of its files attached. The modal holds
     // it until the user has read which files are missing.
     const [pendingProject, setPendingProject] = useState<Project | null>(null);
@@ -60,6 +66,11 @@ export function NewProjectModal({ open, onClose, onCreated }: Props) {
     // reuses the project the user already has instead of creating a second
     // one.
     const createdProjectRef = useRef<Project | null>(null);
+    // Attachment work already done against that project. A retry after a
+    // failed step must not re-upload a file or re-link a document that landed
+    // on the first attempt, or the project ends up with duplicates.
+    const uploadedFilenamesRef = useRef<Set<string>>(new Set());
+    const linkedDocumentIdsRef = useRef<Set<string>>(new Set());
     const { user } = useAuth();
     const { profile } = useUserProfile();
     const preferredPractice =
@@ -74,11 +85,22 @@ export function NewProjectModal({ open, onClose, onCreated }: Props) {
     useEffect(() => {
         if (!open) return;
         let cancelled = false;
+        setOrgLoadError("");
         listOrgs()
             .then((rows) => {
                 if (!cancelled) setOrgs(rows);
             })
-            .catch(() => {});
+            .catch((err: unknown) => {
+                // Silently showing only "No organization" would look like the
+                // caller belongs to no firm, so say the list failed instead.
+                if (!cancelled)
+                    setOrgLoadError(
+                        userFacingApiError(
+                            err,
+                            "Your organizations could not be loaded.",
+                        ),
+                    );
+            });
         return () => {
             cancelled = true;
         };
@@ -146,58 +168,10 @@ export function NewProjectModal({ open, onClose, onCreated }: Props) {
                 ));
             createdProjectRef.current = project;
 
-            const linkResults = await Promise.all(
-                selectedDocuments.map((document) =>
-                    addDocumentToProject(project.id, document.id).then(
-                        () => true,
-                        () => false,
-                    ),
-                ),
-            );
-            const linkedCount = linkResults.filter(Boolean).length;
-            const failedLinkNames = selectedDocuments
-                .filter((_, index) => !linkResults[index])
-                .map((document) => document.filename);
-
-            let uploadedCount = 0;
-            let uploadFailure: string | null = null;
-            if (pendingFiles.length > 0) {
-                try {
-                    const outcomes = await uploadProjectDocuments(
-                        project.id,
-                        pendingFiles.map((file) => ({ file })),
-                    );
-                    uploadedCount = outcomes.filter(
-                        (outcome) => outcome.status === "completed",
-                    ).length;
-                    if (uploadedCount < outcomes.length) {
-                        uploadFailure = failedUploadMessage(outcomes);
-                    }
-                } catch (uploadError) {
-                    // Aborts, session-creation failures, and batch validation
-                    // still throw; everything else comes back as outcomes.
-                    uploadFailure =
-                        uploadError instanceof UploadBatchError
-                            ? failedUploadMessage(uploadError.outcomes)
-                            : userFacingApiError(
-                                  uploadError,
-                                  "The attached files could not be uploaded. Please try again.",
-                              );
-                }
-            }
-
-            const attachedCount = linkedCount + uploadedCount;
-            const requestedCount =
-                selectedDocuments.length + pendingFiles.length;
-            const failureMessage = [
-                uploadFailure,
-                failedLinkNames.length > 0
-                    ? `${failedLinkNames.join(", ")} could not be added to the project.`
-                    : null,
-            ]
-                .filter(Boolean)
-                .join(" ");
-
+            // Grants run before the attachment work: a refusal here stops the
+            // submit, and anything already uploaded or linked would otherwise
+            // have to be redone on the retry — which duplicated documents.
+            //
             // Sequential: these are a handful of addresses, and one refusal
             // should be reported with its own message rather than lost in a
             // race. The endpoint upserts, so a retry after a partial failure
@@ -234,6 +208,88 @@ export function NewProjectModal({ open, onClose, onCreated }: Props) {
                 // project, so pressing Create again retries only the grants.
                 return;
             }
+
+            // Only documents this modal has not already linked: a retry after
+            // a later failure must not add the same document twice.
+            const documentsToLink = selectedDocuments.filter(
+                (document) => !linkedDocumentIdsRef.current.has(document.id),
+            );
+            const linkResults = await Promise.all(
+                documentsToLink.map((document) =>
+                    addDocumentToProject(project.id, document.id).then(
+                        () => true,
+                        () => false,
+                    ),
+                ),
+            );
+            documentsToLink.forEach((document, index) => {
+                if (linkResults[index])
+                    linkedDocumentIdsRef.current.add(document.id);
+            });
+            const failedLinkNames = documentsToLink
+                .filter((_, index) => !linkResults[index])
+                .map((document) => document.filename);
+
+            // Same for uploads. Filenames are unique inside pendingFiles —
+            // handleFileChange rejects a second file of the same name — and
+            // every outcome carries the filename it was sent under.
+            const filesToUpload = pendingFiles.filter(
+                (file) => !uploadedFilenamesRef.current.has(file.name),
+            );
+            let uploadFailure: string | null = null;
+            if (filesToUpload.length > 0) {
+                try {
+                    const outcomes = await uploadProjectDocuments(
+                        project.id,
+                        filesToUpload.map((file) => ({ file })),
+                    );
+                    for (const outcome of outcomes) {
+                        if (outcome.status === "completed")
+                            uploadedFilenamesRef.current.add(outcome.filename);
+                    }
+                    if (
+                        outcomes.some(
+                            (outcome) => outcome.status !== "completed",
+                        )
+                    ) {
+                        uploadFailure = failedUploadMessage(outcomes);
+                    }
+                } catch (uploadError) {
+                    // Aborts, session-creation failures, and batch validation
+                    // still throw; everything else comes back as outcomes.
+                    if (uploadError instanceof UploadBatchError) {
+                        for (const outcome of uploadError.outcomes) {
+                            if (outcome.status === "completed")
+                                uploadedFilenamesRef.current.add(
+                                    outcome.filename,
+                                );
+                        }
+                    }
+                    uploadFailure =
+                        uploadError instanceof UploadBatchError
+                            ? failedUploadMessage(uploadError.outcomes)
+                            : userFacingApiError(
+                                  uploadError,
+                                  "The attached files could not be uploaded. Please try again.",
+                              );
+                }
+            }
+
+            // Counted across attempts, not just this one, so a retry reports
+            // the project's real document count.
+            const attachedCount =
+                linkedDocumentIdsRef.current.size +
+                uploadedFilenamesRef.current.size;
+            const requestedCount =
+                selectedDocuments.length + pendingFiles.length;
+            const failureMessage = [
+                uploadFailure,
+                failedLinkNames.length > 0
+                    ? `${failedLinkNames.join(", ")} could not be added to the project.`
+                    : null,
+            ]
+                .filter(Boolean)
+                .join(" ");
 
             // POST /projects returns a bare row with no role fields, and
             // the list's fail-closed roleFrom() reads "no role fields" as
@@ -284,6 +340,8 @@ export function NewProjectModal({ open, onClose, onCreated }: Props) {
 
     function resetForm() {
         createdProjectRef.current = null;
+        uploadedFilenamesRef.current = new Set();
+        linkedDocumentIdsRef.current = new Set();
         setPendingProject(null);
         setStep("details");
         setName("");
@@ -299,8 +357,15 @@ export function NewProjectModal({ open, onClose, onCreated }: Props) {
     }
 
     function handleClose() {
+        // Escape and the backdrop reach this too: dismissing a create that is
+        // still in flight would leave the outcome unreportable.
+        if (loading) return;
+        // The project exists but never reached onCreated, so the caller's list
+        // does not have it. Say so on the way out instead of leaving the row
+        // invisible until a reload.
+        const createdWithoutHandover = createdProjectRef.current !== null;
         resetForm();
-        onClose();
+        onClose(createdWithoutHandover);
     }
 
     return (
@@ -463,6 +528,11 @@ export function NewProjectModal({ open, onClose, onCreated }: Props) {
                                     })),
                                 ]}
                             />
+                            {orgLoadError && (
+                                <p className="mt-2 text-sm text-red-500">
+                                    {orgLoadError}
+                                </p>
+                            )}
                         </div>
                     </div>
                 ) : step === "access" ? (

--- a/frontend/src/app/components/projects/NewProjectModal.tsx
+++ b/frontend/src/app/components/projects/NewProjectModal.tsx
@@ -21,6 +21,7 @@ import { FieldLabel, FormTextInput } from "../ui/form-field";
 import { ModalSelect } from "../modals/ModalSelect";
 import { ProjectPracticeField } from "./ProjectPracticeField";
 import { userFacingApiError } from "@/app/lib/userFacingError";
+import { createSecureUuid } from "@/shared/lib/secureUuid";
 import {
     CreateAccessStep,
     type PendingDirectGrant,
@@ -59,6 +60,9 @@ export function NewProjectModal({ open, onClose, onCreated }: Props) {
     // A project created with only some of its files attached. The modal holds
     // it until the user has read which files are missing.
     const [pendingProject, setPendingProject] = useState<Project | null>(null);
+    // Mirrors `createdProjectRef` for rendering: a ref does not re-render, and
+    // the wizard's Back button has to retire the moment the project is real.
+    const [projectExists, setProjectExists] = useState(false);
     const fileInputRef = useRef<HTMLInputElement>(null);
     const practiceEditedRef = useRef(false);
     // The project is created before its grants are written and its documents
@@ -69,7 +73,17 @@ export function NewProjectModal({ open, onClose, onCreated }: Props) {
     // Attachment work already done against that project. A retry after a
     // failed step must not re-upload a file or re-link a document that landed
     // on the first attempt, or the project ends up with duplicates.
-    const uploadedFilenamesRef = useRef<Set<string>>(new Set());
+    //
+    // Keyed by the File itself, not by its name. A name is neither unique nor
+    // stable: two files called `contract.pdf` from different folders are two
+    // uploads, and the server trims the name it stores, so ` notes.docx `
+    // came back as `notes.docx`, never matched the pending file, and was
+    // uploaded again on every retry. The identity of the object the user
+    // picked is the only thing that answers "have I already sent this one?".
+    const uploadedFilesRef = useRef<Set<File>>(new Set());
+    // The id each file is uploaded under, so an outcome can be traced back to
+    // the File that produced it even when two of them share a name.
+    const uploadClientIdsRef = useRef<Map<File, string>>(new Map());
     const linkedDocumentIdsRef = useRef<Set<string>>(new Set());
     const { user } = useAuth();
     const { profile } = useUserProfile();
@@ -121,10 +135,23 @@ export function NewProjectModal({ open, onClose, onCreated }: Props) {
         const files = Array.from(e.target.files ?? []);
         e.target.value = "";
         if (!files.length) return;
+        // Deduplicated by identity, not by name. The old name test silently
+        // dropped the second of two files called `contract.pdf` — a normal
+        // thing to attach from two different folders — and the user was never
+        // told one of their picks had not been taken.
         setPendingFiles((prev) => [
             ...prev,
-            ...files.filter((f) => !prev.some((p) => p.name === f.name)),
+            ...files.filter((file) => !prev.includes(file)),
         ]);
+    }
+
+    /** A stable per-file upload id, so outcomes map back to their File. */
+    function uploadClientId(file: File): string {
+        const existing = uploadClientIdsRef.current.get(file);
+        if (existing) return existing;
+        const clientId = createSecureUuid();
+        uploadClientIdsRef.current.set(file, clientId);
+        return clientId;
     }
 
     function finishCreation(project: Project) {
@@ -167,6 +194,7 @@ export function NewProjectModal({ open, onClose, onCreated }: Props) {
                     orgId !== PERSONAL_WORKSPACE ? orgId : undefined,
                 ));
             createdProjectRef.current = project;
+            setProjectExists(true);
 
             // Grants run before the attachment work: a refusal here stops the
             // submit, and anything already uploaded or linked would otherwise
@@ -199,10 +227,28 @@ export function NewProjectModal({ open, onClose, onCreated }: Props) {
                 // navigating away from the only place that knows the sharing
                 // did not happen. Pressing Create again retries the grants
                 // against the same project.
+                // Say what happened to the documents too. The submit stops
+                // here, so nothing the user attached has been sent yet — and
+                // an error that mentions only the sharing reads as though the
+                // files went in, which is the opposite of the truth.
+                const stillPending =
+                    selectedDocuments.filter(
+                        (document) =>
+                            !linkedDocumentIdsRef.current.has(document.id),
+                    ).length +
+                    pendingFiles.filter(
+                        (file) => !uploadedFilesRef.current.has(file),
+                    ).length;
                 setError(
                     `Project created, but access was not granted to ${grantFailures
                         .map((failure) => failure.email)
-                        .join(", ")}: ${grantFailures[0].detail}`,
+                        .join(", ")}: ${grantFailures[0].detail}${
+                        stillPending > 0
+                            ? ` The ${stillPending} selected ${
+                                  stillPending === 1 ? "file is" : "files are"
+                              } still pending and will be attached when you try again.`
+                            : ""
+                    }`,
                 );
                 // Stay open on THIS dialog: createdProjectRef holds the
                 // project, so pressing Create again retries only the grants.
@@ -230,23 +276,36 @@ export function NewProjectModal({ open, onClose, onCreated }: Props) {
                 .filter((_, index) => !linkResults[index])
                 .map((document) => document.filename);
 
-            // Same for uploads. Filenames are unique inside pendingFiles —
-            // handleFileChange rejects a second file of the same name — and
-            // every outcome carries the filename it was sent under.
+            // Same for uploads, tracked by File identity through the client id
+            // each one is sent under — the outcome's `filename` is the
+            // server's trimmed version and cannot be trusted to match.
             const filesToUpload = pendingFiles.filter(
-                (file) => !uploadedFilenamesRef.current.has(file.name),
+                (file) => !uploadedFilesRef.current.has(file),
             );
+            const uploadInputs = filesToUpload.map((file) => ({
+                file,
+                clientId: uploadClientId(file),
+            }));
+            const fileByClientId = new Map(
+                uploadInputs.map((input) => [input.clientId, input.file]),
+            );
+            const recordCompletedUploads = (
+                outcomes: { clientId: string; status: string }[],
+            ) => {
+                for (const outcome of outcomes) {
+                    const file = fileByClientId.get(outcome.clientId);
+                    if (outcome.status === "completed" && file)
+                        uploadedFilesRef.current.add(file);
+                }
+            };
             let uploadFailure: string | null = null;
-            if (filesToUpload.length > 0) {
+            if (uploadInputs.length > 0) {
                 try {
                     const outcomes = await uploadProjectDocuments(
                         project.id,
-                        filesToUpload.map((file) => ({ file })),
+                        uploadInputs,
                     );
-                    for (const outcome of outcomes) {
-                        if (outcome.status === "completed")
-                            uploadedFilenamesRef.current.add(outcome.filename);
-                    }
+                    recordCompletedUploads(outcomes);
                     if (
                         outcomes.some(
                             (outcome) => outcome.status !== "completed",
@@ -258,12 +317,7 @@ export function NewProjectModal({ open, onClose, onCreated }: Props) {
                     // Aborts, session-creation failures, and batch validation
                     // still throw; everything else comes back as outcomes.
                     if (uploadError instanceof UploadBatchError) {
-                        for (const outcome of uploadError.outcomes) {
-                            if (outcome.status === "completed")
-                                uploadedFilenamesRef.current.add(
-                                    outcome.filename,
-                                );
-                        }
+                        recordCompletedUploads(uploadError.outcomes);
                     }
                     uploadFailure =
                         uploadError instanceof UploadBatchError
@@ -279,7 +333,7 @@ export function NewProjectModal({ open, onClose, onCreated }: Props) {
             // the project's real document count.
             const attachedCount =
                 linkedDocumentIdsRef.current.size +
-                uploadedFilenamesRef.current.size;
+                uploadedFilesRef.current.size;
             const requestedCount =
                 selectedDocuments.length + pendingFiles.length;
             const failureMessage = [
@@ -340,7 +394,9 @@ export function NewProjectModal({ open, onClose, onCreated }: Props) {
 
     function resetForm() {
         createdProjectRef.current = null;
-        uploadedFilenamesRef.current = new Set();
+        setProjectExists(false);
+        uploadedFilesRef.current = new Set();
+        uploadClientIdsRef.current = new Map();
         linkedDocumentIdsRef.current = new Set();
         setPendingProject(null);
         setStep("details");
@@ -405,7 +461,17 @@ export function NewProjectModal({ open, onClose, onCreated }: Props) {
                     ? {
                           label: "Back",
                           onClick: () => setStep("access"),
-                          disabled: loading,
+                          // Once the project EXISTS, going back is a lie: the
+                          // retry reuses `createdProjectRef`, so a switch from
+                          // Personal to an organization on the second attempt
+                          // left the project where it was first created and
+                          // applied the new organization's overrides to it.
+                          // The earlier steps no longer describe anything that
+                          // can still be changed here.
+                          disabled: loading || projectExists,
+                          title: projectExists
+                              ? "The project has been created — its details and access can be changed from the project itself."
+                              : undefined,
                       }
                     : step === "access"
                       ? {

--- a/frontend/src/app/components/projects/ProjectAssistantTable.roles.test.tsx
+++ b/frontend/src/app/components/projects/ProjectAssistantTable.roles.test.tsx
@@ -13,6 +13,7 @@ import { ProjectAssistantTable } from "./ProjectAssistantTable";
 const onOwnerOnlyAction = vi.fn();
 const setRenamingChatId = vi.fn();
 const setRenameChatValue = vi.fn();
+const onDeleteChat = vi.fn();
 
 function chat(overrides: Partial<Chat> = {}): Chat {
     return {
@@ -39,7 +40,7 @@ function renderTable(row: Chat) {
             currentUserId="u1"
             onCreateChat={vi.fn()}
             onOpenChat={vi.fn()}
-            onDeleteChat={vi.fn()}
+            onDeleteChat={onDeleteChat}
             onDeleteSelectedChats={vi.fn()}
             onOwnerOnlyAction={onOwnerOnlyAction}
             submitChatRename={vi.fn()}
@@ -54,6 +55,12 @@ function renderTable(row: Chat) {
 function clickRename() {
     fireEvent.click(screen.getByText("···"));
     fireEvent.click(screen.getByText("Rename"));
+}
+
+/** Open the row's action menu and click Delete. */
+function clickDelete() {
+    fireEvent.click(screen.getByText("···"));
+    fireEvent.click(screen.getByText("Delete"));
 }
 
 beforeEach(() => {
@@ -90,5 +97,46 @@ describe("ProjectAssistantTable rename gating", () => {
             action: "rename this chat",
             requiredRole: "editor",
         });
+    });
+});
+
+describe("ProjectAssistantTable delete confirmation", () => {
+    it("asks before deleting a colleague's chat", () => {
+        // One click used to be the whole interaction: the row was gone, and
+        // the chat with it, with nothing between the menu and the request.
+        renderTable(chat({ access_role: "owner", is_owner: false }));
+
+        clickDelete();
+
+        expect(onDeleteChat).not.toHaveBeenCalled();
+        expect(screen.getByText("Delete chat?")).toBeInTheDocument();
+        expect(screen.getByText("This cannot be undone.")).toBeInTheDocument();
+
+        fireEvent.click(screen.getByRole("button", { name: "Delete" }));
+
+        expect(onDeleteChat).toHaveBeenCalledTimes(1);
+        expect(onDeleteChat.mock.calls[0][0]).toMatchObject({ id: "c1" });
+    });
+
+    it("deletes nothing when the confirmation is cancelled", () => {
+        renderTable(chat({ access_role: "owner", is_owner: false }));
+
+        clickDelete();
+        fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+
+        expect(screen.queryByText("Delete chat?")).not.toBeInTheDocument();
+        expect(onDeleteChat).not.toHaveBeenCalled();
+    });
+
+    it("refuses a member without asking them to confirm anything", () => {
+        // The role gate runs first: a confirmation for a delete the server
+        // will refuse is two dialogs for one refusal.
+        renderTable(chat({ access_role: "editor", is_owner: false }));
+
+        clickDelete();
+
+        expect(screen.queryByText("Delete chat?")).not.toBeInTheDocument();
+        expect(onOwnerOnlyAction).toHaveBeenCalledWith("delete this chat");
+        expect(onDeleteChat).not.toHaveBeenCalled();
     });
 });

--- a/frontend/src/app/components/projects/ProjectAssistantTable.test.tsx
+++ b/frontend/src/app/components/projects/ProjectAssistantTable.test.tsx
@@ -4,6 +4,9 @@ import { describe, expect, it, vi } from "vitest";
 import type { Chat } from "@/app/components/shared/types";
 import { ProjectAssistantTable } from "./ProjectAssistantTable";
 
+// Owner rows: deleting is `container.delete`, which the table now checks
+// before it offers the confirmation, so a row with no served role would be
+// refused here rather than reaching the handler.
 const chats: Chat[] = [
     {
         id: "chat-1",
@@ -11,6 +14,7 @@ const chats: Chat[] = [
         user_id: "user-1",
         title: "First chat",
         created_at: "2026-08-27T00:00:00.000Z",
+        access_role: "owner",
     },
     {
         id: "chat-2",
@@ -18,6 +22,7 @@ const chats: Chat[] = [
         user_id: "user-1",
         title: "Second chat",
         created_at: "2026-08-27T00:00:00.000Z",
+        access_role: "owner",
     },
 ];
 
@@ -77,6 +82,9 @@ describe("ProjectAssistantTable row context actions", () => {
         const { onDeleteChat, onDeleteSelectedChats } = renderTable(["chat-2"]);
 
         fireEvent.contextMenu(screen.getByText("First chat"));
+        await user.click(screen.getByRole("button", { name: "Delete" }));
+        // The single-row delete is confirmed first; the bulk one is confirmed
+        // by the page that owns the selection.
         await user.click(screen.getByRole("button", { name: "Delete" }));
 
         expect(onDeleteChat).toHaveBeenCalledWith(chats[0]);

--- a/frontend/src/app/components/projects/ProjectAssistantTable.tsx
+++ b/frontend/src/app/components/projects/ProjectAssistantTable.tsx
@@ -31,6 +31,7 @@ import {
     type TableSortDirection,
     TableStickyCell,
 } from "@/app/components/shared/TablePrimitive";
+import { ConfirmPopup } from "@/app/components/popups/ConfirmPopup";
 import { EmptyState } from "@/app/components/ui/empty-state";
 import { PillButton } from "@/app/components/ui/pill-button";
 import { ChatSkeuoIcon } from "@/app/components/shared/AppSidebarSkeuoIcons";
@@ -94,6 +95,24 @@ export function ProjectAssistantTable({
         direction: TableSortDirection;
     } | null>(null);
     const rowSelectionAnchorIdRef = useRef<string | null>(null);
+    const [chatPendingDelete, setChatPendingDelete] = useState<Chat | null>(
+        null,
+    );
+
+    /**
+     * Deleting a chat is destructive and irreversible, and a project admin's
+     * Delete reaches a colleague's thread — so it is confirmed first, the way
+     * every other delete in the app is. The role gate runs BEFORE the
+     * confirmation: asking a viewer to confirm a delete the server will refuse
+     * is two dialogs for one refusal.
+     */
+    function requestDeleteChat(chat: Chat) {
+        if (!can(roleFrom(chat), "container.delete")) {
+            onOwnerOnlyAction("delete this chat");
+            return;
+        }
+        setChatPendingDelete(chat);
+    }
 
     function clearSelection() {
         rowSelectionAnchorIdRef.current = null;
@@ -191,6 +210,7 @@ export function ProjectAssistantTable({
     );
 
     return (
+        <>
         <TableScrollArea
             header={
                 <TableHeaderRow className="pr-8 md:pr-8">
@@ -312,7 +332,7 @@ export function ProjectAssistantTable({
                                     onDelete={() =>
                                         appliesToSelection
                                             ? onDeleteSelectedChats()
-                                            : onDeleteChat(chat)
+                                            : requestDeleteChat(chat)
                                     }
                                     deleteLabel={
                                         appliesToSelection
@@ -411,7 +431,7 @@ export function ProjectAssistantTable({
                                         );
                                         setRenamingChatId(chat.id);
                                     }}
-                                    onDelete={() => onDeleteChat(chat)}
+                                    onDelete={() => requestDeleteChat(chat)}
                                 />
                             </div>
                         </TableRow>
@@ -420,6 +440,20 @@ export function ProjectAssistantTable({
                 </TableBody>
             )}
         </TableScrollArea>
+        <ConfirmPopup
+            open={chatPendingDelete !== null}
+            title="Delete chat?"
+            message="This cannot be undone."
+            confirmLabel="Delete"
+            confirmVariant="danger"
+            onCancel={() => setChatPendingDelete(null)}
+            onConfirm={() => {
+                const chat = chatPendingDelete;
+                setChatPendingDelete(null);
+                if (chat) void onDeleteChat(chat);
+            }}
+        />
+        </>
     );
 }
 

--- a/frontend/src/app/components/projects/ProjectDetailsModal.test.tsx
+++ b/frontend/src/app/components/projects/ProjectDetailsModal.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { listOrgs } from "@/app/lib/mikeApi";
+import { MikeApiError, listOrgs } from "@/app/lib/mikeApi";
 import type { Project } from "@/app/components/shared/types";
 import { ProjectDetailsModal } from "./ProjectDetailsModal";
 
@@ -58,5 +59,55 @@ describe("ProjectDetailsModal", () => {
         const organisation = await screen.findByLabelText("Organisation");
         expect(organisation).toBeDisabled();
         expect(organisation).toHaveTextContent("Elite Law LLP");
+    });
+
+    it("names the organisation from the row when the org list fails", async () => {
+        // The select falls back to its raw value when no option matches, so a
+        // failed listOrgs used to show the organization's UUID.
+        vi.mocked(listOrgs).mockRejectedValue(new Error("network"));
+        render(
+            <ProjectDetailsModal
+                open
+                project={{
+                    ...project,
+                    organization_name: "Elite Law LLP",
+                }}
+                canEdit
+                onClose={vi.fn()}
+                onSave={vi.fn()}
+            />,
+        );
+
+        const organisation = await screen.findByLabelText("Organisation");
+        expect(organisation).toHaveTextContent("Elite Law LLP");
+        expect(organisation).not.toHaveTextContent("org-1");
+    });
+
+    it("reports what an intentional refusal said instead of a generic line", async () => {
+        const user = userEvent.setup();
+        render(
+            <ProjectDetailsModal
+                open
+                project={project}
+                canEdit
+                onClose={vi.fn()}
+                onSave={vi
+                    .fn()
+                    .mockRejectedValue(
+                        new MikeApiError({
+                            status: 409,
+                            message: "A project with that CM number exists.",
+                        }),
+                    )}
+            />,
+        );
+
+        await user.clear(screen.getByLabelText("Project name"));
+        await user.type(screen.getByLabelText("Project name"), "Renamed");
+        await user.click(screen.getByRole("button", { name: "Update" }));
+
+        expect(
+            await screen.findByText("A project with that CM number exists."),
+        ).toBeInTheDocument();
     });
 });

--- a/frontend/src/app/components/projects/ProjectDetailsModal.tsx
+++ b/frontend/src/app/components/projects/ProjectDetailsModal.tsx
@@ -10,6 +10,7 @@ import {
 } from "@/app/components/ui/form-field";
 import type { Project } from "@/app/components/shared/types";
 import { listOrgs, type Org } from "@/app/lib/mikeApi";
+import { userFacingApiError } from "@/app/lib/userFacingError";
 import { ProjectPracticeField } from "./ProjectPracticeField";
 
 const PERSONAL_WORKSPACE = "__personal__";
@@ -75,6 +76,26 @@ export function ProjectDetailsModal({
         );
     }, [project, trimmedCm, trimmedName, trimmedPractice]);
 
+    // The select falls back to rendering its raw value when no option matches,
+    // so a failed (or still pending) listOrgs used to show the organization's
+    // UUID. The row already carries the name — use it.
+    const orgOptions = useMemo(() => {
+        const options = [
+            { value: PERSONAL_WORKSPACE, label: "No organization" },
+            ...orgs.map((org) => ({ value: org.id, label: org.name })),
+        ];
+        if (
+            project?.org_id &&
+            !options.some((option) => option.value === project.org_id)
+        ) {
+            options.push({
+                value: project.org_id,
+                label: project.organization_name ?? "Organisation",
+            });
+        }
+        return options;
+    }, [orgs, project?.org_id, project?.organization_name]);
+
     if (!project) return null;
 
     async function handleSave() {
@@ -92,8 +113,12 @@ export function ProjectDetailsModal({
                         : "",
             });
             setSaved(true);
-        } catch {
-            setError("Could not update project details.");
+        } catch (err: unknown) {
+            // An intentional 4xx (a name conflict, a refusal) says something
+            // the generic line cannot; anything else still falls back to it.
+            setError(
+                userFacingApiError(err, "Could not update project details."),
+            );
         } finally {
             setSaving(false);
         }
@@ -194,16 +219,7 @@ export function ProjectDetailsModal({
                         value={project.org_id ?? PERSONAL_WORKSPACE}
                         onChange={() => undefined}
                         disabled
-                        options={[
-                            {
-                                value: PERSONAL_WORKSPACE,
-                                label: "No organization",
-                            },
-                            ...orgs.map((org) => ({
-                                value: org.id,
-                                label: org.name,
-                            })),
-                        ]}
+                        options={orgOptions}
                     />
                 </div>
             </div>

--- a/frontend/src/app/components/projects/ProjectDocumentsView.roles.test.tsx
+++ b/frontend/src/app/components/projects/ProjectDocumentsView.roles.test.tsx
@@ -5,9 +5,18 @@ import { can, type Capability, type ProjectRole } from "@/app/lib/permissions";
 import { ProjectDocumentsView } from "./ProjectDocumentsView";
 
 // Everything below the toolbar is out of scope here: this file pins WHICH
-// role sees the folder affordances, not what DocTable does with them.
+// role sees the folder affordances, not what DocTable does with them. The
+// table's props are recorded because the upload menu is assembled from the
+// three action registrations handed to it.
+const docTableProps = vi.hoisted(() => ({
+    current: null as Record<string, unknown> | null,
+}));
+
 vi.mock("@/app/components/documents/DocTable", () => ({
-    DocTable: () => <div data-testid="doc-table" />,
+    DocTable: (props: Record<string, unknown>) => {
+        docTableProps.current = props;
+        return <div data-testid="doc-table" />;
+    },
 }));
 vi.mock("@/app/components/modals/AddDocumentsModal", () => ({
     AddDocumentsModal: () => null,
@@ -83,6 +92,26 @@ describe("ProjectDocumentsView folder affordances", () => {
     it("withholds them from viewers", () => {
         renderAs("viewer");
         expect(screen.queryByText("Folder")).not.toBeInTheDocument();
+    });
+
+    it("wires no upload source at all for a viewer", () => {
+        // All three entries of the Upload menu are the same content.edit
+        // write. "Upload folder" used to stay live for a viewer, so the
+        // native folder picker opened and the refusal only arrived once the
+        // upload session was already under way.
+        renderAs("viewer");
+        expect(docTableProps.current?.onAddDocumentsActionChange).toBeUndefined();
+        expect(docTableProps.current?.onUploadFilesActionChange).toBeUndefined();
+        expect(
+            docTableProps.current?.onUploadFolderActionChange,
+        ).toBeUndefined();
+    });
+
+    it("wires every upload source for an editor", () => {
+        renderAs("editor");
+        expect(docTableProps.current?.onAddDocumentsActionChange).toBeDefined();
+        expect(docTableProps.current?.onUploadFilesActionChange).toBeDefined();
+        expect(docTableProps.current?.onUploadFolderActionChange).toBeDefined();
     });
 
     it("keeps them in place but disabled while the role is unknown", () => {

--- a/frontend/src/app/components/projects/ProjectDocumentsView.tsx
+++ b/frontend/src/app/components/projects/ProjectDocumentsView.tsx
@@ -395,7 +395,16 @@ export function ProjectDocumentsView({ projectId, folderId = null }: Props) {
                         ? handleUploadFilesActionChange
                         : undefined
                 }
-                onUploadFolderActionChange={handleUploadFolderActionChange}
+                // Uploading a folder is the same content.edit write as
+                // uploading files — one native picker further in. Left
+                // ungated, a viewer chose a folder from disk and only then
+                // met the failure, halfway through an upload session they
+                // were never allowed to open.
+                onUploadFolderActionChange={
+                    canDo("content.edit")
+                        ? handleUploadFolderActionChange
+                        : undefined
+                }
                 onCreateFolderActionChange={handleCreateFolderActionChange}
                 onFolderViewBackActionChange={handleFolderBackActionChange}
                 onFolderViewChange={handleFolderViewChange}

--- a/frontend/src/app/components/projects/ProjectWorkspace.loading.test.tsx
+++ b/frontend/src/app/components/projects/ProjectWorkspace.loading.test.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from "react";
 import { describe, expect, it, vi, beforeEach } from "vitest";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { getProject } from "@/app/lib/mikeApi";
@@ -72,6 +73,32 @@ function Probe() {
                 {String(canDo("container.delete"))}
             </span>
             <span data-testid="can-edit">{String(canDo("content.edit"))}</span>
+        </div>
+    );
+}
+
+// Loads the chat list (the optimistic row is only prepended to a loaded
+// list), then exposes the row the workspace stamps for a new chat.
+function ChatProbe() {
+    const { createChat, ensureProjectChats, projectChats } =
+        useProjectWorkspace();
+
+    useEffect(() => {
+        void ensureProjectChats();
+    }, [ensureProjectChats]);
+
+    return (
+        <div>
+            <button onClick={() => void createChat()}>new chat</button>
+            <span data-testid="chat-count">
+                {projectChats === null ? "none" : String(projectChats.length)}
+            </span>
+            <span data-testid="chat-role">
+                {String(projectChats?.[0]?.access_role ?? "none")}
+            </span>
+            <span data-testid="chat-owner">
+                {String(projectChats?.[0]?.is_owner ?? "none")}
+            </span>
         </div>
     );
 }
@@ -187,6 +214,32 @@ describe("ProjectWorkspace while the project is still loading", () => {
         expect(
             screen.queryByText(/Only an admin can/),
         ).not.toBeInTheDocument();
+    });
+
+    it("stamps the caller's project role on a new chat, not owner", async () => {
+        // The server derives a project chat's role from the PROJECT role, so
+        // stamping "owner" on the optimistic row offered an editor a Delete
+        // that came back 403 in a popup.
+        vi.mocked(getProject).mockResolvedValue({
+            ...OWNER_PROJECT,
+            access_role: "editor",
+        } as unknown as Project);
+        render(
+            <ProjectWorkspaceProvider projectId="p1">
+                <ChatProbe />
+            </ProjectWorkspaceProvider>,
+        );
+        await waitFor(() =>
+            expect(screen.getByTestId("chat-count")).toHaveTextContent("0"),
+        );
+
+        fireEvent.click(screen.getByText("new chat"));
+
+        await waitFor(() =>
+            expect(screen.getByTestId("chat-count")).toHaveTextContent("1"),
+        );
+        expect(screen.getByTestId("chat-role")).toHaveTextContent("editor");
+        expect(screen.getByTestId("chat-owner")).toHaveTextContent("false");
     });
 
     it("refuses, and names an admin, once the row says viewer", async () => {

--- a/frontend/src/app/components/projects/ProjectWorkspace.tsx
+++ b/frontend/src/app/components/projects/ProjectWorkspace.tsx
@@ -394,14 +394,20 @@ export function ProjectWorkspaceProvider({
                                   title: null,
                                   created_at: now,
                                   // The row the server would have served for
-                                  // a chat we just created: its creator is
-                                  // its admin. Without these the client's
-                                  // `roleFrom` falls back to viewer — fail
-                                  // closed, correct as a default and wrong
-                                  // here — and the author could not rename or
-                                  // delete their own new chat until reload.
-                                  is_owner: true,
-                                  access_role: "owner",
+                                  // a chat we just created. Without these the
+                                  // client's `roleFrom` falls back to viewer
+                                  // — fail closed, correct as a default and
+                                  // wrong here — and the author could not
+                                  // rename their own new chat until reload.
+                                  //
+                                  // The stamp is the caller's role on the
+                                  // PROJECT, which is what the server derives
+                                  // a project chat's role from. Stamping
+                                  // "owner" offered an editor a Delete that
+                                  // came back 403. `content.edit` passed, so
+                                  // the role is known and at least editor.
+                                  is_owner: accessRole === "owner",
+                                  access_role: accessRole ?? "editor",
                               },
                               ...prev,
                           ]
@@ -413,6 +419,7 @@ export function ProjectWorkspaceProvider({
             setCreatingChat(false);
         }
     }, [
+        accessRole,
         canDo,
         denyUnlessLoading,
         profile?.displayName,
@@ -671,6 +678,10 @@ export function ProjectWorkspaceProvider({
                         resource={project}
                         fetchAccess={getProjectPeople}
                         currentUserEmail={user?.email ?? null}
+                        // Both identifiers: a roster row without an email
+                        // would otherwise offer the caller a Remove that locks
+                        // them out of their own project.
+                        currentUserId={user?.id ?? null}
                         breadcrumb={[
                             "Projects",
                             project.name +

--- a/frontend/src/app/components/projects/ProjectWorkspace.tsx
+++ b/frontend/src/app/components/projects/ProjectWorkspace.tsx
@@ -379,7 +379,10 @@ export function ProjectWorkspaceProvider({
         }
         setCreatingChat(true);
         try {
-            const id = await saveChat(projectId);
+            // The sidebar row the context prepends needs the same project
+            // role this list stamps below; without it the sidebar offered an
+            // editor a Delete the server refuses.
+            const id = await saveChat(projectId, accessRole);
             if (id) {
                 const now = new Date().toISOString();
                 setProjectChats((prev) =>

--- a/frontend/src/app/components/projects/ProjectsOverview.test.tsx
+++ b/frontend/src/app/components/projects/ProjectsOverview.test.tsx
@@ -3,13 +3,19 @@ import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { ProjectsOverview } from "./ProjectsOverview";
 
-const { activeTab, projectRows, setActiveTab, usePaginatedProjectsSpy } =
-    vi.hoisted(() => ({
-        activeTab: { current: "all" as string },
-        projectRows: { current: [] as Record<string, unknown>[] },
-        setActiveTab: vi.fn(),
-        usePaginatedProjectsSpy: vi.fn(),
-    }));
+const {
+    activeTab,
+    projectRows,
+    retrySpy,
+    setActiveTab,
+    usePaginatedProjectsSpy,
+} = vi.hoisted(() => ({
+    activeTab: { current: "all" as string },
+    projectRows: { current: [] as Record<string, unknown>[] },
+    retrySpy: vi.fn(),
+    setActiveTab: vi.fn(),
+    usePaginatedProjectsSpy: vi.fn(),
+}));
 
 vi.mock("next/navigation", () => ({
     useRouter: () => ({ push: vi.fn(), replace: vi.fn() }),
@@ -35,7 +41,7 @@ vi.mock("@/app/hooks/usePaginatedProjects", () => ({
             error: null,
             loadMoreError: null,
             loadMore: vi.fn(),
-            retry: vi.fn(),
+            retry: retrySpy,
             selectedProjectIds: [],
             setSelectedProjectIds: vi.fn(),
             selectAllMatching: vi.fn(),
@@ -58,7 +64,23 @@ vi.mock("@/app/lib/mikeApi", () => ({
     deleteProject: vi.fn(),
 }));
 
-vi.mock("./NewProjectModal", () => ({ NewProjectModal: () => null }));
+vi.mock("./NewProjectModal", () => ({
+    NewProjectModal: ({
+        open,
+        onClose,
+    }: {
+        open: boolean;
+        onClose: (createdWithoutHandover?: boolean) => void;
+    }) =>
+        open ? (
+            <div>
+                <button onClick={() => onClose(true)}>
+                    close after partial create
+                </button>
+                <button onClick={() => onClose()}>close untouched</button>
+            </div>
+        ) : null,
+}));
 vi.mock("./ProjectDetailsModal", () => ({ ProjectDetailsModal: () => null }));
 
 function lastScope() {
@@ -71,6 +93,7 @@ describe("ProjectsOverview tabs", () => {
         activeTab.current = "all";
         projectRows.current = [];
         setActiveTab.mockReset();
+        retrySpy.mockReset();
         usePaginatedProjectsSpy.mockReset();
         vi.stubGlobal(
             "matchMedia",
@@ -178,5 +201,32 @@ describe("ProjectsOverview tabs", () => {
         expect(screen.getByText("3 users")).toBeInTheDocument();
         expect(screen.getByText("Elite Law LLP")).toBeInTheDocument();
         expect(screen.getByTitle("Shared with Elite Law LLP")).toBeVisible();
+    });
+
+    it("refetches when the new-project modal closes on a project it never handed over", async () => {
+        // A project created behind a failed grant or upload never reaches
+        // onCreated, so without this refetch the row the user just made is
+        // missing from the list they land back on until a reload.
+        const user = userEvent.setup();
+        render(<ProjectsOverview />);
+
+        await user.click(screen.getByRole("button", { name: "Create" }));
+        await user.click(
+            screen.getByRole("button", { name: "close after partial create" }),
+        );
+
+        expect(retrySpy).toHaveBeenCalledTimes(1);
+    });
+
+    it("does not refetch when the new-project modal is simply cancelled", async () => {
+        const user = userEvent.setup();
+        render(<ProjectsOverview />);
+
+        await user.click(screen.getByRole("button", { name: "Create" }));
+        await user.click(
+            screen.getByRole("button", { name: "close untouched" }),
+        );
+
+        expect(retrySpy).not.toHaveBeenCalled();
     });
 });

--- a/frontend/src/app/components/projects/ProjectsOverview.tsx
+++ b/frontend/src/app/components/projects/ProjectsOverview.tsx
@@ -931,7 +931,13 @@ export function ProjectsOverview() {
 
             <NewProjectModal
                 open={modalOpen}
-                onClose={() => setModalOpen(false)}
+                onClose={(createdWithoutHandover) => {
+                    setModalOpen(false);
+                    // A project created behind a failed grant or upload never
+                    // arrived through onCreated: refetch so it is on the list
+                    // the user lands back on, not only after a reload.
+                    if (createdWithoutHandover) retry();
+                }}
                 onCreated={(p) => {
                     setProjects((prev) => [p, ...prev]);
                     router.push(`/projects/${p.id}`);

--- a/frontend/src/app/components/shared/DocumentUploadMenu.test.tsx
+++ b/frontend/src/app/components/shared/DocumentUploadMenu.test.tsx
@@ -63,6 +63,23 @@ describe("DocumentUploadMenu", () => {
         expect(screen.getAllByRole("menuitem")).toHaveLength(2);
     });
 
+    it("offers no way in when every source is withheld", () => {
+        // A null action is "you may not do this here". Folder upload has to
+        // answer that the same way files and saved documents do; while it
+        // stayed live for a viewer the menu still opened, the native folder
+        // picker appeared, and the refusal arrived only once the upload
+        // session was under way.
+        render(
+            <DocumentUploadMenu
+                onSavedFiles={null}
+                onUploadFiles={null}
+                onUploadFolder={null}
+            />,
+        );
+
+        expect(screen.getByRole("button", { name: "Upload" })).toBeDisabled();
+    });
+
     it("disables upload while its collection is loading", () => {
         render(
             <DocumentUploadMenu

--- a/frontend/src/app/components/shared/RowActions.test.tsx
+++ b/frontend/src/app/components/shared/RowActions.test.tsx
@@ -1,59 +1,46 @@
-import { render, screen } from "@testing-library/react";
-import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
-import { RowActions } from "./RowActions";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { RowActionMenuItems } from "./RowActions";
 
-describe("RowActions", () => {
-    it("offers and runs the view action from the row button menu", async () => {
-        const user = userEvent.setup();
-        const onView = vi.fn();
-        render(<RowActions onView={onView} onDelete={vi.fn()} />);
-
-        await user.click(
-            screen.getByRole("button", { name: "Open row actions" }),
-        );
-        await user.click(screen.getByRole("button", { name: "View" }));
-
-        expect(onView).toHaveBeenCalledOnce();
-        expect(
-            screen.queryByRole("button", { name: "View" }),
-        ).not.toBeInTheDocument();
-    });
-
-    it("supports a concise edit label", async () => {
-        const user = userEvent.setup();
+// The folder context menu offered "New subfolder" to every reader, and the
+// handler behind it opened the name field with no gate of its own — so a
+// viewer typed a folder name before the server's refusal arrived. It is shown
+// disabled instead, the way Delete already was.
+describe("RowActionMenuItems New subfolder", () => {
+    it("is disabled and inert when the caller cannot organize folders", () => {
+        const onNewSubfolder = vi.fn();
         render(
-            <RowActions
-                onEditDetails={vi.fn()}
-                editDetailsLabel="Edit"
+            <RowActionMenuItems
+                onClose={vi.fn()}
+                onNewSubfolder={onNewSubfolder}
+                newSubfolderDisabled
             />,
         );
 
-        await user.click(
-            screen.getByRole("button", { name: "Open row actions" }),
-        );
+        const item = screen.getByRole("button", { name: "New subfolder" });
+        expect(item).toBeDisabled();
+        expect(item).toHaveAttribute("aria-disabled", "true");
 
-        expect(screen.getByRole("button", { name: "Edit" })).toBeVisible();
-        expect(
-            screen.queryByRole("button", { name: "Edit details" }),
-        ).not.toBeInTheDocument();
+        fireEvent.click(item);
+        expect(onNewSubfolder).not.toHaveBeenCalled();
     });
 
-    it("offers and runs a deselect-rows action", async () => {
-        const user = userEvent.setup();
-        const onDeselect = vi.fn();
-        render(<RowActions onDeselect={onDeselect} />);
-
-        await user.click(
-            screen.getByRole("button", { name: "Open row actions" }),
-        );
-        await user.click(
-            screen.getByRole("button", { name: "Deselect rows" }),
+    it("stays live for an editor", () => {
+        const onNewSubfolder = vi.fn();
+        const onClose = vi.fn();
+        render(
+            <RowActionMenuItems
+                onClose={onClose}
+                onNewSubfolder={onNewSubfolder}
+            />,
         );
 
-        expect(onDeselect).toHaveBeenCalledOnce();
-        expect(
-            screen.queryByRole("button", { name: "Deselect rows" }),
-        ).not.toBeInTheDocument();
+        const item = screen.getByRole("button", { name: "New subfolder" });
+        expect(item).toBeEnabled();
+        expect(item).not.toHaveAttribute("aria-disabled");
+
+        fireEvent.click(item);
+        expect(onNewSubfolder).toHaveBeenCalledTimes(1);
+        expect(onClose).toHaveBeenCalledTimes(1);
     });
 });

--- a/frontend/src/app/components/shared/RowActions.tsx
+++ b/frontend/src/app/components/shared/RowActions.tsx
@@ -47,6 +47,12 @@ interface Props {
     onShowAllVersions?: () => void;
     onUploadNewVersion?: () => void;
     onNewSubfolder?: () => void;
+    /**
+     * Offered but refused: the caller's role cannot organize folders here.
+     * Shown disabled rather than hidden, so the menu is the same shape for
+     * everybody and the reason is legible — the same treatment Delete has.
+     */
+    newSubfolderDisabled?: boolean;
     deleting?: boolean;
     deleteDisabled?: boolean;
     onEditDetails?: () => void;
@@ -82,6 +88,7 @@ export const RowActionMenuItems = forwardRef<
     onShowAllVersions,
     onUploadNewVersion,
     onNewSubfolder,
+    newSubfolderDisabled = false,
     deleting,
     deleteDisabled = false,
     onEditDetails,
@@ -125,8 +132,18 @@ export const RowActionMenuItems = forwardRef<
             )}
             {onNewSubfolder && (
                 <LiquidDropdownButton
-                    onClick={() => { onClose(); onNewSubfolder(); }}
-                    className={ROW_ACTION_LEFT_ITEM_CLASS}
+                    onClick={() => {
+                        if (newSubfolderDisabled) return;
+                        onClose();
+                        onNewSubfolder();
+                    }}
+                    disabled={newSubfolderDisabled}
+                    aria-disabled={newSubfolderDisabled || undefined}
+                    className={cn(
+                        ROW_ACTION_LEFT_ITEM_CLASS,
+                        newSubfolderDisabled &&
+                            "cursor-not-allowed opacity-40 hover:bg-transparent",
+                    )}
                 >
                     <SubfolderSvgIcon className="h-3.5 w-3.5 shrink-0" />
                     {newSubfolderLabel}

--- a/frontend/src/app/components/shared/SidebarChatItem.roles.test.tsx
+++ b/frontend/src/app/components/shared/SidebarChatItem.roles.test.tsx
@@ -186,6 +186,50 @@ describe("SidebarChatItem role gates", () => {
         ).toBeInTheDocument();
     });
 
+    it("marks a colleague's chat as shared", async () => {
+        // get_chats_overview now lists colleagues' organization-project chats
+        // in the same sidebar list as the caller's own, with nothing in the
+        // row telling them apart — so a rename or a delete could land on
+        // somebody else's thread by mistake.
+        render(
+            <SidebarChatItem
+                chat={chat({ is_owner: false, access_role: "editor" })}
+                isActive
+                onSelect={vi.fn()}
+            />,
+        );
+
+        expect(screen.getByText("Shared")).toBeInTheDocument();
+        // Plain text, not a pill badge (AGENTS.md: informational labels are
+        // text) — and outside the title button, so the row is still found by
+        // its exact title.
+        expect(
+            screen.getByRole("button", { name: "Quarterly filing" }),
+        ).toBeInTheDocument();
+    });
+
+    it("does not mark the caller's own chat", () => {
+        render(
+            <SidebarChatItem
+                chat={chat({ is_owner: true })}
+                isActive
+                onSelect={vi.fn()}
+            />,
+        );
+
+        expect(screen.queryByText("Shared")).not.toBeInTheDocument();
+    });
+
+    it("claims nothing about a row that carries no is_owner at all", () => {
+        // A row with no ownership field has told us nothing; "Shared" would
+        // be a claim we cannot make, the same reason roleFrom fails closed.
+        render(
+            <SidebarChatItem chat={chat({})} isActive onSelect={vi.fn()} />,
+        );
+
+        expect(screen.queryByText("Shared")).not.toBeInTheDocument();
+    });
+
     it("surfaces a failed delete instead of swallowing it", async () => {
         deleteChat.mockRejectedValue(new Error("boom"));
         render(

--- a/frontend/src/app/components/shared/SidebarChatItem.roles.test.tsx
+++ b/frontend/src/app/components/shared/SidebarChatItem.roles.test.tsx
@@ -199,13 +199,17 @@ describe("SidebarChatItem role gates", () => {
             />,
         );
 
-        expect(screen.getByText("Shared")).toBeInTheDocument();
         // Plain text, not a pill badge (AGENTS.md: informational labels are
-        // text) — and outside the title button, so the row is still found by
-        // its exact title.
+        // text), at a size and colour that meets the contrast baseline —
+        // text-[10px] text-gray-400 measured about 2.6:1.
+        const marker = screen.getByText("Shared");
+        expect(marker).toHaveClass("text-xs", "text-gray-500");
+        // The marker renders in a sibling element, so it reached neither the
+        // row's tooltip nor its accessible name: a screen-reader user heard
+        // exactly what the thread's owner hears.
         expect(
-            screen.getByRole("button", { name: "Quarterly filing" }),
-        ).toBeInTheDocument();
+            screen.getByRole("button", { name: "Quarterly filing (Shared)" }),
+        ).toHaveAttribute("title", "Quarterly filing (Shared)");
     });
 
     it("does not mark the caller's own chat", () => {

--- a/frontend/src/app/components/shared/SidebarChatItem.tsx
+++ b/frontend/src/app/components/shared/SidebarChatItem.tsx
@@ -147,6 +147,23 @@ export function SidebarChatItem({ chat, isActive, onSelect, projectName }: Props
                         {chat.title ?? "Untitled chat"}
                     </button>
 
+                    {/* Somebody else's thread. get_chats_overview now lists
+                        colleagues' organization-project chats alongside the
+                        caller's own, and nothing in the row said which was
+                        which — the same list, the same weight, so a rename
+                        or a delete could land on a colleague's work by
+                        mistake. Plain text, not a pill: this is an
+                        informational label (AGENTS.md).
+
+                        Strictly `=== false`: a row that carries no is_owner
+                        at all has told us nothing, and marking it "Shared"
+                        would be a claim we cannot make. */}
+                    {chat.is_owner === false && (
+                        <span className="mr-1 shrink-0 text-[10px] text-gray-400">
+                            Shared
+                        </span>
+                    )}
+
                     <DropdownMenu>
                         <DropdownMenuTrigger asChild>
                             <button
@@ -220,6 +237,12 @@ export function SidebarChatItem({ chat, isActive, onSelect, projectName }: Props
                     </DropdownMenu>
                 </>
             )}
+            {/* TODO(contacts): no `contacts` to pass. The sidebar rows come
+                from get_chats_overview and GET /chat/:id serves only
+                chat + is_owner + access_role, so no ranked admin list
+                reaches a chat surface and the popup's "Ask …" line can never
+                render here. Needs the server to return the shape project
+                detail already returns as `admin_contacts`. */}
             <PermissionDeniedPopup
                 open={!!gate}
                 action={gate?.action}

--- a/frontend/src/app/components/shared/SidebarChatItem.tsx
+++ b/frontend/src/app/components/shared/SidebarChatItem.tsx
@@ -55,6 +55,15 @@ export function SidebarChatItem({ chat, isActive, onSelect, projectName }: Props
     const canRename = can(role, "content.edit");
     const canShare = can(role, "access.manage");
     const canDelete = can(role, "container.delete");
+    // One label for the row's tooltip and its accessible name, so the
+    // "Shared" marker rendered beside the title is part of both.
+    const chatTitle = chat.title ?? "Untitled chat";
+    const rowLabel = [
+        projectName ? `${projectName}: ${chatTitle}` : chatTitle,
+        chat.is_owner === false ? "(Shared)" : null,
+    ]
+        .filter(Boolean)
+        .join(" ");
 
     useEffect(() => {
         if (isRenaming) editInputRef.current?.focus();
@@ -139,7 +148,13 @@ export function SidebarChatItem({ chat, isActive, onSelect, projectName }: Props
                                 ? "pr-3 text-gray-900"
                                 : "pr-0 text-gray-700 group-hover:pr-3",
                         )}
-                        title={projectName ? `${projectName}: ${chat.title ?? "Untitled chat"}` : (chat.title ?? "Untitled chat")}
+                        // The "Shared" marker sits in a SIBLING element, so
+                        // neither the tooltip nor the accessible name of this
+                        // row carried it: a screen-reader user heard exactly
+                        // what the owner of the thread hears. It belongs in
+                        // both.
+                        title={rowLabel}
+                        aria-label={rowLabel}
                     >
                         {projectName && (
                             <span className="text-gray-400 font-normal">{projectName}: </span>
@@ -159,7 +174,11 @@ export function SidebarChatItem({ chat, isActive, onSelect, projectName }: Props
                         at all has told us nothing, and marking it "Shared"
                         would be a claim we cannot make. */}
                     {chat.is_owner === false && (
-                        <span className="mr-1 shrink-0 text-[10px] text-gray-400">
+                        // `text-[10px] text-gray-400` measured about 2.6:1 —
+                        // below the 4.5:1 the accessibility baseline requires,
+                        // on the one word in the row that says whose work this
+                        // is. text-xs on the muted gray that does meet it.
+                        <span className="mr-1 shrink-0 text-xs text-gray-500">
                             Shared
                         </span>
                     )}

--- a/frontend/src/app/components/tabular/NewTRModal.test.tsx
+++ b/frontend/src/app/components/tabular/NewTRModal.test.tsx
@@ -175,6 +175,36 @@ describe("NewTRModal", () => {
         await waitFor(() => expect(onClose).toHaveBeenCalledTimes(1));
     });
 
+    it("stays open on a partial failure and lets Create retry it", async () => {
+        // onAdd resolving with a message means the review exists but part of
+        // the request did not happen. Closing here would hide the only account
+        // of it, and reporting the generic create failure would be a lie.
+        const onAdd = vi
+            .fn()
+            .mockResolvedValueOnce(
+                "Review created, but access was not granted to colleague@firm.test: That address is not in your organization.",
+            )
+            .mockResolvedValueOnce(undefined);
+        const onClose = vi.fn();
+        render(<NewTRModal open onClose={onClose} onAdd={onAdd} />);
+
+        fireEvent.change(screen.getByLabelText("Review name"), {
+            target: { value: "Shared review" },
+        });
+        fireEvent.click(screen.getByRole("button", { name: "Next" }));
+        fireEvent.click(screen.getByRole("button", { name: "Next" }));
+        fireEvent.click(screen.getByRole("button", { name: "Create" }));
+
+        expect(await screen.findByRole("alert")).toHaveTextContent(
+            "Review created, but access was not granted to colleague@firm.test: That address is not in your organization.",
+        );
+        expect(onClose).not.toHaveBeenCalled();
+
+        fireEvent.click(screen.getByRole("button", { name: "Create" }));
+        await waitFor(() => expect(onClose).toHaveBeenCalledTimes(1));
+        expect(onAdd).toHaveBeenCalledTimes(2);
+    });
+
     it("stores uploads from a project review in that project", async () => {
         const uploadedDocument = {
             id: "uploaded-document",

--- a/frontend/src/app/components/tabular/NewTRModal.test.tsx
+++ b/frontend/src/app/components/tabular/NewTRModal.test.tsx
@@ -205,6 +205,31 @@ describe("NewTRModal", () => {
         expect(onAdd).toHaveBeenCalledTimes(2);
     });
 
+    it("retires Back once the review exists", async () => {
+        // The retry reuses the created review, so the earlier steps no longer
+        // describe anything that can still change: a Personal → project switch
+        // between attempts left the review where it was first created while
+        // applying the new scope's assignments to it.
+        const onAdd = vi
+            .fn()
+            .mockResolvedValue(
+                "Review created, but access was not granted to colleague@firm.test: That address is not in your organization.",
+            );
+        render(<NewTRModal open onClose={vi.fn()} onAdd={onAdd} />);
+
+        fireEvent.change(screen.getByLabelText("Review name"), {
+            target: { value: "Shared review" },
+        });
+        fireEvent.click(screen.getByRole("button", { name: "Next" }));
+        fireEvent.click(screen.getByRole("button", { name: "Next" }));
+        expect(screen.getByRole("button", { name: "Back" })).toBeEnabled();
+
+        fireEvent.click(screen.getByRole("button", { name: "Create" }));
+        await screen.findByRole("alert");
+
+        expect(screen.getByRole("button", { name: "Back" })).toBeDisabled();
+    });
+
     it("stores uploads from a project review in that project", async () => {
         const uploadedDocument = {
             id: "uploaded-document",

--- a/frontend/src/app/components/tabular/NewTRModal.tsx
+++ b/frontend/src/app/components/tabular/NewTRModal.tsx
@@ -41,6 +41,12 @@ const TABULAR_DIRECTORY_TABS = ["files", "projects"] as const;
 interface Props {
     open: boolean;
     onClose: () => void;
+    /**
+     * Creates the review. Resolving with a string means the review itself was
+     * created but part of the request was not honoured — the dialog stays open
+     * and shows that message, and pressing Create again retries the remainder
+     * against the same review rather than making a second one.
+     */
     onAdd: (
         title: string,
         projectId: string | undefined,
@@ -49,7 +55,7 @@ interface Props {
         documentGrouping: "document" | "folder" | undefined,
         model: string,
         accessAssignments: { email: string; role: AccessAssignmentRole }[],
-    ) => Promise<void> | void;
+    ) => Promise<string | void> | void;
     projects?: Project[];
     /** When provided, skip the project/directory picker and show only these docs */
     projectDocs?: Document[];
@@ -170,6 +176,15 @@ export function NewTRModal({
 
     if (!open) return null;
 
+    // Dismissal — Escape, the backdrop and the close button all arrive here.
+    // A create in flight owns the dialog: leaving now would strand the only
+    // account of what happened to it. The success path calls `handleClose`
+    // directly, which is why the guard lives here and not there.
+    function handleDismiss() {
+        if (creatingRef.current) return;
+        handleClose();
+    }
+
     function handleClose() {
         setStep("details");
         setTitle("");
@@ -210,6 +225,7 @@ export function NewTRModal({
         if (creatingRef.current) return;
         creatingRef.current = true;
         setCreating(true);
+        setUploadError(null);
         const selectedWorkflow = workflows.find(
             (w) => w.id === selectedWorkflowId,
         );
@@ -220,7 +236,7 @@ export function NewTRModal({
               : undefined;
         const assignments = effectiveProjectId ? [] : directGrants;
         try {
-            await onAdd(
+            const partialFailure = await onAdd(
                 title.trim(),
                 effectiveProjectId,
                 selectedDocuments.length > 0
@@ -231,6 +247,13 @@ export function NewTRModal({
                 selectedModel,
                 assignments,
             );
+            if (partialFailure) {
+                // The review exists. Report what did not happen and stay open;
+                // closing here would hide the only account of it, and the
+                // generic create failure would be a lie.
+                setUploadError(partialFailure);
+                return;
+            }
             handleClose();
         } catch (error) {
             setUploadError(
@@ -370,7 +393,7 @@ export function NewTRModal({
     return (
         <Modal
             open={open}
-            onClose={handleClose}
+            onClose={handleDismiss}
             breadcrumbs={[
                 ...breadcrumbs,
                 step === "details"

--- a/frontend/src/app/components/tabular/NewTRModal.tsx
+++ b/frontend/src/app/components/tabular/NewTRModal.tsx
@@ -104,6 +104,13 @@ export function NewTRModal({
     const [groupBySubfolder, setGroupBySubfolder] = useState(false);
     const [uploading, setUploading] = useState(false);
     const [creating, setCreating] = useState(false);
+    // The review already exists, because a first attempt created it and then
+    // failed on the grants. The page holds that row and the retry reuses it,
+    // so the earlier steps no longer describe anything this dialog can still
+    // change: switching Personal → a project on the second attempt left the
+    // review where it was created and applied the new scope's assignments to
+    // it. Back retires once this is true.
+    const [reviewExists, setReviewExists] = useState(false);
     const [uploadError, setUploadError] = useState<string | null>(null);
     const fileInputRef = useRef<HTMLInputElement>(null);
     const creatingRef = useRef(false);
@@ -187,6 +194,7 @@ export function NewTRModal({
 
     function handleClose() {
         setStep("details");
+        setReviewExists(false);
         setTitle("");
         setUnderProject(false);
         setSelectedProjectId("");
@@ -252,6 +260,7 @@ export function NewTRModal({
                 // closing here would hide the only account of it, and the
                 // generic create failure would be a lie.
                 setUploadError(partialFailure);
+                setReviewExists(true);
                 return;
             }
             handleClose();
@@ -428,7 +437,10 @@ export function NewTRModal({
                     ? {
                           label: "Back",
                           onClick: () => setStep("access"),
-                          disabled: uploading,
+                          disabled: uploading || reviewExists,
+                          title: reviewExists
+                              ? "The review has been created — its details and access can be changed from the review itself."
+                              : undefined,
                       }
                     : step === "access"
                       ? {

--- a/frontend/src/app/components/tabular/TRChatPanel.tsx
+++ b/frontend/src/app/components/tabular/TRChatPanel.tsx
@@ -123,8 +123,15 @@ interface Props {
     onClose: () => void;
     initialChatId?: string | null;
     onChatIdChange?: (chatId: string | null) => void;
-    /** Sending is member-tier server-side; false renders a read-only composer. */
-    canSend?: boolean;
+    /**
+     * Sending is member-tier server-side; false renders a read-only composer.
+     *
+     * `null` is the third answer — the review's role has not arrived yet. It
+     * closes the composer like `false`, but ChatInput's placeholder stays
+     * neutral instead of telling an owner they are "viewing only" for the
+     * length of a fetch.
+     */
+    canSend?: boolean | null;
 }
 
 // ---------------------------------------------------------------------------

--- a/frontend/src/app/components/tabular/TabularReviewView.access.test.tsx
+++ b/frontend/src/app/components/tabular/TabularReviewView.access.test.tsx
@@ -1,0 +1,221 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import {
+    getTabularReview,
+    getTabularReviewAccess,
+    grantTabularReviewAccess,
+    revokeTabularReviewAccess,
+    type ContentAccessGrant,
+} from "@/app/lib/mikeApi";
+import type { TabularReview } from "@/app/components/shared/types";
+import { TRView } from "./TabularReviewView";
+
+// What this file pins: an access change the server accepted is never reported
+// as a failure. Reloading the roster afterwards is bookkeeping, and its failure
+// used to travel back out of the handler into AccessModal's catch — so a role
+// that was granted came back as "Could not change that role."
+vi.mock("next/navigation", () => ({
+    useRouter: () => ({ push: vi.fn(), replace: vi.fn() }),
+    useSearchParams: () => new URLSearchParams(),
+}));
+vi.mock("@/app/lib/mikeApi", () => ({
+    MikeApiError: class MikeApiError extends Error {},
+    clearTabularCells: vi.fn(),
+    deleteTabularReview: vi.fn(),
+    getTabularReview: vi.fn(),
+    getTabularReviewAccess: vi.fn(),
+    getProject: vi.fn(),
+    getTabularReviewPeople: vi.fn(async () => ({ owner: null, members: [] })),
+    getOllamaModels: vi.fn(async () => []),
+    grantTabularReviewAccess: vi.fn(),
+    listProjects: vi.fn(async () => []),
+    regenerateTabularCell: vi.fn(),
+    revokeTabularReviewAccess: vi.fn(),
+    streamTabularGeneration: vi.fn(),
+    streamTabularGenerationResume: vi.fn(),
+    updateTabularReview: vi.fn(),
+    uploadReviewDocument: vi.fn(),
+}));
+vi.mock("@/app/contexts/AuthContext", () => ({
+    useAuth: () => ({ user: { id: "me", email: "me@firm.test" } }),
+}));
+vi.mock("@/app/contexts/UserProfileContext", () => ({
+    useUserProfile: () => ({ profile: { apiKeys: {} }, apiKeysDegraded: false }),
+}));
+vi.mock("@/app/contexts/SidebarContext", () => ({
+    useSidebar: () => ({ setSidebarOpen: vi.fn() }),
+}));
+vi.mock("../assistant/ModelToggle", () => ({ ModelToggle: () => null }));
+vi.mock("./TRTable", () => ({ TRTable: () => <div /> }));
+vi.mock("./TRSidePanel", () => ({ TRSidePanel: () => null }));
+vi.mock("./TRChatPanel", () => ({ TRChatPanel: () => null }));
+vi.mock("./AddColumnModal", () => ({ AddColumnModal: () => null }));
+vi.mock("./TRWorkflowModal", () => ({ TRWorkflowModal: () => null }));
+vi.mock("./TabularReviewDetailsModal", () => ({
+    TabularReviewDetailsModal: () => null,
+}));
+vi.mock("../modals/AddDocumentsModal", () => ({
+    AddDocumentsModal: () => null,
+}));
+vi.mock("../popups/ApiKeyMissingPopup", () => ({
+    ApiKeyMissingPopup: () => null,
+}));
+
+// A stand-in for AccessModal keeping the one behaviour under test: the real
+// modal awaits the handler it is given and turns any rejection into a message
+// (AccessModal.tsx `changeRole`/`remove`). It renders whether or not the modal
+// is open so the handlers can be driven without walking the header menu.
+vi.mock("../modals/AccessModal", async () => {
+    const { useState } = await import("react");
+    const { userFacingApiError } = await import("@/app/lib/userFacingError");
+    return {
+        AccessModal: ({
+            access,
+        }: {
+            access: {
+                onGrant: (email: string, role: string) => Promise<void>;
+                onRevoke: (email: string) => Promise<void>;
+            };
+        }) => {
+            const [error, setError] = useState<string | null>(null);
+            return (
+                <div>
+                    <button
+                        type="button"
+                        onClick={async () => {
+                            try {
+                                await access.onGrant(
+                                    "colleague@firm.test",
+                                    "editor",
+                                );
+                            } catch (cause) {
+                                setError(
+                                    userFacingApiError(
+                                        cause,
+                                        "Could not change that role.",
+                                    ),
+                                );
+                            }
+                        }}
+                    >
+                        grant editor
+                    </button>
+                    <button
+                        type="button"
+                        onClick={async () => {
+                            try {
+                                await access.onRevoke("colleague@firm.test");
+                            } catch (cause) {
+                                setError(
+                                    userFacingApiError(
+                                        cause,
+                                        "Could not remove access.",
+                                    ),
+                                );
+                            }
+                        }}
+                    >
+                        remove access
+                    </button>
+                    {error && <p role="alert">{error}</p>}
+                </div>
+            );
+        },
+    };
+});
+
+function review(over: Partial<TabularReview>): TabularReview {
+    return {
+        id: "r1",
+        project_id: null,
+        user_id: "me",
+        title: "Diligence",
+        columns_config: [],
+        document_ids: [],
+        created_at: "2026-01-01T00:00:00Z",
+        updated_at: "2026-01-01T00:00:00Z",
+        ...over,
+    } as TabularReview;
+}
+
+describe("TabularReviewView access mutations", () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        vi.mocked(getTabularReview).mockResolvedValue({
+            review: review({ access_role: "owner" }),
+            cells: [],
+            rows: [],
+            documents: [],
+        });
+        window.matchMedia = vi.fn().mockImplementation((query: string) => ({
+            matches: true,
+            media: query,
+            onchange: null,
+            addListener: vi.fn(),
+            removeListener: vi.fn(),
+            addEventListener: vi.fn(),
+            removeEventListener: vi.fn(),
+            dispatchEvent: vi.fn(),
+        }));
+    });
+
+    it("does not report a granted role when only the roster reload fails", async () => {
+        vi.mocked(grantTabularReviewAccess).mockResolvedValue(
+            {} as ContentAccessGrant,
+        );
+        vi.mocked(getTabularReviewAccess).mockRejectedValue(
+            new Error("roster unavailable"),
+        );
+
+        render(<TRView reviewId="r1" />);
+        fireEvent.click(await screen.findByText("grant editor"));
+
+        await waitFor(() =>
+            expect(grantTabularReviewAccess).toHaveBeenCalledWith(
+                "r1",
+                "colleague@firm.test",
+                "editor",
+            ),
+        );
+        expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+    });
+
+    it("does not report a revoke when only the roster reload fails", async () => {
+        vi.mocked(revokeTabularReviewAccess).mockResolvedValue(undefined);
+        vi.mocked(getTabularReviewAccess).mockRejectedValue(
+            new Error("roster unavailable"),
+        );
+
+        render(<TRView reviewId="r1" />);
+        fireEvent.click(await screen.findByText("remove access"));
+
+        await waitFor(() =>
+            expect(revokeTabularReviewAccess).toHaveBeenCalledWith(
+                "r1",
+                "colleague@firm.test",
+            ),
+        );
+        expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+    });
+
+    it("still reports a grant the server refused", async () => {
+        // The other half of the same rule: swallowing the reload must not
+        // swallow the mutation.
+        vi.mocked(grantTabularReviewAccess).mockRejectedValue(
+            new Error("refused"),
+        );
+        vi.mocked(getTabularReviewAccess).mockResolvedValue({
+            grants: [],
+            scope: "direct",
+            org_id: null,
+            access_role: "owner",
+        });
+
+        render(<TRView reviewId="r1" />);
+        fireEvent.click(await screen.findByText("grant editor"));
+
+        expect(await screen.findByRole("alert")).toHaveTextContent(
+            "Could not change that role.",
+        );
+    });
+});

--- a/frontend/src/app/components/tabular/TabularReviewView.chatGate.test.tsx
+++ b/frontend/src/app/components/tabular/TabularReviewView.chatGate.test.tsx
@@ -1,0 +1,139 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import { getTabularReview } from "@/app/lib/mikeApi";
+import type { TabularReview } from "@/app/components/shared/types";
+import { TRView } from "./TabularReviewView";
+
+// What this file pins: the review chat composer has THREE states, not two.
+// `canSend={false}` is a sentence — ChatInput renders "Viewing only — sending
+// needs edit access" — and the review's role is unknown for the whole of GET
+// /tabular-review/:id, so an owner opening their own review from a chat link
+// was told they were a viewer until it landed.
+vi.mock("next/navigation", () => ({
+    useRouter: () => ({ push: vi.fn(), replace: vi.fn() }),
+    useSearchParams: () => new URLSearchParams("chat=new"),
+}));
+vi.mock("@/app/lib/mikeApi", () => ({
+    MikeApiError: class MikeApiError extends Error {},
+    clearTabularCells: vi.fn(),
+    deleteTabularReview: vi.fn(),
+    getTabularReview: vi.fn(),
+    getTabularReviewAccess: vi.fn(async () => ({
+        grants: [],
+        scope: "direct",
+        org_id: null,
+        access_role: "viewer",
+    })),
+    getProject: vi.fn(),
+    getTabularReviewPeople: vi.fn(async () => ({ owner: null, members: [] })),
+    getOllamaModels: vi.fn(async () => []),
+    grantTabularReviewAccess: vi.fn(),
+    listProjects: vi.fn(async () => []),
+    regenerateTabularCell: vi.fn(),
+    revokeTabularReviewAccess: vi.fn(),
+    streamTabularGeneration: vi.fn(),
+    streamTabularGenerationResume: vi.fn(),
+    updateTabularReview: vi.fn(),
+    uploadReviewDocument: vi.fn(),
+}));
+vi.mock("@/app/contexts/AuthContext", () => ({
+    useAuth: () => ({ user: { id: "me", email: "me@firm.test" } }),
+}));
+vi.mock("@/app/contexts/UserProfileContext", () => ({
+    useUserProfile: () => ({ profile: { apiKeys: {} }, apiKeysDegraded: false }),
+}));
+vi.mock("@/app/contexts/SidebarContext", () => ({
+    useSidebar: () => ({ setSidebarOpen: vi.fn() }),
+}));
+vi.mock("../assistant/ModelToggle", () => ({ ModelToggle: () => null }));
+vi.mock("./TRTable", () => ({ TRTable: () => <div /> }));
+vi.mock("./TRSidePanel", () => ({ TRSidePanel: () => null }));
+vi.mock("./TRChatPanel", () => ({
+    TRChatPanel: ({ canSend }: { canSend?: boolean | null }) => (
+        <div data-testid="tr-can-send">{String(canSend)}</div>
+    ),
+}));
+vi.mock("./AddColumnModal", () => ({ AddColumnModal: () => null }));
+vi.mock("./TRWorkflowModal", () => ({ TRWorkflowModal: () => null }));
+vi.mock("./TabularReviewDetailsModal", () => ({
+    TabularReviewDetailsModal: () => null,
+}));
+vi.mock("../modals/AddDocumentsModal", () => ({
+    AddDocumentsModal: () => null,
+}));
+vi.mock("../popups/ApiKeyMissingPopup", () => ({
+    ApiKeyMissingPopup: () => null,
+}));
+vi.mock("../modals/AccessModal", () => ({ AccessModal: () => null }));
+
+function review(over: Partial<TabularReview>): TabularReview {
+    return {
+        id: "r1",
+        project_id: null,
+        user_id: "owner",
+        title: "Diligence",
+        columns_config: [],
+        document_ids: [],
+        created_at: "2026-01-01T00:00:00Z",
+        updated_at: "2026-01-01T00:00:00Z",
+        ...over,
+    } as TabularReview;
+}
+
+beforeEach(() => {
+    vi.clearAllMocks();
+    window.matchMedia = vi.fn().mockImplementation((query: string) => ({
+        matches: true,
+        media: query,
+        onchange: null,
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+    }));
+});
+
+describe("TabularReviewView review-chat composer", () => {
+    it("says nothing about sending until the review's role arrives", async () => {
+        vi.mocked(getTabularReview).mockReturnValue(new Promise(() => {}));
+
+        render(<TRView reviewId="r1" />);
+
+        expect(await screen.findByTestId("tr-can-send")).toHaveTextContent(
+            "null",
+        );
+    });
+
+    it("hands a viewer a read-only composer once the role is known", async () => {
+        vi.mocked(getTabularReview).mockResolvedValue({
+            review: review({ access_role: "viewer" }),
+            cells: [],
+            rows: [],
+            documents: [],
+        });
+
+        render(<TRView reviewId="r1" />);
+
+        await waitFor(() =>
+            expect(screen.getByTestId("tr-can-send")).toHaveTextContent(
+                "false",
+            ),
+        );
+    });
+
+    it("opens the composer for an editor", async () => {
+        vi.mocked(getTabularReview).mockResolvedValue({
+            review: review({ access_role: "editor" }),
+            cells: [],
+            rows: [],
+            documents: [],
+        });
+
+        render(<TRView reviewId="r1" />);
+
+        await waitFor(() =>
+            expect(screen.getByTestId("tr-can-send")).toHaveTextContent("true"),
+        );
+    });
+});

--- a/frontend/src/app/components/tabular/TabularReviewView.columns.test.tsx
+++ b/frontend/src/app/components/tabular/TabularReviewView.columns.test.tsx
@@ -1,0 +1,127 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { getTabularReview } from "@/app/lib/mikeApi";
+import type { TabularReview } from "@/app/components/shared/types";
+import { TRView } from "./TabularReviewView";
+
+// What this file pins: the Add Columns button refuses a viewer BEFORE the
+// modal opens. The refusal used to fire on submit only, so a viewer named a
+// column, wrote its prompt and chose its format before being told that adding
+// columns is for editors.
+vi.mock("next/navigation", () => ({
+    useRouter: () => ({ push: vi.fn(), replace: vi.fn() }),
+    useSearchParams: () => new URLSearchParams(),
+}));
+vi.mock("@/app/lib/mikeApi", () => ({
+    MikeApiError: class MikeApiError extends Error {},
+    clearTabularCells: vi.fn(),
+    deleteTabularReview: vi.fn(),
+    getTabularReview: vi.fn(),
+    getTabularReviewAccess: vi.fn(async () => ({
+        grants: [],
+        scope: "direct",
+        org_id: null,
+        access_role: "viewer",
+    })),
+    getProject: vi.fn(),
+    getTabularReviewPeople: vi.fn(async () => ({ owner: null, members: [] })),
+    getOllamaModels: vi.fn(async () => []),
+    grantTabularReviewAccess: vi.fn(),
+    listProjects: vi.fn(async () => []),
+    regenerateTabularCell: vi.fn(),
+    revokeTabularReviewAccess: vi.fn(),
+    streamTabularGeneration: vi.fn(),
+    streamTabularGenerationResume: vi.fn(),
+    updateTabularReview: vi.fn(),
+    uploadReviewDocument: vi.fn(),
+}));
+vi.mock("@/app/contexts/AuthContext", () => ({
+    useAuth: () => ({ user: { id: "me", email: "me@firm.test" } }),
+}));
+vi.mock("@/app/contexts/UserProfileContext", () => ({
+    useUserProfile: () => ({ profile: { apiKeys: {} }, apiKeysDegraded: false }),
+}));
+vi.mock("@/app/contexts/SidebarContext", () => ({
+    useSidebar: () => ({ setSidebarOpen: vi.fn() }),
+}));
+vi.mock("../assistant/ModelToggle", () => ({ ModelToggle: () => null }));
+vi.mock("./TRTable", () => ({ TRTable: () => <div /> }));
+vi.mock("./TRSidePanel", () => ({ TRSidePanel: () => null }));
+vi.mock("./TRChatPanel", () => ({ TRChatPanel: () => null }));
+vi.mock("./TRWorkflowModal", () => ({ TRWorkflowModal: () => null }));
+vi.mock("./TabularReviewDetailsModal", () => ({
+    TabularReviewDetailsModal: () => null,
+}));
+vi.mock("../modals/AddDocumentsModal", () => ({
+    AddDocumentsModal: () => null,
+}));
+vi.mock("../popups/ApiKeyMissingPopup", () => ({
+    ApiKeyMissingPopup: () => null,
+}));
+// The real modal is a large form; all this test needs is whether it opened.
+vi.mock("./AddColumnModal", () => ({
+    AddColumnModal: ({ open }: { open: boolean }) =>
+        open ? <div data-testid="add-column-modal" /> : null,
+}));
+vi.mock("../modals/AccessModal", () => ({ AccessModal: () => null }));
+
+function review(over: Partial<TabularReview>): TabularReview {
+    return {
+        id: "r1",
+        project_id: null,
+        user_id: "owner",
+        title: "Diligence",
+        columns_config: [],
+        document_ids: [],
+        created_at: "2026-01-01T00:00:00Z",
+        updated_at: "2026-01-01T00:00:00Z",
+        ...over,
+    } as TabularReview;
+}
+
+function renderAs(role: "viewer" | "editor") {
+    vi.mocked(getTabularReview).mockResolvedValue({
+        review: review({ access_role: role }),
+        cells: [],
+        rows: [],
+        documents: [],
+    });
+    return render(<TRView reviewId="r1" />);
+}
+
+beforeEach(() => {
+    vi.clearAllMocks();
+    window.matchMedia = vi.fn().mockImplementation((query: string) => ({
+        matches: true,
+        media: query,
+        onchange: null,
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+    }));
+});
+
+describe("TabularReviewView Add Columns gating", () => {
+    it("refuses a viewer at the button instead of at the submit", async () => {
+        renderAs("viewer");
+
+        fireEvent.click(await screen.findByText("Add Columns"));
+
+        expect(await screen.findByText("Editors only")).toBeInTheDocument();
+        expect(
+            screen.getByText("Only an editor can add columns."),
+        ).toBeInTheDocument();
+        expect(screen.queryByTestId("add-column-modal")).not.toBeInTheDocument();
+    });
+
+    it("opens the modal for an editor", async () => {
+        renderAs("editor");
+
+        fireEvent.click(await screen.findByText("Add Columns"));
+
+        expect(screen.getByTestId("add-column-modal")).toBeInTheDocument();
+        expect(screen.queryByText("Editors only")).not.toBeInTheDocument();
+    });
+});

--- a/frontend/src/app/components/tabular/TabularReviewView.tsx
+++ b/frontend/src/app/components/tabular/TabularReviewView.tsx
@@ -1795,6 +1795,9 @@ export function TRView({ reviewId, projectId }: Props) {
                 resource={review}
                 fetchAccess={getTabularReviewPeople}
                 currentUserEmail={user?.email ?? null}
+                // Both identifiers, so a roster row without an email still
+                // cannot offer the caller a Remove that locks them out.
+                currentUserId={user?.id ?? null}
                 breadcrumb={[
                     "Tabular Reviews",
                     review?.title || "Untitled Review",
@@ -1806,13 +1809,17 @@ export function TRView({ reviewId, projectId }: Props) {
                     ownerLabel: "Review owners",
                     inheritedFromProjectId: review?.project_id ?? null,
                     canManage: can(reviewRole, "access.manage"),
+                    // The mutation is what AccessModal reports on. Reloading
+                    // the roster afterwards is bookkeeping, so its failure
+                    // must not travel back up as "Could not change that role"
+                    // for a grant the server already accepted.
                     onGrant: async (email, role) => {
                         await grantTabularReviewAccess(reviewId, email, role);
-                        await refreshGrants();
+                        await refreshGrants().catch(() => {});
                     },
                     onRevoke: async (email) => {
                         await revokeTabularReviewAccess(reviewId, email);
-                        await refreshGrants();
+                        await refreshGrants().catch(() => {});
                     },
                 }}
             />

--- a/frontend/src/app/components/tabular/TabularReviewView.tsx
+++ b/frontend/src/app/components/tabular/TabularReviewView.tsx
@@ -334,6 +334,18 @@ export function TRView({ reviewId, projectId }: Props) {
 
     const requireStructure = requireContent;
 
+    /**
+     * Adding columns is `content.edit` server-side, so the refusal belongs at
+     * the button, not at the submit: a viewer used to open the modal, name a
+     * column, write a prompt and pick a format before "Editors only" arrived.
+     * `handleAddColumn` keeps its own gate as the backstop for any other way
+     * in.
+     */
+    function openAddColumns() {
+        if (!requireStructure("add columns")) return;
+        setAddColOpen(true);
+    }
+
     // Who to ask when an action is refused. A review inside a project inherits
     // that project's admin contacts; a standalone review's contact is its
     // creator, which only the people roster knows — so it is fetched the first
@@ -1542,7 +1554,7 @@ export function TRView({ reviewId, projectId }: Props) {
                                     )}
                                     {!loading && (
                                         <TabPillButton
-                                            onClick={() => setAddColOpen(true)}
+                                            onClick={openAddColumns}
                                             disabled={
                                                 savingColumn ||
                                                 savingColumnsConfig
@@ -1627,7 +1639,7 @@ export function TRView({ reviewId, projectId }: Props) {
                                 }}
                                 onUpdateColumn={handleUpdateColumn}
                                 onDeleteColumn={handleDeleteColumn}
-                                onAddColumn={() => setAddColOpen(true)}
+                                onAddColumn={openAddColumns}
                                 onAddDocuments={() => {
                                     if (
                                         !requireStructure(

--- a/frontend/src/app/components/tabular/TabularReviewView.tsx
+++ b/frontend/src/app/components/tabular/TabularReviewView.tsx
@@ -1664,7 +1664,7 @@ export function TRView({ reviewId, projectId }: Props) {
                             }}
                             initialChatId={selectedChatId}
                             onChatIdChange={setSelectedChatId}
-                            canSend={canEditContent}
+                            canSend={roleKnown ? canEditContent : null}
                         />
                     )}
                 </div>

--- a/frontend/src/app/components/workflows/NewWorkflowModal.test.tsx
+++ b/frontend/src/app/components/workflows/NewWorkflowModal.test.tsx
@@ -6,6 +6,8 @@ import {
     createWorkflow,
     listOrgMembers,
     listOrgs,
+    lookupUserByEmail,
+    MikeApiError,
     shareWorkflow,
     updateWorkflow,
 } from "@/app/lib/mikeApi";
@@ -22,6 +24,7 @@ vi.mock("@/app/lib/mikeApi", async (importOriginal) => ({
     createWorkflow: vi.fn(),
     listOrgMembers: vi.fn(),
     listOrgs: vi.fn(),
+    lookupUserByEmail: vi.fn(),
     shareWorkflow: vi.fn(),
     updateWorkflow: vi.fn(),
 }));
@@ -75,6 +78,11 @@ describe("NewWorkflowModal editing", () => {
         vi.mocked(createWorkflow).mockResolvedValue(workflow);
         vi.mocked(copyDocumentsToWorkflowAssets).mockResolvedValue([]);
         vi.mocked(shareWorkflow).mockResolvedValue(undefined);
+        vi.mocked(lookupUserByEmail).mockResolvedValue({
+            exists: true,
+            email: "counsel@firm.test",
+            display_name: "Counsel",
+        });
         vi.mocked(updateWorkflow).mockResolvedValue(workflow);
         useUserProfile.mockReturnValue({ profile: { practiceAreas: [] } });
     });
@@ -325,5 +333,128 @@ describe("NewWorkflowModal editing", () => {
                 "Deny Elite Law LLP members from accessing this workflow.",
             ),
         ).not.toHaveClass("pl-3");
+    });
+
+    async function reachCreateWithOneRecipient(
+        user: ReturnType<typeof userEvent.setup>,
+    ) {
+        await user.click(screen.getByRole("button", { name: "Tabular" }));
+        await user.type(screen.getByLabelText("Title"), "Tabular workflow");
+        await user.click(screen.getByRole("button", { name: "Next" }));
+
+        await user.click(screen.getByPlaceholderText("Add by email..."));
+        // paste, not per-key typing: one input event cannot be cut off
+        // mid-word by a slow re-render on a loaded machine.
+        await user.paste("counsel@firm.test");
+        await user.click(screen.getByRole("button", { name: "Add" }));
+    }
+
+    it("reports a refused grant against the workflow that was created", async () => {
+        const user = userEvent.setup({ delay: null });
+        const onCreated = vi.fn();
+        const onClose = vi.fn();
+        vi.mocked(shareWorkflow).mockRejectedValueOnce(
+            new MikeApiError({
+                message: "Only owners can share this workflow.",
+                status: 403,
+            }),
+        );
+        render(
+            <NewWorkflowModal
+                open
+                onClose={onClose}
+                onCreated={onCreated}
+            />,
+        );
+
+        await reachCreateWithOneRecipient(user);
+        await user.click(
+            screen.getByRole("button", { name: "Create workflow" }),
+        );
+
+        expect(
+            await screen.findByText(
+                "Workflow created, but access was not granted to counsel@firm.test: Only owners can share this workflow.",
+            ),
+        ).toBeVisible();
+        expect(createWorkflow).toHaveBeenCalledTimes(1);
+        expect(onCreated).not.toHaveBeenCalled();
+        expect(onClose).not.toHaveBeenCalled();
+
+        // Pressing Create again must retry only the grant, against the
+        // workflow that already exists.
+        await user.click(
+            screen.getByRole("button", { name: "Create workflow" }),
+        );
+        await waitFor(() => expect(onCreated).toHaveBeenCalledTimes(1));
+        expect(createWorkflow).toHaveBeenCalledTimes(1);
+        expect(shareWorkflow).toHaveBeenCalledTimes(2);
+    });
+
+    it("tells the caller to refetch when a created workflow is dismissed unshared", async () => {
+        const user = userEvent.setup({ delay: null });
+        const onClose = vi.fn();
+        vi.mocked(shareWorkflow).mockRejectedValue(
+            new MikeApiError({
+                message: "Only owners can share this workflow.",
+                status: 403,
+            }),
+        );
+        render(
+            <NewWorkflowModal open onClose={onClose} onCreated={vi.fn()} />,
+        );
+
+        await reachCreateWithOneRecipient(user);
+        await user.click(
+            screen.getByRole("button", { name: "Create workflow" }),
+        );
+        await screen.findByText(/Workflow created, but access was not granted/);
+
+        await user.click(screen.getByRole("button", { name: "Close" }));
+        expect(onClose).toHaveBeenCalledWith(true);
+    });
+
+    it("does not ask for a refetch when nothing was created", async () => {
+        const user = userEvent.setup({ delay: null });
+        const onClose = vi.fn();
+        render(
+            <NewWorkflowModal open onClose={onClose} onCreated={vi.fn()} />,
+        );
+
+        await user.click(screen.getByRole("button", { name: "Close" }));
+        expect(onClose).toHaveBeenCalledWith(false);
+    });
+
+    it("refuses to dismiss while a create is in flight", async () => {
+        const user = userEvent.setup({ delay: null });
+        const onClose = vi.fn();
+        vi.mocked(createWorkflow).mockReturnValue(new Promise(() => {}));
+        render(
+            <NewWorkflowModal open onClose={onClose} onCreated={vi.fn()} />,
+        );
+
+        await reachCreateWithOneRecipient(user);
+        await user.click(
+            screen.getByRole("button", { name: "Create workflow" }),
+        );
+        await screen.findByRole("button", { name: "Creating…" });
+
+        await user.keyboard("{Escape}");
+        await user.click(screen.getByRole("button", { name: "Close" }));
+        expect(onClose).not.toHaveBeenCalled();
+    });
+
+    it("surfaces a failure to load the organization list", async () => {
+        vi.mocked(listOrgs).mockRejectedValue(
+            new MikeApiError({
+                message: "Organizations are unavailable.",
+                status: 403,
+            }),
+        );
+        render(<NewWorkflowModal open onClose={vi.fn()} onCreated={vi.fn()} />);
+
+        expect(
+            await screen.findByText("Organizations are unavailable."),
+        ).toBeVisible();
     });
 });

--- a/frontend/src/app/components/workflows/NewWorkflowModal.test.tsx
+++ b/frontend/src/app/components/workflows/NewWorkflowModal.test.tsx
@@ -245,6 +245,82 @@ describe("NewWorkflowModal editing", () => {
         ).toBeLessThan(onCreated.mock.invocationCallOrder[0]);
     });
 
+    it("reports a failed asset copy against the workflow that exists", async () => {
+        // The copy ran before the grants and outside any try of its own, so a
+        // failure came back as "Failed to create workflow" — about a workflow
+        // the server had already made — and the retry re-copied everything
+        // that had worked.
+        const user = userEvent.setup({ delay: null });
+        const onCreated = vi.fn();
+        vi.mocked(copyDocumentsToWorkflowAssets).mockRejectedValueOnce(
+            new Error("copy failed"),
+        );
+        render(
+            <NewWorkflowModal open onClose={vi.fn()} onCreated={onCreated} />,
+        );
+
+        await user.type(screen.getByLabelText("Title"), "New workflow");
+        await user.click(screen.getByRole("button", { name: "Next" }));
+        await user.click(screen.getByRole("button", { name: "Next" }));
+        await user.click(screen.getByRole("button", { name: "Select asset" }));
+        await user.click(
+            screen.getByRole("button", { name: "Create workflow" }),
+        );
+
+        expect(
+            await screen.findByText(
+                "Workflow created, but 1 asset could not be copied. Press Create again to retry the copy.",
+            ),
+        ).toBeInTheDocument();
+        expect(
+            screen.queryByText("Failed to create workflow"),
+        ).not.toBeInTheDocument();
+        // Held open on the only screen that knows: the row never reached the
+        // caller's list.
+        expect(onCreated).not.toHaveBeenCalled();
+
+        // The retry reuses the workflow and re-sends only the missing asset.
+        await user.click(
+            screen.getByRole("button", { name: "Create workflow" }),
+        );
+        await waitFor(() => expect(onCreated).toHaveBeenCalled());
+        expect(createWorkflow).toHaveBeenCalledTimes(1);
+        expect(copyDocumentsToWorkflowAssets).toHaveBeenCalledTimes(2);
+    });
+
+    it("copies assets only after the grants have been written", async () => {
+        // Grants first: a refused grant stops the submit, and an asset copied
+        // before it would have to be redone on the retry.
+        const user = userEvent.setup({ delay: null });
+        vi.mocked(shareWorkflow).mockRejectedValue(new Error("nope"));
+        render(<NewWorkflowModal open onClose={vi.fn()} onCreated={vi.fn()} />);
+
+        await user.type(screen.getByLabelText("Title"), "New workflow");
+        await user.click(screen.getByRole("button", { name: "Next" }));
+        await user.click(screen.getByPlaceholderText("Add by email..."));
+        // paste, not per-key typing: one input event cannot be cut off
+        // mid-word by a slow re-render on a loaded machine.
+        await user.paste("counsel@firm.test");
+        await user.click(screen.getByRole("button", { name: "Add" }));
+        await user.click(screen.getByRole("button", { name: "Next" }));
+        await user.click(screen.getByRole("button", { name: "Select asset" }));
+        await user.click(
+            screen.getByRole("button", { name: "Create workflow" }),
+        );
+
+        expect(
+            await screen.findByText(
+                /Workflow created, but access was not granted to counsel@firm\.test/,
+            ),
+        ).toBeInTheDocument();
+        expect(copyDocumentsToWorkflowAssets).not.toHaveBeenCalled();
+        expect(
+            screen.getByText(
+                /The 1 selected file is still pending and will be copied when you try again\./,
+            ),
+        ).toBeInTheDocument();
+    });
+
     it("finishes a tabular workflow on Access without showing Assets", async () => {
         const user = userEvent.setup({ delay: null });
         const onCreated = vi.fn();

--- a/frontend/src/app/components/workflows/NewWorkflowModal.tsx
+++ b/frontend/src/app/components/workflows/NewWorkflowModal.tsx
@@ -156,7 +156,13 @@ const CANADA_PROVINCE_OPTIONS = [
 
 interface Props {
     open: boolean;
-    onClose: () => void;
+    /**
+     * `createdWithoutHandoff` is true when the dialog is dismissed after a
+     * workflow was created but never handed to `onCreated` (its access grants
+     * or asset copies failed). The caller should refetch so the new row is
+     * visible.
+     */
+    onClose: (createdWithoutHandoff?: boolean) => void;
     onCreated: (workflow: Workflow) => void;
     editWorkflow?: Workflow;
     readOnly?: boolean;
@@ -187,6 +193,7 @@ export function NewWorkflowModal({
     >(null);
     const [loading, setLoading] = useState(false);
     const [orgs, setOrgs] = useState<Org[]>([]);
+    const [orgsError, setOrgsError] = useState("");
     const [orgId, setOrgId] = useState(PERSONAL_WORKSPACE);
     const [directGrants, setDirectGrants] = useState<PendingDirectGrant[]>([]);
     const [orgOverrides, setOrgOverrides] = useState<PendingOrgOverride[]>([]);
@@ -387,12 +394,23 @@ export function NewWorkflowModal({
     useEffect(() => {
         if (!open) return;
         let cancelled = false;
+        setOrgsError("");
         listOrgs()
             .then((rows) => {
                 if (!cancelled) setOrgs(rows);
             })
-            .catch(() => {
-                if (!cancelled) setOrgs([]);
+            .catch((err: unknown) => {
+                if (cancelled) return;
+                setOrgs([]);
+                // Without this the selector silently offers only "No
+                // organization" and the workflow lands in the personal
+                // workspace by accident.
+                setOrgsError(
+                    userFacingApiError(
+                        err,
+                        "Could not load your organizations.",
+                    ),
+                );
             });
         return () => {
             cancelled = true;
@@ -478,11 +496,38 @@ export function NewWorkflowModal({
                 const recipients = assignments.filter(
                     (assignment) => !ownEmail || assignment.email !== ownEmail,
                 );
+                // Sequential, and one refusal must not take the whole submit
+                // down with it: the workflow already exists, so a rejected
+                // grant is reported against the addresses it applies to
+                // instead of surfacing as "Failed to create workflow". The
+                // share endpoint upserts, so retrying is safe.
+                const grantFailures: { email: string; detail: string }[] = [];
                 for (const assignment of recipients) {
-                    await shareWorkflow(workflow.id, {
-                        emails: [assignment.email],
-                        role: assignment.role,
-                    });
+                    try {
+                        await shareWorkflow(workflow.id, {
+                            emails: [assignment.email],
+                            role: assignment.role,
+                        });
+                    } catch (err: unknown) {
+                        grantFailures.push({
+                            email: assignment.email,
+                            detail: userFacingApiError(
+                                err,
+                                "the request failed",
+                            ),
+                        });
+                    }
+                }
+                if (grantFailures.length > 0) {
+                    // Stay open on THIS dialog: createdWorkflowRef holds the
+                    // workflow, so pressing Create again retries only the
+                    // grants against the same workflow.
+                    setError(
+                        `Workflow created, but access was not granted to ${grantFailures
+                            .map((failure) => failure.email)
+                            .join(", ")}: ${grantFailures[0]!.detail}`,
+                    );
+                    return;
                 }
                 onCreated({
                     ...workflow,
@@ -528,8 +573,17 @@ export function NewWorkflowModal({
     }
 
     function handleClose() {
+        // A create in flight owns the dialog: Escape, the backdrop and the
+        // close button must not dismiss it out from under an in-progress
+        // workflow creation.
+        if (loading) return;
+        // A workflow whose grants (or asset copies) failed was still created,
+        // but it never reached onCreated, so the caller's list has no row for
+        // it. Tell the caller to refetch instead of leaving it invisible
+        // until a page reload.
+        const createdWithoutHandoff = createdWorkflowRef.current !== null;
         resetForm();
-        onClose();
+        onClose(createdWithoutHandoff);
     }
 
     async function handleMarkdownImport(
@@ -923,6 +977,11 @@ export function NewWorkflowModal({
                                     })),
                                 ]}
                             />
+                            {orgsError && (
+                                <p className="mt-2 text-sm text-red-500">
+                                    {orgsError}
+                                </p>
+                            )}
                         </div>
                     </div>
                 )}

--- a/frontend/src/app/components/workflows/NewWorkflowModal.tsx
+++ b/frontend/src/app/components/workflows/NewWorkflowModal.tsx
@@ -476,17 +476,6 @@ export function NewWorkflowModal({
                     createdWorkflowRef.current ??
                     (await createWorkflow(createPayload));
                 createdWorkflowRef.current = workflow;
-                const pendingAssetIds = selectedAssets
-                    .map((document) => document.id)
-                    .filter((id) => !copiedAssetIdsRef.current.has(id));
-                if (type === "assistant" && pendingAssetIds.length > 0) {
-                    await copyDocumentsToWorkflowAssets(
-                        workflow.id,
-                        pendingAssetIds,
-                    );
-                    for (const id of pendingAssetIds)
-                        copiedAssetIdsRef.current.add(id);
-                }
                 const assignments = applyAccess
                     ? orgId === PERSONAL_WORKSPACE
                         ? directGrants
@@ -518,6 +507,9 @@ export function NewWorkflowModal({
                         });
                     }
                 }
+                const pendingAssetIds = selectedAssets
+                    .map((document) => document.id)
+                    .filter((id) => !copiedAssetIdsRef.current.has(id));
                 if (grantFailures.length > 0) {
                     // Stay open on THIS dialog: createdWorkflowRef holds the
                     // workflow, so pressing Create again retries only the
@@ -525,9 +517,49 @@ export function NewWorkflowModal({
                     setError(
                         `Workflow created, but access was not granted to ${grantFailures
                             .map((failure) => failure.email)
-                            .join(", ")}: ${grantFailures[0]!.detail}`,
+                            .join(", ")}: ${grantFailures[0]!.detail}${
+                            pendingAssetIds.length > 0
+                                ? ` The ${pendingAssetIds.length} selected ${
+                                      pendingAssetIds.length === 1
+                                          ? "file is"
+                                          : "files are"
+                                  } still pending and will be copied when you try again.`
+                                : ""
+                        }`,
                     );
                     return;
+                }
+
+                // The asset copy used to run BEFORE the grants and outside any
+                // try of its own. A failed copy therefore threw out of the
+                // whole submit and was reported as "Failed to create workflow"
+                // — about a workflow that exists — and because nothing
+                // recorded what had been copied, the retry sent every asset
+                // again and duplicated the ones that had worked. It runs last
+                // now, one asset at a time, and each id is recorded as it
+                // lands, so a retry sends only what is still missing.
+                if (type === "assistant" && pendingAssetIds.length > 0) {
+                    let copyFailures = 0;
+                    for (const id of pendingAssetIds) {
+                        try {
+                            await copyDocumentsToWorkflowAssets(workflow.id, [
+                                id,
+                            ]);
+                            copiedAssetIdsRef.current.add(id);
+                        } catch {
+                            copyFailures += 1;
+                        }
+                    }
+                    if (copyFailures > 0) {
+                        setError(
+                            `Workflow created, but ${copyFailures} ${
+                                copyFailures === 1 ? "asset" : "assets"
+                            } could not be copied. Press Create again to retry the ${
+                                copyFailures === 1 ? "copy" : "copies"
+                            }.`,
+                        );
+                        return;
+                    }
                 }
                 onCreated({
                     ...workflow,

--- a/frontend/src/app/components/workflows/UseWorkflowModal.tsx
+++ b/frontend/src/app/components/workflows/UseWorkflowModal.tsx
@@ -22,6 +22,7 @@ import {
 import { NoModelsWarningPopup } from "../popups/NoModelsWarningPopup";
 import { useUserProfile } from "@/app/contexts/UserProfileContext";
 import { isModelAvailable } from "@/app/lib/modelAvailability";
+import { roleFrom } from "@/app/lib/permissions";
 
 interface Props {
     workflow: Workflow | null;
@@ -190,7 +191,18 @@ export function UseWorkflowModal({ workflow, onClose, skipSelect = false }: Prop
         setSaving(true);
         try {
             const projectId = inProject ? selectedProjectId! : undefined;
-            const chatId = await saveChat(projectId);
+            // A project chat inherits the caller's role on the project, so
+            // the optimistic sidebar row must carry that role rather than
+            // assume the creator owns it. The picker rows already carry the
+            // server-computed role; absent one the context falls back to
+            // editor, which is the minimum this action required anyway.
+            const projectRow = projectId
+                ? projects.find((candidate) => candidate.id === projectId)
+                : undefined;
+            const chatId = await saveChat(
+                projectId,
+                projectRow ? roleFrom(projectRow) : null,
+            );
             if (!chatId) return;
             const files = selectedDocuments.map((document) => ({
                 filename: document.filename,

--- a/frontend/src/app/components/workflows/WorkflowDetailPage.test.tsx
+++ b/frontend/src/app/components/workflows/WorkflowDetailPage.test.tsx
@@ -1,0 +1,183 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+    deleteWorkflowShare,
+    getWorkflow,
+    getWorkflowPeople,
+    listWorkflowShares,
+    MikeApiError,
+    shareWorkflow,
+} from "@/app/lib/mikeApi";
+import type { Workflow } from "../shared/types";
+import { WorkflowDetailPage } from "./WorkflowDetailPage";
+
+// `importOriginal` keeps the real `MikeApiError`: `userFacingApiError`
+// decides with `instanceof`, so a stand-in class would make every 4xx look
+// like an unexpected failure.
+vi.mock("@/app/lib/mikeApi", async (importOriginal) => ({
+    ...(await importOriginal<typeof import("@/app/lib/mikeApi")>()),
+    deleteWorkflow: vi.fn(),
+    deleteWorkflowShare: vi.fn(),
+    getWorkflow: vi.fn(),
+    getWorkflowPeople: vi.fn(),
+    listWorkflowShares: vi.fn(),
+    shareWorkflow: vi.fn(),
+    updateWorkflow: vi.fn(),
+}));
+
+vi.mock("next/navigation", () => ({
+    useRouter: () => ({ push: vi.fn() }),
+    useSearchParams: () => ({ get: () => null }),
+}));
+
+vi.mock("@/app/contexts/AuthContext", () => ({
+    useAuth: () => ({ user: { id: "me", email: "me@firm.test" } }),
+}));
+vi.mock("@/app/contexts/UserProfileContext", () => ({
+    useUserProfile: () => ({ profile: { practiceAreas: [] } }),
+}));
+vi.mock("@/app/hooks/useQueryParamTab", () => ({
+    useQueryParamTab: () => ["prompt", vi.fn()],
+}));
+
+vi.mock("@/app/components/workflows/WorkflowPromptEditor", () => ({
+    WorkflowPromptEditor: () => null,
+}));
+vi.mock("./WorkflowAssets", () => ({
+    WorkflowAssets: () => null,
+}));
+vi.mock("@/app/components/workflows/UseWorkflowModal", () => ({
+    UseWorkflowModal: () => null,
+}));
+vi.mock("@/app/components/workflows/NewWorkflowModal", () => ({
+    NewWorkflowModal: () => null,
+}));
+vi.mock("@/app/components/modals/AddDocumentsModal", () => ({
+    AddDocumentsModal: () => null,
+}));
+
+const workflow = {
+    id: "workflow-1",
+    is_owner: true,
+    access_role: "owner",
+    org_id: null,
+    metadata: {
+        title: "Contract Intake",
+        type: "assistant",
+        language: "English",
+        practice: null,
+        jurisdictions: null,
+    },
+    skill_md: "",
+} as unknown as Workflow;
+
+function people() {
+    return Promise.resolve({
+        owner: {
+            user_id: "me",
+            email: "me@firm.test",
+            display_name: "Me",
+            role: "owner" as const,
+        },
+        members: [
+            {
+                email: "counsel@firm.test",
+                display_name: null,
+                role: "viewer" as const,
+            },
+        ],
+    });
+}
+
+describe("WorkflowDetailPage access mutations", () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        vi.mocked(getWorkflow).mockResolvedValue(workflow);
+        vi.mocked(getWorkflowPeople).mockImplementation(people);
+        vi.mocked(listWorkflowShares).mockResolvedValue([]);
+        vi.mocked(shareWorkflow).mockResolvedValue(undefined);
+        vi.mocked(deleteWorkflowShare).mockResolvedValue(undefined);
+        vi.stubGlobal(
+            "matchMedia",
+            vi.fn().mockReturnValue({
+                matches: true,
+                addEventListener: vi.fn(),
+                removeEventListener: vi.fn(),
+            }),
+        );
+    });
+
+    async function openAccess(user: ReturnType<typeof userEvent.setup>) {
+        render(<WorkflowDetailPage id="workflow-1" workflowType="assistant" />);
+        await user.click(
+            await screen.findByRole("button", {
+                name: "Open workflow access",
+            }),
+        );
+        return screen.findByRole("button", {
+            name: "Role for counsel@firm.test",
+        });
+    }
+
+    it("does not report a role change as failed when only the re-read fails", async () => {
+        const user = userEvent.setup();
+        vi.mocked(listWorkflowShares).mockRejectedValue(
+            new MikeApiError({ message: "Shares unavailable.", status: 500 }),
+        );
+
+        const rolePill = await openAccess(user);
+        await user.click(rolePill);
+        await user.click(screen.getByRole("menuitem", { name: "Owner" }));
+
+        await waitFor(() =>
+            expect(shareWorkflow).toHaveBeenCalledWith("workflow-1", {
+                emails: ["counsel@firm.test"],
+                role: "owner",
+            }),
+        );
+        expect(
+            screen.queryByText("Could not change that role."),
+        ).not.toBeInTheDocument();
+    });
+
+    it("does not report a revoke as failed when only the re-read fails", async () => {
+        const user = userEvent.setup();
+        vi.mocked(listWorkflowShares).mockRejectedValue(
+            new MikeApiError({ message: "Shares unavailable.", status: 500 }),
+        );
+
+        await openAccess(user);
+        await user.click(
+            screen.getByRole("button", {
+                name: "Actions for counsel@firm.test",
+            }),
+        );
+        await user.click(screen.getByRole("menuitem", { name: "Remove" }));
+
+        await waitFor(() =>
+            expect(listWorkflowShares).toHaveBeenCalledWith("workflow-1"),
+        );
+        expect(
+            screen.queryByText("Could not remove access."),
+        ).not.toBeInTheDocument();
+    });
+
+    it("still reports a role change the grant itself refused", async () => {
+        const user = userEvent.setup();
+        vi.mocked(shareWorkflow).mockRejectedValue(
+            new MikeApiError({
+                message: "Only owners can share this workflow.",
+                status: 403,
+            }),
+        );
+
+        const rolePill = await openAccess(user);
+        await user.click(rolePill);
+        await user.click(screen.getByRole("menuitem", { name: "Owner" }));
+
+        expect(
+            await screen.findByText("Only owners can share this workflow."),
+        ).toBeVisible();
+    });
+});

--- a/frontend/src/app/components/workflows/WorkflowDetailPage.test.tsx
+++ b/frontend/src/app/components/workflows/WorkflowDetailPage.test.tsx
@@ -141,6 +141,30 @@ describe("WorkflowDetailPage access mutations", () => {
         ).not.toBeInTheDocument();
     });
 
+    it("says the list is stale when the re-read fails", async () => {
+        // `.catch(() => {})` left the roster showing the roles as they were
+        // BEFORE a change the server accepted, with nothing saying the screen
+        // had stopped tracking the server.
+        const user = userEvent.setup();
+        vi.mocked(listWorkflowShares).mockRejectedValue(
+            new MikeApiError({ message: "Shares unavailable.", status: 500 }),
+        );
+
+        const rolePill = await openAccess(user);
+        await user.click(rolePill);
+        await user.click(screen.getByRole("menuitem", { name: "Owner" }));
+
+        expect(
+            await screen.findByText(
+                "The change was saved, but this list could not be reloaded. Reopen Access to see the current one.",
+            ),
+        ).toBeVisible();
+        // Still not reported as a failed change.
+        expect(
+            screen.queryByText("Could not change that role."),
+        ).not.toBeInTheDocument();
+    });
+
     it("does not report a revoke as failed when only the re-read fails", async () => {
         const user = userEvent.setup();
         vi.mocked(listWorkflowShares).mockRejectedValue(

--- a/frontend/src/app/components/workflows/WorkflowDetailPage.tsx
+++ b/frontend/src/app/components/workflows/WorkflowDetailPage.tsx
@@ -578,6 +578,9 @@ export function WorkflowDetailPage({ id, workflowType }: Props) {
           resource={{ id }}
           fetchAccess={fetchWorkflowAccess}
           currentUserEmail={user?.email ?? null}
+          // Both identifiers, so a roster row without an email still cannot
+          // offer the caller a Remove that locks them out of their own row.
+          currentUserId={user?.id ?? null}
           breadcrumb={["Workflows", workflow.metadata.title, "Access"]}
           access={{
             grants: workflowShares.map((share) => ({
@@ -587,9 +590,14 @@ export function WorkflowDetailPage({ id, workflowType }: Props) {
             orgId: workflow.org_id ?? null,
             ownerLabel: "Workflow owners",
             canManage: canShare,
+            // The refresh is deliberately not part of the mutation's result:
+            // AccessModal reports a rejection as "Could not change that role"
+            // / "Could not remove access", so a failing re-read would blame
+            // the grant that actually succeeded. A stale roster is the lesser
+            // problem, and the next open re-reads it.
             onGrant: async (email, role) => {
               await shareWorkflow(id, { emails: [email], role });
-              await fetchWorkflowShares();
+              await fetchWorkflowShares().catch(() => {});
             },
             onRevoke: async (email) => {
               const share = workflowShares.find(
@@ -598,7 +606,7 @@ export function WorkflowDetailPage({ id, workflowType }: Props) {
                   email.trim().toLowerCase(),
               );
               if (share) await deleteWorkflowShare(id, share.id);
-              await fetchWorkflowShares();
+              await fetchWorkflowShares().catch(() => {});
             },
           }}
         />

--- a/frontend/src/app/components/workflows/WorkflowDetailPage.tsx
+++ b/frontend/src/app/components/workflows/WorkflowDetailPage.tsx
@@ -31,6 +31,7 @@ import {
   type ProjectPeople,
 } from "@/app/lib/mikeApi";
 import { can, roleFromLoaded } from "@/app/lib/permissions";
+import { userFacingApiError } from "@/app/lib/userFacingError";
 import { UseWorkflowModal } from "@/app/components/workflows/UseWorkflowModal";
 import { WFEditColumnModal } from "@/app/components/workflows/WFEditColumnModal";
 import { WFColumnViewModal } from "@/app/components/workflows/WFColumnViewModal";
@@ -170,6 +171,11 @@ export function WorkflowDetailPage({ id, workflowType }: Props) {
   // Share / use / details popovers
   const [shareOpen, setShareOpen] = useState(false);
   const [workflowShares, setWorkflowShares] = useState<WorkflowShare[]>([]);
+  // A roster re-read that failed after a change the server accepted. Shown
+  // beside the list rather than in place of the success.
+  const [shareRefreshError, setShareRefreshError] = useState<string | null>(
+    null,
+  );
   const [detailsOpen, setDetailsOpen] = useState(false);
   const [useOpen, setUseOpen] = useState(false);
   const [deleteOpen, setDeleteOpen] = useState(false);
@@ -270,6 +276,25 @@ export function WorkflowDetailPage({ id, workflowType }: Props) {
     setWorkflowShares(shares);
     return shares;
   }, [id]);
+
+  /**
+   * Re-read the roster after a change the server has already accepted, and
+   * say so when that read fails instead of leaving the modal showing the
+   * roles as they were before the change.
+   */
+  const refreshShares = useCallback(async () => {
+    try {
+      await fetchWorkflowShares();
+      setShareRefreshError(null);
+    } catch (error) {
+      setShareRefreshError(
+        userFacingApiError(
+          error,
+          "The change was saved, but this list could not be reloaded. Reopen Access to see the current one.",
+        ),
+      );
+    }
+  }, [fetchWorkflowShares]);
 
   const fetchWorkflowAccess = useCallback(async (): Promise<ProjectPeople> => {
     return getWorkflowPeople(id);
@@ -502,7 +527,10 @@ export function WorkflowDetailPage({ id, workflowType }: Props) {
           [
             canShare
               ? {
-                  onClick: () => setShareOpen(true),
+                  onClick: () => {
+                    setShareRefreshError(null);
+                    setShareOpen(true);
+                  },
                   title: "Open workflow access",
                   iconOnly: true,
                   icon: <Users className="h-4 w-4" />,
@@ -590,14 +618,21 @@ export function WorkflowDetailPage({ id, workflowType }: Props) {
             orgId: workflow.org_id ?? null,
             ownerLabel: "Workflow owners",
             canManage: canShare,
+            error: shareRefreshError,
             // The refresh is deliberately not part of the mutation's result:
             // AccessModal reports a rejection as "Could not change that role"
             // / "Could not remove access", so a failing re-read would blame
-            // the grant that actually succeeded. A stale roster is the lesser
-            // problem, and the next open re-reads it.
+            // the grant that actually succeeded.
+            //
+            // It is not nothing, either. `.catch(() => {})` left the list
+            // showing the roles as they were BEFORE a change the server had
+            // accepted, with no sign that the screen had stopped tracking the
+            // server — the next click would then be aimed at a row whose role
+            // is not the role it shows. The mutation still reads as a
+            // success; the stale list says it is stale.
             onGrant: async (email, role) => {
               await shareWorkflow(id, { emails: [email], role });
-              await fetchWorkflowShares().catch(() => {});
+              await refreshShares();
             },
             onRevoke: async (email) => {
               const share = workflowShares.find(
@@ -606,7 +641,7 @@ export function WorkflowDetailPage({ id, workflowType }: Props) {
                   email.trim().toLowerCase(),
               );
               if (share) await deleteWorkflowShare(id, share.id);
-              await fetchWorkflowShares().catch(() => {});
+              await refreshShares();
             },
           }}
         />

--- a/frontend/src/app/components/workflows/WorkflowList.test.tsx
+++ b/frontend/src/app/components/workflows/WorkflowList.test.tsx
@@ -8,6 +8,7 @@ const {
   getWorkflowFilterOptions,
   importWorkflowAddon,
   listWorkflowAddons,
+  retryWorkflows,
   routerPush,
   setActiveTab,
   usePaginatedWorkflowsSpy,
@@ -18,6 +19,7 @@ const {
   importWorkflowAddon: vi.fn(),
   setActiveTab: vi.fn(),
   listWorkflowAddons: vi.fn(),
+  retryWorkflows: vi.fn(),
   routerPush: vi.fn(),
   usePaginatedWorkflowsSpy: vi.fn(),
   workflowRows: { current: [] as Record<string, unknown>[] },
@@ -44,6 +46,7 @@ vi.mock("@/app/hooks/usePaginatedWorkflows", () => ({
       error: null,
       loadMoreError: null,
       loadMore: vi.fn(),
+      retry: retryWorkflows,
       selectedWorkflowIds: [],
       setSelectedWorkflowIds: vi.fn(),
       selectAllMatching: vi.fn(),
@@ -65,7 +68,23 @@ vi.mock("./UseWorkflowModal", () => ({
 }));
 
 vi.mock("./NewWorkflowModal", () => ({
-  NewWorkflowModal: () => null,
+  NewWorkflowModal: ({
+    open,
+    onClose,
+  }: {
+    open: boolean;
+    onClose: (createdWithoutHandoff?: boolean) => void;
+  }) =>
+    open ? (
+      <div>
+        <button type="button" onClick={() => onClose(true)}>
+          Dismiss after partial create
+        </button>
+        <button type="button" onClick={() => onClose(false)}>
+          Dismiss without creating
+        </button>
+      </div>
+    ) : null,
 }));
 
 vi.mock("./WorkflowAddonPreviewModal", () => ({
@@ -80,6 +99,7 @@ describe("WorkflowList pack toolbar", () => {
     getWorkflowFilterOptions.mockReset();
     listWorkflowAddons.mockReset();
     importWorkflowAddon.mockReset();
+    retryWorkflows.mockReset();
     routerPush.mockReset();
     usePaginatedWorkflowsSpy.mockReset();
     listWorkflowAddons.mockReturnValue(new Promise(() => {}));
@@ -292,5 +312,53 @@ describe("WorkflowList pack toolbar", () => {
     expect(usePaginatedWorkflowsSpy.mock.calls.at(-1)?.[0]).toEqual(
       expect.objectContaining({ scope: "private" }),
     );
+  });
+
+  it("refetches when the new-workflow modal is dismissed after a partial create", async () => {
+    const user = userEvent.setup();
+    activeTab.current = "all";
+    // The workflow exists on the server but never reached onCreated, so only
+    // a refetch can put its row in the list.
+    retryWorkflows.mockImplementation(() => {
+      workflowRows.current = [
+        {
+          id: "created-workflow",
+          user_id: "user-1",
+          access_scope: "private",
+          metadata: {
+            title: "Created workflow",
+            type: "assistant",
+            contributors: [],
+            language: "English",
+            practice: null,
+            jurisdictions: null,
+          },
+          is_system: false,
+        },
+      ];
+    });
+    render(<WorkflowList />);
+
+    expect(screen.queryByText("Created workflow")).not.toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "New workflow" }));
+    await user.click(
+      screen.getByRole("button", { name: "Dismiss after partial create" }),
+    );
+
+    expect(retryWorkflows).toHaveBeenCalledTimes(1);
+    expect(await screen.findByText("Created workflow")).toBeVisible();
+  });
+
+  it("does not refetch when the new-workflow modal is dismissed with nothing created", async () => {
+    const user = userEvent.setup();
+    activeTab.current = "all";
+    render(<WorkflowList />);
+
+    await user.click(screen.getByRole("button", { name: "New workflow" }));
+    await user.click(
+      screen.getByRole("button", { name: "Dismiss without creating" }),
+    );
+
+    expect(retryWorkflows).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/app/components/workflows/WorkflowList.tsx
+++ b/frontend/src/app/components/workflows/WorkflowList.tsx
@@ -171,6 +171,7 @@ export function WorkflowList({
     error: workflowsError,
     loadMoreError,
     loadMore,
+    retry: refreshWorkflows,
     selectedWorkflowIds,
     setSelectedWorkflowIds,
     selectAllMatching,
@@ -610,7 +611,13 @@ export function WorkflowList({
 
       <NewWorkflowModal
         open={newModalOpen}
-        onClose={() => setNewModalOpen(false)}
+        onClose={(createdWithoutHandoff) => {
+          setNewModalOpen(false);
+          // The workflow exists but never reached onCreated (its access
+          // grants failed), so nothing has inserted a row for it. Refetch
+          // rather than leave it invisible until a page reload.
+          if (createdWithoutHandoff) refreshWorkflows();
+        }}
         onCreated={(workflow) => {
           setWorkflows((current) => [workflow, ...current]);
           setNewModalOpen(false);

--- a/frontend/src/app/contexts/ChatHistoryContext.roles.test.tsx
+++ b/frontend/src/app/contexts/ChatHistoryContext.roles.test.tsx
@@ -39,6 +39,15 @@ function Probe() {
     return (
         <div>
             <button onClick={() => void saveChat()}>save</button>
+            <button onClick={() => void saveChat("p1", "editor")}>
+                save in project as editor
+            </button>
+            <button onClick={() => void saveChat("p1", "owner")}>
+                save in project as owner
+            </button>
+            <button onClick={() => void saveChat("p1")}>
+                save in project with unknown role
+            </button>
             <button
                 onClick={() => {
                     renameChat("chat-9", "New title").catch(() => {
@@ -66,6 +75,17 @@ beforeEach(() => {
     renameChatApi.mockResolvedValue(undefined);
 });
 
+async function renderProbe() {
+    render(
+        <ChatHistoryProvider>
+            <Probe />
+        </ChatHistoryProvider>,
+    );
+    await waitFor(() =>
+        expect(screen.getByTestId("loaded")).toHaveTextContent("true"),
+    );
+}
+
 describe("saveChat's optimistic row", () => {
     it("carries the creator's owner standing, as the server would serve it", async () => {
         render(
@@ -85,6 +105,42 @@ describe("saveChat's optimistic row", () => {
             expect(screen.getByTestId("role")).toHaveTextContent("owner"),
         );
         expect(screen.getByTestId("is-owner")).toHaveTextContent("true");
+    });
+
+    // A PROJECT chat's role is not the creator's to claim: the server derives
+    // it from the project (ensureSharedRowAccess). Stamping owner offered an
+    // editor the Delete item in the sidebar, and the server answered 403.
+    it("stamps a project chat with the caller's project role, not owner", async () => {
+        await renderProbe();
+
+        fireEvent.click(screen.getByText("save in project as editor"));
+
+        await waitFor(() =>
+            expect(screen.getByTestId("role")).toHaveTextContent("editor"),
+        );
+        expect(screen.getByTestId("is-owner")).toHaveTextContent("false");
+    });
+
+    it("keeps owner standing for a project owner", async () => {
+        await renderProbe();
+
+        fireEvent.click(screen.getByText("save in project as owner"));
+
+        await waitFor(() =>
+            expect(screen.getByTestId("role")).toHaveTextContent("owner"),
+        );
+        expect(screen.getByTestId("is-owner")).toHaveTextContent("true");
+    });
+
+    it("falls back to editor, not owner, when the project role is unknown", async () => {
+        await renderProbe();
+
+        fireEvent.click(screen.getByText("save in project with unknown role"));
+
+        await waitFor(() =>
+            expect(screen.getByTestId("role")).toHaveTextContent("editor"),
+        );
+        expect(screen.getByTestId("is-owner")).toHaveTextContent("false");
     });
 
     it("rethrows a refused rename so the row can say why", async () => {

--- a/frontend/src/app/contexts/ChatHistoryContext.tsx
+++ b/frontend/src/app/contexts/ChatHistoryContext.tsx
@@ -18,6 +18,7 @@ import {
     renameChat,
 } from "@/app/lib/mikeApi";
 import type { Chat, Message } from "@/app/components/shared/types";
+import type { ProjectRole } from "@/app/lib/permissions";
 
 interface ChatHistoryContextType {
     chats: Chat[] | null;
@@ -27,7 +28,10 @@ interface ChatHistoryContextType {
     setCurrentChatId: (chatId: string | null) => void;
     loadChats: () => Promise<void>;
   loadMoreChats: () => Promise<void>;
-    saveChat: (projectId?: string) => Promise<string | null>;
+    saveChat: (
+        projectId?: string,
+        projectRole?: ProjectRole | null,
+    ) => Promise<string | null>;
     renameChat: (chatId: string, title: string) => Promise<void>;
     updateChatTitle: (chatId: string, title: string) => void;
     newChatMessages: Message[] | null;
@@ -147,28 +151,44 @@ export function ChatHistoryProvider({ children }: { children: ReactNode }) {
     );
 
     const saveChat = useCallback(
-        async (projectId?: string): Promise<string | null> => {
+        async (
+            projectId?: string,
+            projectRole?: ProjectRole | null,
+        ): Promise<string | null> => {
             try {
                 const { id } = await createChat(
                     projectId ? { project_id: projectId } : undefined,
                 );
                 const now = new Date().toISOString();
+                // The optimistic row must say what the server would say.
+                // The overview RPC serves is_owner + access_role on every
+                // row, and the sidebar's gates read them via roleFrom(),
+                // which fails closed to viewer when both are absent — so
+                // without a stamp the creator was refused rename and delete
+                // on their own brand-new thread until a reload.
+                //
+                // What the stamp should SAY differs by chat kind. A
+                // standalone chat belongs to its creator, so owner is what
+                // the server serves back. A PROJECT chat does not: the
+                // server derives its role from the caller's role on the
+                // project (ensureSharedRowAccess), so an editor who starts a
+                // thread there is an editor on it. Stamping owner offered
+                // that editor a Delete which came back 403 — the sidebar
+                // promised something the server refuses. Callers pass their
+                // project role; absent one we fall back to editor, the
+                // minimum the server requires to have created the chat at
+                // all, rather than to the top of the ladder.
+                const role: ProjectRole = projectId
+                    ? (projectRole ?? "editor")
+                    : "owner";
                 const newChat: Chat = {
                     id,
                     project_id: projectId ?? null,
                     user_id: user?.id ?? "",
                     title: null,
                     created_at: now,
-                    // The optimistic row must say what the server would say.
-                    // The overview RPC serves is_owner + access_role on every
-                    // row, and the sidebar's gates read them via roleFrom(),
-                    // which fails closed to viewer when both are absent — so
-                    // without this stamp the creator was refused rename and
-                    // delete on their own brand-new thread until a reload.
-                    // The caller IS the creator here, and a chat's creator
-                    // derives admin standing on their row by definition.
-                    is_owner: true,
-                    access_role: "owner",
+                    is_owner: role === "owner",
+                    access_role: role,
                 };
                 setChats((prev) => [newChat, ...(prev ?? [])]);
                 return id;

--- a/frontend/src/app/lib/mikeApi.test.ts
+++ b/frontend/src/app/lib/mikeApi.test.ts
@@ -367,10 +367,13 @@ describe("apiRequest plumbing (via thin wrappers)", () => {
         });
     });
 
-    it("labels a 4xx with its status when the detail is unusable", async () => {
-        // The non-5xx sibling of the test above: a client error whose detail
-        // is not a usable string gets the status-labelled fallback, never the
-        // internal-error copy reserved for 5xx.
+    it("treats a 4xx with an unusable detail as a malformed response", async () => {
+        // The non-5xx sibling of the test above, and the one that reached a
+        // user: a 4xx message is shown VERBATIM by userFacingApiError, on the
+        // assumption that a 4xx says something actionable. The old
+        // status-labelled fallback was not that — it put "Account not deleted
+        // / API error: 409" on screen. A body with no detail is a malformed
+        // error response and says the malformed-response sentence.
         fetchMock.mockResolvedValue(
             jsonResponse({ detail: { nested: true } }, { status: 404 }),
         );
@@ -378,7 +381,25 @@ describe("apiRequest plumbing (via thin wrappers)", () => {
         await expect(getUserProfile()).rejects.toMatchObject({
             status: 404,
             code: null,
-            message: "API error: 404",
+            message: "The request could not be completed. Please try again.",
+        });
+    });
+
+    it("uses the same wording whether the body is empty JSON or not JSON", async () => {
+        // A 409 with `{}` (the shape that produced "API error: 409") and a
+        // 409 with no JSON at all are the same failure to the reader.
+        fetchMock.mockResolvedValue(jsonResponse({}, { status: 409 }));
+        await expect(getUserProfile()).rejects.toMatchObject({
+            status: 409,
+            message: "The request could not be completed. Please try again.",
+        });
+
+        fetchMock.mockResolvedValue(
+            new Response("<html>gateway</html>", { status: 409 }),
+        );
+        await expect(getUserProfile()).rejects.toMatchObject({
+            status: 409,
+            message: "The request could not be completed. Please try again.",
         });
     });
 

--- a/frontend/src/app/lib/mikeApi.ts
+++ b/frontend/src/app/lib/mikeApi.ts
@@ -223,12 +223,20 @@ async function toApiError(response: Response, path: string) {
             status: response.status,
             code: typeof parsed.code === "string" ? parsed.code : null,
             requestId,
+            // A 4xx whose body carries no usable `detail` is a malformed
+            // error response, and it is treated as one. `API error: 409` used
+            // to be produced here instead — and because a 4xx message is the
+            // one userFacingApiError shows VERBATIM (on the assumption that a
+            // 4xx says something the user can act on), it reached the screen:
+            // "Account not deleted / API error: 409". The catch arm below
+            // already has the right sentence for "the server did not tell us
+            // what went wrong"; this arm now uses it too.
             message:
                 response.status >= 500
                     ? INTERNAL_ERROR_MESSAGE
                     : typeof parsed.detail === "string" && parsed.detail
                       ? parsed.detail
-                      : `API error: ${response.status}`,
+                      : MALFORMED_ERROR_RESPONSE_MESSAGE,
         });
     } catch {
         devLog("[mike-api] non-ok non-json response", {

--- a/frontend/src/shared/ui/ModalUI.tsx
+++ b/frontend/src/shared/ui/ModalUI.tsx
@@ -76,6 +76,15 @@ export function ModalUI({
                 : [];
 
         window.requestAnimationFrame(() => {
+            // React's `autoFocus` prop focuses the element on mount but never
+            // writes an `autofocus` attribute, so the attribute probe below
+            // never matched and this frame stole focus from the intended
+            // field to the first focusable (the Close button). If something
+            // inside the dialog already holds focus, leave it there.
+            const active = document.activeElement as HTMLElement | null;
+            if (dialog && active && active !== dialog && dialog.contains(active)) {
+                return;
+            }
             const target =
                 focusable().find((element) =>
                     element.hasAttribute("autofocus"),

--- a/scripts/audit-gate.mjs
+++ b/scripts/audit-gate.mjs
@@ -48,7 +48,30 @@ for (const [packagePath, entry] of Object.entries(lock.packages ?? {})) {
 }
 
 const packageEntries = Object.entries(packages);
+
+// FAIL CLOSED ON AN EMPTY LOCKFILE. A lockfile with no `packages` map (an
+// npm 6 lockfile, a truncated write, a wrong cwd) produces zero queries, so
+// every loop below is skipped, `advisories` is empty and the gate prints
+// "passed" having checked nothing at all — a gate that answers "clean" for a
+// tree it never looked at is worse than no gate.
+if (packageEntries.length === 0) {
+  console.error(
+    "package-lock.json declared no resolved packages — refusing to pass the gate.",
+  );
+  console.error(
+    "  (npm 6 lockfiles have no `packages` map; run `npm install` with npm 7+ to regenerate it.)",
+  );
+  process.exit(1);
+}
+
 const osvBaseUrl = process.env.OSV_API_BASE_URL ?? "https://api.osv.dev/v1";
+
+/**
+ * How many advisory batches were actually answered by a service. Checked
+ * before the pass line: a run that never got an answer has not audited
+ * anything, and must not be allowed to report success.
+ */
+let batchesAnswered = 0;
 
 async function fetchJson(url, init, { attempts = 3, timeoutMs = 30_000 } = {}) {
   let lastError;
@@ -92,15 +115,39 @@ async function loadNpmReport() {
       body: JSON.stringify(batch),
     }, { attempts: 1, timeoutMs: 15_000 });
 
+    // VALIDATE, don't coerce. A registry (or a proxy, or a captive network)
+    // that answers 200 with `{"error":"..."}` used to sail through here: the
+    // payload is an object, its one value is not an array, the old code
+    // coerced it to `[]`, and the gate reported "0 advisories, passed". An
+    // advisory service that did not answer the question must send us to OSV,
+    // and if OSV fails too the gate fails — never passes by default.
     if (!batchReport || Array.isArray(batchReport) || typeof batchReport !== "object") {
       throw new Error("npm returned an invalid advisory report");
     }
+    for (const key of ["error", "message", "code"]) {
+      if (Object.hasOwn(batchReport, key)) {
+        throw new Error(
+          `npm advisory service returned an error payload (${key}: ${JSON.stringify(batchReport[key])})`,
+        );
+      }
+    }
+    for (const [packageName, packageAdvisories] of Object.entries(batchReport)) {
+      if (!Array.isArray(packageAdvisories)) {
+        throw new Error(
+          `npm returned a non-array advisory list for ${packageName}`,
+        );
+      }
+    }
+    batchesAnswered += 1;
     for (const [packageName, packageAdvisories] of Object.entries(batchReport)) {
       report[packageName] = [
         ...(report[packageName] ?? []),
-        ...(Array.isArray(packageAdvisories) ? packageAdvisories : []),
+        ...packageAdvisories,
       ];
     }
+  }
+  if (batchesAnswered === 0) {
+    throw new Error("npm answered no advisory batches");
   }
   return report;
 }
@@ -128,6 +175,7 @@ async function loadOsvReport() {
     if (!Array.isArray(response?.results)) {
       throw new Error("OSV returned an invalid advisory report");
     }
+    batchesAnswered += 1;
     for (const [resultIndex, result] of response.results.entries()) {
       const query = batchQueries[resultIndex];
       for (const vulnerability of result.vulns ?? []) {
@@ -195,6 +243,9 @@ let report;
 try {
   report = await loadNpmReport();
 } catch (npmError) {
+  // Each loader counts only its OWN answered batches; a partially answered
+  // npm run must not lend its credit to the OSV attempt.
+  batchesAnswered = 0;
   console.warn(
     `npm advisory service unavailable; checking OSV instead (${npmError instanceof Error ? npmError.message : String(npmError)})`,
   );
@@ -242,6 +293,14 @@ for (const e of unused) {
 if (blocking.length > 0) {
   console.error(`\n${blocking.length} high/critical advisories are not allowlisted:`);
   for (const line of blocking) console.error(`  ${line}`);
+  process.exit(1);
+}
+// Last line of defence: reaching here with nothing answered means the loops
+// above ran zero times, which is "no data", not "no advisories".
+if (batchesAnswered === 0) {
+  console.error(
+    "No advisory service answered — refusing to pass the gate.",
+  );
   process.exit(1);
 }
 console.log(`audit gate passed (${advisories.size} high/critical advisories, all allowlisted)`);

--- a/scripts/audit-gate.mjs
+++ b/scripts/audit-gate.mjs
@@ -67,6 +67,27 @@ if (packageEntries.length === 0) {
 const osvBaseUrl = process.env.OSV_API_BASE_URL ?? "https://api.osv.dev/v1";
 
 /**
+ * CANARY. `{}` is a perfectly valid npm bulk response — it is what the
+ * registry sends for a clean tree — which means NO shape check can tell
+ * "we looked and found nothing" apart from "this endpoint does not answer
+ * this question". A proxy, a captive portal, an internal mirror that
+ * implements the route as a stub, or the endpoint's eventual retirement all
+ * produce 200 `{}`, and the gate happily printed "0 advisories, passed".
+ *
+ * So every batch carries a package+version we KNOW carries a high-severity
+ * advisory. If the answer does not mention it, the endpoint is not answering
+ * advisory questions and we fall through to OSV. The canary is stripped
+ * before the report is evaluated, so it never appears as a finding.
+ *
+ * adm-zip 0.5.12 is the choice because it is already a real, allowlisted
+ * dependency of the word-addin workspace: whatever retires it from the
+ * advisory database will also break that allowlist entry, so the two cannot
+ * drift apart unnoticed.
+ */
+const CANARY_PACKAGE = "adm-zip";
+const CANARY_VERSION = "0.5.12";
+
+/**
  * How many advisory batches were actually answered by a service. Checked
  * before the pass line: a run that never got an answer has not audited
  * anything, and must not be allowed to report success.
@@ -105,6 +126,13 @@ async function loadNpmReport() {
   // fallback was the source of the previous five-minute CI failures.
   for (let offset = 0; offset < packageEntries.length; offset += 500) {
     const batch = Object.fromEntries(packageEntries.slice(offset, offset + 500));
+    // Only strip the canary back out if it was not already part of this
+    // workspace's tree. When it IS a real dependency its advisories are a
+    // real finding and must survive.
+    const canaryIsReal = Object.hasOwn(batch, CANARY_PACKAGE);
+    batch[CANARY_PACKAGE] = [
+      ...new Set([...(batch[CANARY_PACKAGE] ?? []), CANARY_VERSION]),
+    ];
     const batchReport = await fetchJson(endpoint, {
       method: "POST",
       headers: {
@@ -138,6 +166,19 @@ async function loadNpmReport() {
         );
       }
     }
+    // The canary must come back. An empty or missing entry means this
+    // endpoint did not answer the question we asked, however well-formed its
+    // 200 was — send the run to OSV rather than pass on silence.
+    if (
+      !Array.isArray(batchReport[CANARY_PACKAGE]) ||
+      batchReport[CANARY_PACKAGE].length === 0
+    ) {
+      throw new Error(
+        `npm returned no advisory for the canary ${CANARY_PACKAGE}@${CANARY_VERSION} — the endpoint is not answering advisory queries`,
+      );
+    }
+    if (!canaryIsReal) delete batchReport[CANARY_PACKAGE];
+
     batchesAnswered += 1;
     for (const [packageName, packageAdvisories] of Object.entries(batchReport)) {
       report[packageName] = [
@@ -174,6 +215,14 @@ async function loadOsvReport() {
     });
     if (!Array.isArray(response?.results)) {
       throw new Error("OSV returned an invalid advisory report");
+    }
+    // OSV answers positionally: one result per query, in order. A short array
+    // means some queries went unanswered, and reading the rest as "clean"
+    // would silently drop packages from the audit.
+    if (response.results.length !== batchQueries.length) {
+      throw new Error(
+        `OSV answered ${response.results.length} of ${batchQueries.length} queries`,
+      );
     }
     batchesAnswered += 1;
     for (const [resultIndex, result] of response.results.entries()) {

--- a/scripts/audit-gate.test.mjs
+++ b/scripts/audit-gate.test.mjs
@@ -1,0 +1,84 @@
+// Regression tests for the FAIL-CLOSED contract of scripts/audit-gate.mjs.
+//
+// Run: node --test scripts/audit-gate.test.mjs
+//
+// The gate's only job is to refuse. Every bug it has had was the same bug —
+// some path where "we could not check" printed the same "audit gate passed"
+// as "we checked and it is clean" — so these tests assert the exit code for
+// the two ways that has happened, not the advisory parsing.
+
+import { deepStrictEqual, notStrictEqual, strictEqual } from "node:assert";
+import { spawn } from "node:child_process";
+import { createServer } from "node:http";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { after, test } from "node:test";
+import { fileURLToPath } from "node:url";
+
+const gatePath = join(dirname(fileURLToPath(import.meta.url)), "audit-gate.mjs");
+
+/** A registry that answers 200 with a JSON body that is not an advisory map. */
+const requests = [];
+const stub = createServer((req, res) => {
+  requests.push(req.url);
+  res.writeHead(200, { "content-type": "application/json" });
+  res.end(JSON.stringify({ error: "nope" }));
+});
+await new Promise((resolve) => stub.listen(0, "127.0.0.1", resolve));
+const stubUrl = `http://127.0.0.1:${stub.address().port}`;
+after(() => stub.close());
+
+// spawn, never spawnSync: the stub registry runs on THIS process's event
+// loop, and a synchronous child would block it — the child's requests would
+// go unanswered until they timed out, turning a 0.2s test into a 100s one.
+function runGate(lockfile) {
+  const dir = mkdtempSync(join(tmpdir(), "audit-gate-"));
+  writeFileSync(join(dir, "package-lock.json"), JSON.stringify(lockfile));
+  const child = spawn(process.execPath, [gatePath], {
+    cwd: dir,
+    env: {
+      ...process.env,
+      npm_config_registry: stubUrl,
+      OSV_API_BASE_URL: stubUrl,
+    },
+  });
+  let stdout = "";
+  let stderr = "";
+  child.stdout.setEncoding("utf8").on("data", (c) => (stdout += c));
+  child.stderr.setEncoding("utf8").on("data", (c) => (stderr += c));
+  return new Promise((resolve, reject) => {
+    child.on("error", reject);
+    child.on("close", (status) => resolve({ status, stdout, stderr }));
+  });
+}
+
+const LOCKFILE_WITH_PACKAGES = {
+  lockfileVersion: 3,
+  packages: {
+    "": { name: "fixture", version: "1.0.0" },
+    "node_modules/left-pad": { version: "1.3.0" },
+  },
+};
+
+test("fails when the advisory services answer 200 with an error payload", async () => {
+  // Both services are the stub, so npm fails validation and the OSV fallback
+  // fails too. Passing here would mean shipping unaudited dependencies every
+  // time a proxy or a captive network sat in front of the registry.
+  const result = await runGate(LOCKFILE_WITH_PACKAGES);
+  notStrictEqual(result.status, 0, `expected non-zero exit\n${result.stderr}`);
+  strictEqual(result.stdout.includes("audit gate passed"), false);
+});
+
+test("fails when the lockfile declares no packages, without calling out", async () => {
+  // An npm 6 lockfile (or a truncated one) yields zero queries, so every loop
+  // in the gate is skipped and it used to report a clean audit having made no
+  // network call at all.
+  requests.length = 0;
+  const result = await runGate({ lockfileVersion: 1, dependencies: {} });
+  notStrictEqual(result.status, 0, `expected non-zero exit\n${result.stderr}`);
+  strictEqual(result.stdout.includes("audit gate passed"), false);
+  strictEqual(result.stderr.includes("no resolved packages"), true);
+  // Nothing was consulted — which is exactly why it must not pass.
+  deepStrictEqual(requests, []);
+});

--- a/scripts/audit-gate.test.mjs
+++ b/scripts/audit-gate.test.mjs
@@ -5,7 +5,7 @@
 // The gate's only job is to refuse. Every bug it has had was the same bug —
 // some path where "we could not check" printed the same "audit gate passed"
 // as "we checked and it is clean" — so these tests assert the exit code for
-// the two ways that has happened, not the advisory parsing.
+// the ways that has happened, not the advisory parsing.
 
 import { deepStrictEqual, notStrictEqual, strictEqual } from "node:assert";
 import { spawn } from "node:child_process";
@@ -18,12 +18,39 @@ import { fileURLToPath } from "node:url";
 
 const gatePath = join(dirname(fileURLToPath(import.meta.url)), "audit-gate.mjs");
 
-/** A registry that answers 200 with a JSON body that is not an advisory map. */
+const NPM_BULK_PATH = "/-/npm/v1/security/advisories/bulk";
+/** The canary the gate smuggles into every npm batch. */
+const CANARY_ADVISORY = {
+    id: 1123686,
+    url: "https://github.com/advisories/GHSA-xcpc-8h2w-3j85",
+    title: "adm-zip: Crafted ZIP file triggers 4GB memory allocation",
+    severity: "high",
+};
+
+/**
+ * One stub standing in for BOTH advisory services; each test installs the
+ * responses it needs. `requests` records (url, body) so a test can prove what
+ * the gate did and did not consult.
+ */
 const requests = [];
+let respond = () => ({ status: 200, body: { error: "nope" } });
+
 const stub = createServer((req, res) => {
-  requests.push(req.url);
-  res.writeHead(200, { "content-type": "application/json" });
-  res.end(JSON.stringify({ error: "nope" }));
+    let raw = "";
+    req.setEncoding("utf8");
+    req.on("data", (chunk) => (raw += chunk));
+    req.on("end", () => {
+        let parsed = null;
+        try {
+            parsed = raw ? JSON.parse(raw) : null;
+        } catch {
+            parsed = null;
+        }
+        requests.push({ url: req.url, body: parsed });
+        const { status = 200, body } = respond(req.url, parsed) ?? {};
+        res.writeHead(status, { "content-type": "application/json" });
+        res.end(JSON.stringify(body ?? {}));
+    });
 });
 await new Promise((resolve) => stub.listen(0, "127.0.0.1", resolve));
 const stubUrl = `http://127.0.0.1:${stub.address().port}`;
@@ -33,52 +60,189 @@ after(() => stub.close());
 // loop, and a synchronous child would block it — the child's requests would
 // go unanswered until they timed out, turning a 0.2s test into a 100s one.
 function runGate(lockfile) {
-  const dir = mkdtempSync(join(tmpdir(), "audit-gate-"));
-  writeFileSync(join(dir, "package-lock.json"), JSON.stringify(lockfile));
-  const child = spawn(process.execPath, [gatePath], {
-    cwd: dir,
-    env: {
-      ...process.env,
-      npm_config_registry: stubUrl,
-      OSV_API_BASE_URL: stubUrl,
-    },
-  });
-  let stdout = "";
-  let stderr = "";
-  child.stdout.setEncoding("utf8").on("data", (c) => (stdout += c));
-  child.stderr.setEncoding("utf8").on("data", (c) => (stderr += c));
-  return new Promise((resolve, reject) => {
-    child.on("error", reject);
-    child.on("close", (status) => resolve({ status, stdout, stderr }));
-  });
+    const dir = mkdtempSync(join(tmpdir(), "audit-gate-"));
+    writeFileSync(join(dir, "package-lock.json"), JSON.stringify(lockfile));
+    const child = spawn(process.execPath, [gatePath], {
+        cwd: dir,
+        env: {
+            ...process.env,
+            npm_config_registry: stubUrl,
+            OSV_API_BASE_URL: stubUrl,
+        },
+    });
+    let stdout = "";
+    let stderr = "";
+    child.stdout.setEncoding("utf8").on("data", (c) => (stdout += c));
+    child.stderr.setEncoding("utf8").on("data", (c) => (stderr += c));
+    return new Promise((resolve, reject) => {
+        child.on("error", reject);
+        child.on("close", (status) => resolve({ status, stdout, stderr }));
+    });
 }
 
 const LOCKFILE_WITH_PACKAGES = {
-  lockfileVersion: 3,
-  packages: {
-    "": { name: "fixture", version: "1.0.0" },
-    "node_modules/left-pad": { version: "1.3.0" },
-  },
+    lockfileVersion: 3,
+    packages: {
+        "": { name: "fixture", version: "1.0.0" },
+        "node_modules/left-pad": { version: "1.3.0" },
+    },
 };
 
 test("fails when the advisory services answer 200 with an error payload", async () => {
-  // Both services are the stub, so npm fails validation and the OSV fallback
-  // fails too. Passing here would mean shipping unaudited dependencies every
-  // time a proxy or a captive network sat in front of the registry.
-  const result = await runGate(LOCKFILE_WITH_PACKAGES);
-  notStrictEqual(result.status, 0, `expected non-zero exit\n${result.stderr}`);
-  strictEqual(result.stdout.includes("audit gate passed"), false);
+    // Both services are the stub, so npm fails validation and the OSV fallback
+    // fails too. Passing here would mean shipping unaudited dependencies every
+    // time a proxy or a captive network sat in front of the registry.
+    requests.length = 0;
+    respond = () => ({ status: 200, body: { error: "nope" } });
+    const result = await runGate(LOCKFILE_WITH_PACKAGES);
+    notStrictEqual(result.status, 0, `expected non-zero exit\n${result.stderr}`);
+    strictEqual(result.stdout.includes("audit gate passed"), false);
 });
 
 test("fails when the lockfile declares no packages, without calling out", async () => {
-  // An npm 6 lockfile (or a truncated one) yields zero queries, so every loop
-  // in the gate is skipped and it used to report a clean audit having made no
-  // network call at all.
-  requests.length = 0;
-  const result = await runGate({ lockfileVersion: 1, dependencies: {} });
-  notStrictEqual(result.status, 0, `expected non-zero exit\n${result.stderr}`);
-  strictEqual(result.stdout.includes("audit gate passed"), false);
-  strictEqual(result.stderr.includes("no resolved packages"), true);
-  // Nothing was consulted — which is exactly why it must not pass.
-  deepStrictEqual(requests, []);
+    // An npm 6 lockfile (or a truncated one) yields zero queries, so every loop
+    // in the gate is skipped and it used to report a clean audit having made no
+    // network call at all.
+    requests.length = 0;
+    respond = () => ({ status: 200, body: {} });
+    const result = await runGate({ lockfileVersion: 1, dependencies: {} });
+    notStrictEqual(result.status, 0, `expected non-zero exit\n${result.stderr}`);
+    strictEqual(result.stdout.includes("audit gate passed"), false);
+    strictEqual(result.stderr.includes("no resolved packages"), true);
+    // Nothing was consulted — which is exactly why it must not pass.
+    deepStrictEqual(requests, []);
+});
+
+// THE `{}` PROBLEM. An empty object is npm's legitimate answer for a clean
+// tree, so no shape check can separate it from an endpoint that does not
+// implement the route (a proxy, a mirror, the endpoint's retirement). The
+// canary is what separates them: the gate asks about a package it KNOWS is
+// vulnerable, and silence about that package is silence about everything.
+test("treats an empty npm answer as unsupported and falls through to OSV", async () => {
+    requests.length = 0;
+    respond = (url) => {
+        if (url === NPM_BULK_PATH) return { status: 200, body: {} };
+        if (url === "/querybatch")
+            // One query: the fixture has one package at one version.
+            return { status: 200, body: { results: [{}] } };
+        return { status: 200, body: {} };
+    };
+
+    const result = await runGate(LOCKFILE_WITH_PACKAGES);
+
+    strictEqual(result.status, 0, `expected a pass via OSV\n${result.stderr}`);
+    strictEqual(result.stdout.includes("audit gate passed"), true);
+    // It did not believe npm...
+    strictEqual(result.stderr.includes("canary"), true);
+    // ...and it actually asked the fallback instead.
+    strictEqual(
+        requests.some((request) => request.url === "/querybatch"),
+        true,
+    );
+});
+
+test("sends the canary in every npm batch and keeps it out of the findings", async () => {
+    requests.length = 0;
+    respond = (url) => {
+        if (url === NPM_BULK_PATH)
+            return { status: 200, body: { "adm-zip": [CANARY_ADVISORY] } };
+        return { status: 200, body: {} };
+    };
+
+    const result = await runGate(LOCKFILE_WITH_PACKAGES);
+
+    const bulk = requests.find((request) => request.url === NPM_BULK_PATH);
+    // The canary rides along with the workspace's real packages...
+    deepStrictEqual(bulk.body["adm-zip"], ["0.5.12"]);
+    deepStrictEqual(bulk.body["left-pad"], ["1.3.0"]);
+    // ...the answer is accepted, so OSV is never consulted...
+    strictEqual(
+        requests.some((request) => request.url === "/querybatch"),
+        false,
+    );
+    // ...and the canary's own high-severity advisory is stripped before the
+    // report is judged, so it is not reported against a tree that does not
+    // contain adm-zip at all.
+    strictEqual(result.status, 0, `expected a pass\n${result.stderr}`);
+    strictEqual(
+        result.stdout.includes("audit gate passed (0 high/critical advisories"),
+        true,
+    );
+});
+
+test("keeps the canary's advisory when the workspace really depends on it", async () => {
+    // Stripping unconditionally would blind the gate to the one package it
+    // uses as its probe — and word-addin genuinely ships adm-zip in its dev
+    // tree, which is why it has an allowlist entry.
+    requests.length = 0;
+    respond = (url) => {
+        if (url === NPM_BULK_PATH)
+            return { status: 200, body: { "adm-zip": [CANARY_ADVISORY] } };
+        return { status: 200, body: {} };
+    };
+
+    const result = await runGate({
+        lockfileVersion: 3,
+        packages: {
+            "": { name: "fixture", version: "1.0.0" },
+            "node_modules/adm-zip": { version: "0.5.12" },
+        },
+    });
+
+    strictEqual(result.status, 0, `expected a pass\n${result.stderr}`);
+    strictEqual(
+        result.stdout.includes("ALLOWLISTED high: GHSA-xcpc-8h2w-3j85"),
+        true,
+    );
+});
+
+test("fails when OSV answers fewer results than it was asked about", async () => {
+    // OSV's querybatch is positional. A short array used to be read as "the
+    // rest are clean", quietly dropping packages from the audit.
+    requests.length = 0;
+    respond = (url) => {
+        if (url === NPM_BULK_PATH) return { status: 200, body: {} };
+        if (url === "/querybatch") return { status: 200, body: { results: [] } };
+        return { status: 200, body: {} };
+    };
+
+    const result = await runGate(LOCKFILE_WITH_PACKAGES);
+
+    notStrictEqual(result.status, 0, `expected non-zero exit\n${result.stdout}`);
+    strictEqual(result.stdout.includes("audit gate passed"), false);
+    strictEqual(result.stderr.includes("OSV answered 0 of 1"), true);
+});
+
+test("fails on an advisory the FALLBACK found after npm went silent", async () => {
+    // The other half of the `{}` path. Falling through to OSV is only worth
+    // anything if the fallback's findings are then judged: a run that
+    // switched services and then printed "passed" over a real high-severity
+    // advisory would be the same silent pass in a new disguise.
+    requests.length = 0;
+    const advisoryId = "GHSA-1111-2222-3333";
+    respond = (url) => {
+        if (url === NPM_BULK_PATH) return { status: 200, body: {} };
+        if (url === "/querybatch")
+            return {
+                status: 200,
+                body: { results: [{ vulns: [{ id: advisoryId }] }] },
+            };
+        if (url === `/vulns/${advisoryId}`)
+            return {
+                status: 200,
+                body: {
+                    id: advisoryId,
+                    summary: "left-pad: pads left too enthusiastically",
+                    database_specific: { severity: "HIGH" },
+                },
+            };
+        return { status: 200, body: {} };
+    };
+
+    const result = await runGate(LOCKFILE_WITH_PACKAGES);
+
+    notStrictEqual(result.status, 0, `expected non-zero exit\n${result.stdout}`);
+    strictEqual(result.stdout.includes("audit gate passed"), false);
+    // Named, so the failure is actionable rather than just red.
+    strictEqual(result.stderr.includes(advisoryId), true);
 });


### PR DESCRIPTION
Review-fix child of #426, based on `feat/organization-access` so the diff reads as fixes on top of the PR. Draft on purpose.

## Summary

#426 was reviewed the way the earlier org PRs were: five read-only review agents over the diff, then the branch booted on an isolated local stack (upgrade-path database: `main` schema plus the two PR migrations, applied twice), then every serious finding replicated in Chrome or via the API, then fixes on this branch, then every replicated finding re-run against the fixed code. The evidence report is linked in the review comment.

Verdict on #426 as pushed: the model is coherent and the org lifecycle, last-admin guard, deny hiding and inherited access all work as described. It should not merge as is because of four blockers that were replicated live and three that were verified in code, all fixed here. The remaining items are product decisions, listed at the end.

## Replicated live, then fixed

| # | What a user experiences on #426 | On this branch |
|---|---|---|
| 1 | An org member **denied** on a matter opens "Add documents", types part of the matter or file name, and sees the matter's name and the document's filename, size and date in the picker, and can attach it. Bytes were still refused. | The picker's search applies the same deny verdict as every other route. Denied member sees nothing from the walled matter; owner and org admins still see everything. |
| 2 | The **only admin** of an org presses "Delete account". The app signs them out and shows the login page. The background job fails forever (trigger `org_member_protect_resource_ownership`), and they log straight back in. | The route answers 409 before destroying anything: "You are the only admin of Frank Solo LLP. Make another member an admin, or delete the organization, before deleting your account." The settings page shows it and keeps the session. The job path refuses terminally instead of retrying 20 times. |
| 3 | New-project wizard with a file attached: if the grant step fails, "Project created, but access was not granted" appears; clicking Create again uploads the file **again** (measured 1 document before the retry, 2 after). | Grants run before uploads and completed work is remembered: 0 documents before the retry, 1 after, grant applied. Same class fixed for reviews (a retry created a second review) and workflows. |
| 4 | `scripts/audit-gate.mjs` prints "audit gate passed" and exits 0 when the registry answers 200 with `{"error":...}` or `{}`, and when the lockfile has no `packages` map (no network call at all). `main`'s version exits 1 in the same situation. | Fails closed again: error bodies and non-array values are rejected, an empty package list exits, and at least one batch must have been answered. `node --test scripts/audit-gate.test.mjs` pins it. |
| 5 | A **viewer** who can open a project creates a folder and is told "Project not found" (404) instead of being refused. Thirteen write routes. | 404 only when the project is invisible; otherwise 403 with an intentional message that the client shows verbatim. |

![deny leak before/after](https://raw.githubusercontent.com/amal66/mike/assets/pr426-evidence-2026-09-04/pr426-deny-leak-before-after.gif)

*Before: denied member Bob sees "Matter P" and `secret-merger-agreement.docx` in his document picker. After: the same search shows nothing.*

![account delete before/after](https://raw.githubusercontent.com/amal66/mike/assets/pr426-evidence-2026-09-04/pr426-account-delete-before-after.gif)

*Before: Frank, sole admin, is back on the assistant page after "deleting" his account. After: the deletion is refused with the reason, session intact.*

![wizard retry before/after](https://raw.githubusercontent.com/amal66/mike/assets/pr426-evidence-2026-09-04/pr426-wizard-retry-before-after.gif)

*Before: one Create click plus one retry left two copies of the file. After: one copy.*

## Verified in code, then fixed

- **Migration 02 destroyed every direct share on a review inside a project** and then dropped the column. Those recipients are now archived to `tabular_review_legacy_shares` before the drop (see design decisions).
- **Heir auto-promotion**: deleting the sole admin promoted the earliest-joined member, and the DB trigger then erased that member's deny overrides, making a walled-off person an owner of the walled matter with no audit row. Removed; see the 409 above.
- **Zero-member org**: sole admin, no members, org owns content: the org was left with nobody in it, invisible and undeletable. Now refused.
- **Eight new tables never revoked from `anon`/`authenticated`** in the migration (schema.sql had it). The drift CI cannot see ACL drift because `reset_public()` drops the default privileges; that CI gap is not fixed here.
- **workflow_shares email case**: the only grant column without a lowercase CHECK; list lowered both sides, detail did not, so a legacy mixed-case row listed then 404'd. Deduped, lowercased, CHECK added, comparison fixed.
- **Creator's own email backfilled as an editor grant** on their own project (reads as "Shared with 1 user"). Excluded.
- **Document context, audit trail and async export** still decided access by `documents.user_id`. All three resolve per document now.
- **DELETE /single-documents/:id** by `user_id` only: an org owner could not delete a detached document. Uses the role model now.
- **Workflow share revoke** ignored its result (DB error and unknown id both 204); org share batches wrote partially. Fixed.
- **Frontend**: self-row Remove was an instant lockout and self role change always failed; the deny list was always collapsed with no count; the delete-org confirm outlived its modal and still deleted; self-demotion kept the admin UI; a sent invitation was reported as failed when the refresh failed; a failed invitations fetch rendered as "you have no invitations"; project-chat gates were creator-based and contradicted the server in both directions; refused renames and deletes were unhandled rejections; shared-chat citation pills did nothing; a new project chat was stamped Owner; `ModalUI` stole focus from the auto-focused field one frame after every modal opened.
- **e2e**: `critical-path` and `chat-management` were never migrated to the three-step wizard and would fail every CI run; two locators became strict-mode ambiguous after the new aria-label. One shared `createProject()` helper now.

## Design decisions taken here (stated so they can be vetoed)

1. **Refuse, do not promote.** Deleting an account that is the sole admin of an org with members or content is refused with a named org. The alternative on #426 silently escalated a possibly-denied member. If auto-promotion is wanted, it needs an audit row and must skip anyone holding a deny override.
2. **Archive, do not widen.** Contained-review shares that have no home in the new model go to `tabular_review_legacy_shares` (service_role only). Promoting them to project-level viewer grants would widen a one-review share into the whole matter.
3. **A chat share does not share its documents.** Recipients of a standalone chat see the transcript; citation pills now explain the refusal instead of doing nothing. Widening document access along a chat grant is a product call.
4. **403 wording** is intentional and shown verbatim by the client.

## Not addressed here (product decisions for the maintainer)

- **Outside counsel cannot be given any access to an organisation project.** `POST /projects/:id/access` on an org project accepts org members only (400 "Only current organization members can be assigned a role") and `validate_direct_access_scope` refuses the row at the DB. That is the case the #267 review asked for ("outside counsel as a viewer without joining the org"); the new model has no representation for it.
- **Every org member's global chat list now contains every colleague's chat in every org project**, with no scope filter. Not a leak, but a large undocumented product change.
- The org access editor only exposes **owner** and **deny**; editor/viewer overrides the API accepts are invisible and unrevocable in the UI.
- `PillButton` `sm`/`normal` were resized, changing about 98 existing buttons including the Word add-in's accept/reject row.
- Select-all under an access filter selects only the loaded page; the "Shared" filter returns org rows and there is no "Organisation" filter.
- `validate_direct_access_scope` takes `FOR UPDATE` on the project row to read an immutable column, so sharing and renaming block each other.
- The document-mutation tool gate in the chat routes is unreachable (chat standing can never exceed project standing) and its tests mock an impossible state.
- The org member typeahead in the access editor is mouse-only.

## Full Chrome run on this branch (5 September 2026)

Thirteen flows driven in a real browser against this branch with five accounts (Alice admin/creator, Dave second admin, Bob member, Carol outsider, Frank sole admin of his own org), one recording per flow. Every flow behaved as the model says. Four small defects surfaced and are fixed in the round-two commits below.

| # | Flow | Result |
|---|---|---|
| 1 | Create org, invite Member and Admin | ![](https://raw.githubusercontent.com/amal66/mike/assets/pr426-evidence-2026-09-04/run/flow-01-org-create-invite.gif) |
| 2 | Recipients accept from the Invites tab | ![](https://raw.githubusercontent.com/amal66/mike/assets/pr426-evidence-2026-09-04/run/flow-02-invitation-accept.gif) |
| 3 | Sole admin tries to demote themselves: confirm, then Postgres refuses | ![](https://raw.githubusercontent.com/amal66/mike/assets/pr426-evidence-2026-09-04/run/flow-03-last-admin-protection.gif) |
| 4 | Personal project sharing: own row read-only, Carol Viewer → Editor | ![](https://raw.githubusercontent.com/amal66/mike/assets/pr426-evidence-2026-09-04/run/flow-04-project-sharing-roles.gif) |
| 5 | Plain member creates a folder in the org matter (Editor by default) | ![](https://raw.githubusercontent.com/amal66/mike/assets/pr426-evidence-2026-09-04/run/flow-05-member-inheritance.gif) |
| 6 | Viewer: no Folder button, uploads disabled, delete refused with a contact | ![](https://raw.githubusercontent.com/amal66/mike/assets/pr426-evidence-2026-09-04/run/flow-06-viewer-read-only.gif) |
| 7 | Outsider pastes the org matter URL: Project not found | ![](https://raw.githubusercontent.com/amal66/mike/assets/pr426-evidence-2026-09-04/run/flow-07-outsider-denied.gif) |
| 8 | Deny list (1); Bob's tab becomes Project not found; matter leaves his list | ![](https://raw.githubusercontent.com/amal66/mike/assets/pr426-evidence-2026-09-04/run/flow-08-deny-wall.gif) |
| 9 | Shared chat: Viewer read-only with Shared marker, Editor can type, Share refused as owner-only | ![](https://raw.githubusercontent.com/amal66/mike/assets/pr426-evidence-2026-09-04/run/flow-09-shared-chat-roles.gif) |
| 10 | Org admin deletes a colleague's chat from the Chats tab | ![](https://raw.githubusercontent.com/amal66/mike/assets/pr426-evidence-2026-09-04/run/flow-10-admin-chat-delete.gif) |
| 11 | Standalone review shared as Viewer: Add Columns refused, "ask Alice" | ![](https://raw.githubusercontent.com/amal66/mike/assets/pr426-evidence-2026-09-04/run/flow-11-review-gating.gif) |
| 12 | Sole admin's account deletion refused with the reason, session kept | ![](https://raw.githubusercontent.com/amal66/mike/assets/pr426-evidence-2026-09-04/run/flow-12-sole-admin-delete-refused.gif) |
| 13 | Wizard retry after a refused grant leaves one document | ![](https://raw.githubusercontent.com/amal66/mike/assets/pr426-evidence-2026-09-04/run/flow-13-wizard-retry-idempotent.gif) |

Found during the run, fixed in round two:

- Add member modal listed an already-accepted invitation as Pending and the roster stayed stale until reload.
- A viewer's Upload menu disabled Saved files and Upload files but left Upload folder enabled.
- Deleting a colleague's chat from the project Chats tab had no confirmation.
- A review viewer could open and fill the New column modal; the "Editors only" refusal fired only on submit.

## Verification round (8 September 2026)

Four independent verifiers were pointed at the first twelve commits: a live backend attacker, a live migrations verifier, an audit-only reader of every commit, and a frontend verifier running every suite including the production build and the coverage ratchet. What they found is fixed in the last two commits, each pinned by tests shown to fail on the pre-fix source.

**Held under attack:** every deny-bypass vector tried (lists, detail, sub-resources, library search, chats, reviews, workflows, org inventory, audit, exports, upload sessions, forged download tokens, copy and import routes, cm_number and practice search, a direct grant inserted by SQL); the 403/404 split on the 13 fixed sites; account deletion in all five shapes plus a leave-then-delete race and a job inserted by hand; grant validation and the promote-clears-deny path; the workflow share batch, revoke semantics and the lowercase CHECK; fresh-versus-upgraded schema parity (identical fingerprints); the eight revokes proven effective against Supabase default privileges (TRUNCATE by `authenticated` succeeded before, is refused now); RLS on every org table; frontend typecheck, 1060 tests, lint, production build, and coverage floors.

**Found and fixed in round three:**

- A review viewer could start generation (cells written, audit event under the viewer); review chat, version delete and the non-project upload branch still answered 404 to a viewer who could see the resource.
- The sole-admin refusal inside the deletion job was retryable and ran after documents and storage were destroyed; the 409 sentence ignored the per-org reason.
- The document picker read overrides for every org project and still showed a creator who had left the org that org's project.
- Accessible project ids were unordered, unpaged and an N+1; the audit trail interpolated every reachable project id into one URL filter; document context asked one verdict per document; attach-from-documents omitted `org_id`; a failed creator-profile read was ignored.
- The org workflow share batch was a loop of upserts, not one write.
- The audit gate still passed on a registry answering `200 {}`; it now carries a canary package that must be echoed, OSV must answer every query, and CI runs the gate's own tests.
- Migration 02: creator exclusion now falls back to `auth.users`, the archive excludes self-shares, and the archive keeps its review id as a plain indexed column instead of a cascading foreign key.
- Frontend: sidebar still stamped Owner on project chats; the chat share modal could self-lock and lost the roster on a refused grants read; deleted documents in the owner's own chat were blamed on the sharer; two org roster fetches raced (a 3-member roster collapsed to 1 live); refresh failures were console-only; the delete confirm stayed live over a deleted org; a 4xx without detail leaked "API error: 409"; uploads keyed by filename; asset copies ran before grants; Back stayed enabled after a partial creation; viewers still saw enabled empty-state Upload and New subfolder; self-deny offered; deny list re-expanded; the Shared marker was under contrast; ConfirmPopup lacked a dialog role; one e2e locator was still ambiguous.
- Tests that passed on broken code were replaced with filter-aware stubs and `instanceof` assertions.

**Still open, with a reason:**

- The commit `7655a736` does not compile on its own (its chat.ts hunk lands one commit early); the branch builds at every later commit and the history was not rewritten to keep the review-fix diff stable.
- The last-admin trigger can reach zero admins under two concurrent demotions at `REPEATABLE READ`; the app runs `READ COMMITTED`, where it holds. Pre-existing in #426's migration 01; a one-line write to the org row would harden it.
- Two older migrations (`20260421_01_docx_editing`, `20260502_secure_user_api_keys`) never revoked their tables from `anon`/`authenticated` either, so the sentence "every earlier table-creating migration carries the revoke" in commit `818b7a4c` is overstated; the schema-drift job cannot see privilege drift because it drops the default privileges with the schema.
- `tabular_review_legacy_shares` is documented in `docs/deployment.md` but nothing in the product surfaces it to an upgrading operator.
- The design calls listed under "Not addressed here" are unchanged.

Gates at the tip: backend typecheck clean, 1448 tests passing (39 stack-gated skips); frontend typecheck clean, 1097 tests passing, lint 0 errors; add-in typecheck clean; audit-gate node tests 7/7; both migrations replayed twice on an upgraded scratch database and fingerprint-identical to a fresh install; `git diff --check` clean. Not re-run after round three: the Playwright suite and the production build (both green at ffbe6fff); the live stack was not rebooted after round three because the machine was under load, so round-three backend behaviour is pinned by route tests rather than re-driven in Chrome.

## Testing performed

- Backend: `npx tsc --noEmit` clean; `npx vitest run` 113 files / 1420 tests passed (6 files skipped: stack-gated).
- Frontend: `npx tsc --noEmit` clean; `npx vitest run` 148 files / 1060 tests passed (after round two); `npx eslint .` 0 errors.
- Word add-in: `npm run typecheck` clean.
- `node --test scripts/audit-gate.test.mjs` 2/2; stub registry returning `{"error":..}` now exits 1.
- Both migrations replayed twice on the upgraded database with `ON_ERROR_STOP=1`; a scratch fresh install of `schema.sql` compared object-by-object (functions, constraints, ACLs) against the upgraded database: identical.
- `git diff --check` clean.
- Playwright was not run here (needs the documented stack on :3100); the three touched specs typecheck.
- Full Chrome run of thirteen flows on this branch with five accounts (table above); the four defects it found are fixed in the last commit and one of them was re-verified live.

## Replication

**Base case on #426 (`28b8fb8a`)**, local stack, org with admin A and member B, org project P with one document, B denied on P via the Access modal:
1. As B: Assistant, "Add documents", Projects tab, type the file name. P and the file appear. (`GET /projects?view=directory-search&search=<name>` returns the row.)
2. As a user who is the only admin of an org that owns a project: Settings, Delete account, confirm. You land on the login page; `select status, last_error from db_jobs where kind='account.delete'` shows pending with "Database error deleting user"; log in again and it works.
3. New project, add a recipient on the Access step, attach a file, then `revoke insert on public.project_access_grants from service_role;` and click Create. "Project created, but access was not granted". `grant insert ...` back, click Create again. Two documents.
4. From `frontend/`: run a stub registry that answers `200 {"error":"nope"}` on :4599 and `npm_config_registry=http://127.0.0.1:4599 node ../scripts/audit-gate.mjs; echo $?` prints 0.

**On this branch**: step 1 shows nothing for B; step 2 shows "Account not deleted: You are the only admin of ..." and the session stays; step 3 leaves one document; step 4 exits 1 with "Both advisory services failed".

## Tradeoffs

- The 409 makes "delete my account" a two-step task for sole admins. That is the explicit alternative to silently handing the firm to somebody else.
- The archive table is one more object in the schema; it holds nothing on a fresh install and only what the old backfill would have thrown away on an upgrade.
- Grants-before-uploads means a refused grant now stops the wizard before any file leaves the browser; users who wanted the files regardless will retry once more.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J5Ja9B2yyXEAByq8YZMexw


