### PR TITLE
feat(auth): enterprise SSO sign-in via GoTrue SAML providers

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -66,6 +66,15 @@ UPLOAD_JOB_WALL_CLOCK_MS=900000
 SUPABASE_AUTH_EXTERNAL_GOOGLE_CLIENT_ID=
 SUPABASE_AUTH_EXTERNAL_GOOGLE_CLIENT_SECRET=
 
+# Enterprise SSO via Supabase Auth SAML providers (disabled by default).
+# Register providers in GoTrue first; see docs/deployment.md.
+SSO_ENABLED=false
+# Optional default domain skips the domain input.
+SSO_DEFAULT_DOMAIN=
+SSO_BUTTON_LABEL=Single sign-on
+# Optional comma-separated exact domain allowlist (no wildcards).
+SSO_ALLOWED_DOMAINS=
+
 R2_ENDPOINT_URL=https://your-account-id.r2.cloudflarestorage.com
 # Optional browser-reachable endpoint used only when signing direct-upload
 # URLs. Required when R2_ENDPOINT_URL is an internal Docker hostname.

--- a/backend/src/lib/__tests__/ssoSession.test.ts
+++ b/backend/src/lib/__tests__/ssoSession.test.ts
@@ -1,0 +1,65 @@
+import express from "express";
+import request from "supertest";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createRequestSupabase } from "../authSession";
+
+// Exercise the real SSR/Auth SDK; only the upstream HTTP boundary is mocked.
+describe("SSO PKCE session", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.unstubAllEnvs();
+  });
+
+  it("sends a PKCE challenge and persists an HttpOnly verifier for the callback", async () => {
+    vi.stubEnv("NODE_ENV", "production");
+    vi.stubEnv("SUPABASE_URL", "https://auth.example.test");
+    vi.stubEnv("SUPABASE_PUBLISHABLE_KEY", "test-key");
+    const upstream = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ url: "https://idp.example/saml" }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+    vi.stubGlobal("fetch", upstream);
+    const app = express();
+    app.post("/sso", async (req, res) => {
+      const client = createRequestSupabase(req, res);
+      const { data, error } = await client.auth.signInWithSSO({
+        domain: "example.com",
+        options: {
+          redirectTo: "https://app.example.test/auth/callback",
+          skipBrowserRedirect: true,
+        },
+      });
+      if (error) return res.status(500).end();
+      return res.json(data);
+    });
+    const response = await request(app)
+      .post("/sso")
+      .set("Origin", "https://app.example.test");
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({ url: "https://idp.example/saml" });
+    expect(upstream).toHaveBeenCalledTimes(1);
+    const [url, init] = upstream.mock.calls[0];
+    expect(url).toBe("https://auth.example.test/auth/v1/sso");
+    const body = JSON.parse(init.body);
+    expect(body).toMatchObject({
+      domain: "example.com",
+      skip_http_redirect: true,
+      code_challenge_method: "s256",
+    });
+    expect(body.code_challenge).toMatch(/^[A-Za-z0-9_-]{43}$/);
+    expect(body.redirect_to).toContain(
+      "https://app.example.test/auth/callback",
+    );
+    const cookies = response.headers["set-cookie"] as unknown as string[];
+    const verifier = cookies.find((cookie) =>
+      cookie.includes("-code-verifier="),
+    );
+    expect(verifier).toContain("__Host-mike-session");
+    expect(verifier).toContain("HttpOnly");
+    expect(verifier).toContain("Secure");
+    expect(verifier).toContain("SameSite=Lax");
+    expect(verifier).toContain("Path=/");
+  });
+});

--- a/backend/src/lib/ssoConfig.ts
+++ b/backend/src/lib/ssoConfig.ts
@@ -1,0 +1,44 @@
+import { z } from "zod";
+
+// Accept DNS domains only, never email addresses, URLs, wildcards or ports.
+export const ssoDomainSchema = z
+  .string()
+  .trim()
+  .toLowerCase()
+  .max(253)
+  .regex(
+    /^(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.)+[a-z](?:[a-z0-9-]{0,61}[a-z0-9])?$/,
+  );
+
+export function ssoConfiguration(env: NodeJS.ProcessEnv = process.env) {
+  const enabled = env.SSO_ENABLED?.trim().toLowerCase() === "true";
+  if (!enabled) {
+    return {
+      enabled: false,
+      buttonLabel: "Single sign-on",
+      defaultDomain: null,
+      allowedDomains: null,
+    };
+  }
+  const defaultDomain = env.SSO_DEFAULT_DOMAIN?.trim()
+    ? ssoDomainSchema.parse(env.SSO_DEFAULT_DOMAIN)
+    : null;
+  const allowedDomains = env.SSO_ALLOWED_DOMAINS?.trim()
+    ? env.SSO_ALLOWED_DOMAINS.split(",").map((domain) =>
+        ssoDomainSchema.parse(domain),
+      )
+    : null;
+  if (
+    defaultDomain &&
+    allowedDomains &&
+    !allowedDomains.includes(defaultDomain)
+  ) {
+    throw new Error("SSO default domain must be allowed");
+  }
+  return {
+    enabled,
+    buttonLabel: env.SSO_BUTTON_LABEL?.trim() || "Single sign-on",
+    defaultDomain,
+    allowedDomains,
+  };
+}

--- a/backend/src/routes/__tests__/auth.test.ts
+++ b/backend/src/routes/__tests__/auth.test.ts
@@ -16,6 +16,7 @@ const {
       signInWithPassword: vi.fn(),
       signUp: vi.fn(),
       signInWithOAuth: vi.fn(),
+      signInWithSSO: vi.fn(),
       exchangeCodeForSession: vi.fn(),
       resetPasswordForEmail: vi.fn(),
       signOut: vi.fn(),
@@ -79,6 +80,13 @@ describe("auth routes", () => {
     process.env.FRONTEND_URL = origin;
     process.env.NODE_ENV = "production";
     delete process.env.WORD_ADDIN_URL;
+    for (const key of [
+      "SSO_ENABLED",
+      "SSO_DEFAULT_DOMAIN",
+      "SSO_ALLOWED_DOMAINS",
+      "SSO_BUTTON_LABEL",
+    ])
+      delete process.env[key];
     createRequestSupabase.mockReset().mockReturnValue(authClient);
     clearRequestAuthCookies.mockReset();
     issueAuthHandoff.mockReset();
@@ -150,6 +158,181 @@ describe("auth routes", () => {
         skipBrowserRedirect: true,
       },
     });
+  });
+
+  it("disables SSO by default and exposes only public settings", async () => {
+    const config = await request(app).get("/auth/config");
+    expect(config.body).toEqual({
+      ssoEnabled: false,
+      ssoButtonLabel: "Single sign-on",
+      ssoDomainRequired: false,
+    });
+    expect(config.headers["cache-control"]).toBe("private, no-store");
+    const response = await request(app)
+      .post("/auth/oauth")
+      .set("Origin", origin)
+      .send({ provider: "sso", domain: "example.com" });
+    expect(response.status).toBe(403);
+    expect(createRequestSupabase).not.toHaveBeenCalled();
+  });
+
+  it("uses a normalized default domain and the shared callback", async () => {
+    process.env.SSO_ENABLED = "true";
+    process.env.SSO_DEFAULT_DOMAIN = " Example.COM ";
+    process.env.SSO_ALLOWED_DOMAINS = "example.com, other.example";
+    process.env.SSO_BUTTON_LABEL = "Company login";
+    authClient.auth.signInWithSSO.mockResolvedValue({
+      data: { url: "https://idp.example/saml" },
+      error: null,
+    });
+    const config = await request(app).get("/auth/config");
+    expect(config.body).toEqual({
+      ssoEnabled: true,
+      ssoButtonLabel: "Company login",
+      ssoDomainRequired: false,
+    });
+    const response = await request(app)
+      .post("/auth/oauth")
+      .set("Origin", origin)
+      .send({
+        provider: "sso",
+        next: "//attacker.example",
+        callbackPath: "https://attacker.example",
+      });
+    expect(response.body).toEqual({ url: "https://idp.example/saml" });
+    expect(authClient.auth.signInWithSSO).toHaveBeenCalledWith({
+      domain: "example.com",
+      options: {
+        redirectTo: `${origin}/auth/callback?next=%2Fonboarding%2Fprofile`,
+        skipBrowserRedirect: true,
+      },
+    });
+  });
+
+  it("requests a domain when no default exists and allows a permitted override", async () => {
+    process.env.SSO_ENABLED = "true";
+    expect(
+      (await request(app).get("/auth/config")).body.ssoDomainRequired,
+    ).toBe(true);
+    const missing = await request(app)
+      .post("/auth/oauth")
+      .set("Origin", origin)
+      .send({ provider: "sso" });
+    expect(missing.body.code).toBe("sso_domain_required");
+    process.env.SSO_DEFAULT_DOMAIN = "default.example";
+    process.env.SSO_ALLOWED_DOMAINS = "default.example,other.example";
+    authClient.auth.signInWithSSO.mockResolvedValue({
+      data: { url: "https://idp.example/saml" },
+      error: null,
+    });
+    const response = await request(app)
+      .post("/auth/oauth")
+      .set("Origin", origin)
+      .send({ provider: "sso", domain: " OTHER.EXAMPLE ", next: "/projects" });
+    expect(response.status).toBe(200);
+    expect(authClient.auth.signInWithSSO).toHaveBeenCalledWith(
+      expect.objectContaining({
+        domain: "other.example",
+        options: expect.objectContaining({
+          redirectTo: `${origin}/auth/callback?next=%2Fprojects`,
+        }),
+      }),
+    );
+  });
+
+  it.each([
+    "",
+    "user@example.com",
+    "https://example.com",
+    "*.example.com",
+    "example.com:443",
+    "-bad.example",
+    "example..com",
+    123,
+    null,
+    "a".repeat(64) + ".com",
+  ])("rejects invalid SSO domain %s", async (domain) => {
+    process.env.SSO_ENABLED = "true";
+    const response = await request(app)
+      .post("/auth/oauth")
+      .set("Origin", origin)
+      .send({ provider: "sso", domain });
+    expect(response.status).toBe(400);
+    expect(createRequestSupabase).not.toHaveBeenCalled();
+  });
+
+  it("enforces exact domain allowlisting and trusted origins", async () => {
+    process.env.SSO_ENABLED = "true";
+    process.env.SSO_ALLOWED_DOMAINS = "example.com";
+    for (const domain of [
+      "other.example",
+      "sub.example.com",
+      "example.com.evil.test",
+    ]) {
+      const response = await request(app)
+        .post("/auth/oauth")
+        .set("Origin", origin)
+        .send({ provider: "sso", domain });
+      expect(response.body.code).toBe("sso_domain_not_allowed");
+    }
+    const response = await request(app)
+      .post("/auth/oauth")
+      .set("Origin", "https://attacker.example")
+      .send({ provider: "sso", domain: "example.com" });
+    expect(response.status).toBe(403);
+    expect(createRequestSupabase).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    { SSO_DEFAULT_DOMAIN: "https://bad.example" },
+    { SSO_ALLOWED_DOMAINS: "example.com,,other.example" },
+    { SSO_DEFAULT_DOMAIN: "other.example", SSO_ALLOWED_DOMAINS: "example.com" },
+  ])("fails closed for invalid configuration %s", async (env) => {
+    Object.assign(process.env, env, { SSO_ENABLED: "true" });
+    const response = await request(app)
+      .post("/auth/oauth")
+      .set("Origin", origin)
+      .send({ provider: "sso", domain: "example.com" });
+    expect(response.status).toBe(500);
+    expect(response.body.code).toBe("internal_error");
+    expect((await request(app).get("/auth/config")).status).toBe(500);
+    expect(createRequestSupabase).not.toHaveBeenCalled();
+  });
+
+  it.each([400, 404, 429, 500])(
+    "sanitizes provider errors (%s)",
+    async (status) => {
+      process.env.SSO_ENABLED = "true";
+      authClient.auth.signInWithSSO.mockResolvedValue({
+        data: null,
+        error: { status, message: "private provider diagnostics" },
+      });
+      const response = await request(app)
+        .post("/auth/oauth")
+        .set("Origin", origin)
+        .send({ provider: "sso", domain: "example.com" });
+      expect(response.status).toBe(status < 500 ? 400 : 500);
+      expect(response.text).not.toContain("private provider diagnostics");
+    },
+  );
+
+  it("sanitizes thrown failures and missing redirects", async () => {
+    process.env.SSO_ENABLED = "true";
+    authClient.auth.signInWithSSO.mockRejectedValueOnce(
+      new Error("private diagnostics"),
+    );
+    authClient.auth.signInWithSSO.mockResolvedValueOnce({
+      data: {},
+      error: null,
+    });
+    for (let i = 0; i < 2; i++) {
+      const response = await request(app)
+        .post("/auth/oauth")
+        .set("Origin", origin)
+        .send({ provider: "sso", domain: "example.com" });
+      expect(response.status).toBe(500);
+      expect(response.text).not.toContain("private diagnostics");
+    }
   });
 
   it("does not reveal whether a password-reset email exists", async () => {

--- a/backend/src/routes/auth.ts
+++ b/backend/src/routes/auth.ts
@@ -10,6 +10,8 @@ import { consumeAuthHandoff, issueAuthHandoff } from "../lib/authHandoff";
 import { requestOriginIsWordAddin } from "../lib/origins";
 import { requireAuth } from "../middleware/auth";
 import { requireTrustedOrigin } from "../middleware/trustedOrigin";
+import { ssoConfiguration, ssoDomainSchema } from "../lib/ssoConfig";
+import { sendInternalError } from "../lib/httpError";
 
 export const authRouter = Router();
 
@@ -184,7 +186,87 @@ authRouter.post("/signup", async (req, res) => {
   }
 });
 
+// Public presentation settings only; provider administration remains in GoTrue.
+authRouter.get("/config", (_req, res) => {
+  try {
+    const config = ssoConfiguration();
+    res.json({
+      ssoEnabled: config.enabled,
+      ssoButtonLabel: config.buttonLabel,
+      ssoDomainRequired: config.enabled && !config.defaultDomain,
+    });
+  } catch {
+    // Do not pass configuration values or provider diagnostics to the logger.
+    sendInternalError(res, new Error("Invalid SSO configuration"));
+  }
+});
+
+const ssoRequestSchema = z.object({
+  provider: z.literal("sso"),
+  domain: ssoDomainSchema.optional(),
+});
+
+async function startSso(req: Request, res: Response) {
+  try {
+    const config = ssoConfiguration();
+    if (!config.enabled) {
+      return res
+        .status(403)
+        .json({
+          code: "sso_disabled",
+          detail: "Single sign-on is not enabled.",
+        });
+    }
+    const parsed = ssoRequestSchema.safeParse(req.body);
+    if (!parsed.success) return invalidBody(res);
+    const domain = parsed.data.domain ?? config.defaultDomain;
+    if (!domain) {
+      return res
+        .status(400)
+        .json({
+          code: "sso_domain_required",
+          detail: "Enter your organization's domain.",
+        });
+    }
+    if (config.allowedDomains && !config.allowedDomains.includes(domain)) {
+      return res
+        .status(400)
+        .json({
+          code: "sso_domain_not_allowed",
+          detail: "Single sign-on is not available for this domain.",
+        });
+    }
+    const client = createRequestSupabase(req, res);
+    const { data, error } = await client.auth.signInWithSSO({
+      domain,
+      options: {
+        redirectTo: callbackUrl(req, req.body?.next, "/onboarding/profile"),
+        skipBrowserRedirect: true,
+      },
+    });
+    if (error) {
+      if (error.status && error.status >= 400 && error.status < 500) {
+        return res
+          .status(400)
+          .json({
+            code: "sso_unavailable",
+            detail: "Unable to start single sign-on for this domain.",
+          });
+      }
+      throw new Error("SSO provider request failed");
+    }
+    if (!data?.url) throw new Error("Missing SSO redirect");
+    return res.json({ url: data.url });
+  } catch {
+    return sendInternalError(
+      res,
+      new Error("SSO sign-in could not be started"),
+    );
+  }
+}
+
 authRouter.post("/oauth", async (req, res) => {
+  if (req.body?.provider === "sso") return startSso(req, res);
   if (req.body?.provider !== "google") return invalidBody(res);
   try {
     const client = createRequestSupabase(req, res);

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -58,6 +58,11 @@ services:
       GOTRUE_EXTERNAL_GOOGLE_CLIENT_ID: ${GOTRUE_EXTERNAL_GOOGLE_CLIENT_ID:-}
       GOTRUE_EXTERNAL_GOOGLE_SECRET: ${GOTRUE_EXTERNAL_GOOGLE_SECRET:-}
       GOTRUE_EXTERNAL_GOOGLE_REDIRECT_URI: ${SUPABASE_PUBLIC_URL:-http://localhost:54321}/auth/v1/callback
+      # Enterprise SAML is opt-in. Set these in the Compose environment/root
+      # .env (not backend/.env); see docs/deployment.md for provider setup.
+      # GOTRUE_SAML_ENABLED: "true"
+      # GOTRUE_SAML_PRIVATE_KEY: ${GOTRUE_SAML_PRIVATE_KEY:-}
+      # GOTRUE_SAML_EXTERNAL_URL: ${SUPABASE_PUBLIC_URL:-http://localhost:54321}/auth/v1
       # Keep local signup frictionless by default. Set this to false to exercise
       # the confirmation-email flow; the message will be caught by Mailpit.
       GOTRUE_MAILER_AUTOCONFIRM: ${GOTRUE_MAILER_AUTOCONFIRM:-true}

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -218,6 +218,135 @@ HttpOnly cookie. No Supabase access or refresh token enters add-in JavaScript or
 OfficeRuntime storage. The add-in also does not retain Google's provider access
 token or request Google Drive or Gmail access.
 
+## Enterprise SSO (SAML)
+
+Self-hosted Mike can use SAML providers registered in Supabase Auth (GoTrue),
+including Okta, Microsoft Entra ID, and Google Workspace SAML. The login and
+signup pages offer SSO when enabled. The existing email/password and Google
+methods remain available; this feature does not enforce SSO-only access.
+
+### Configure GoTrue
+
+For the Compose GoTrue service, uncomment the SAML environment entries in
+`docker-compose.yml`. Set `GOTRUE_SAML_ENABLED=true`, provide
+`GOTRUE_SAML_PRIVATE_KEY`, and set `GOTRUE_SAML_EXTERNAL_URL` to the public Auth
+base URL, for example `https://auth.example.com/auth/v1`. The `/auth/v1` suffix
+is required behind the Compose gateway: GoTrue appends `/sso/saml/acs` and
+`/sso/saml/metadata` to this base. Keep `SUPABASE_PUBLIC_URL` as the gateway
+origin. Configure these values in the root Compose `.env` or shell environment;
+`backend/.env` is loaded by the backend service, not the Auth service.
+
+The pinned GoTrue version expects a standard base64-encoded **PKCS#1 DER RSA
+private key** (at least 2048 bits), not PEM or PKCS#8. With OpenSSL 3:
+
+```bash
+umask 077
+openssl genrsa -traditional -out saml-private.pem 2048
+openssl rsa -in saml-private.pem -traditional -outform DER -out saml-private.der
+openssl base64 -A -in saml-private.der -out saml-private.base64
+```
+
+Put the base64 file's contents in `GOTRUE_SAML_PRIVATE_KEY` using your deployment
+secret store. Keep the key stable across restarts and replicas; rotating it
+requires updating the IdP's trust configuration. Keep all key files outside the
+repository. Restart the Auth service after configuring SAML.
+
+In GoTrue, set `GOTRUE_SITE_URL` to the deployed frontend origin and restrict
+`GOTRUE_URI_ALLOW_LIST` to the frontend's `/auth/callback` URL (plus existing
+required callbacks). Replace the permissive local Compose allowlist for a
+public deployment. For hosted Supabase, use its SAML provider setup and URL
+configuration instead of configuring GoTrue container variables.
+
+### Register an identity provider
+
+Import the service provider metadata from:
+
+```text
+https://auth.example.com/auth/v1/sso/saml/metadata
+```
+
+Use its entity ID/audience and assertion consumer service (ACS) URL in your
+IdP. The ACS is `https://auth.example.com/auth/v1/sso/saml/acs`, not Mike's
+frontend callback. Configure the IdP to supply an email attribute and assign
+the intended users or groups to the application.
+
+For example, create a SAML 2.0 application in Okta, set its Single sign-on URL
+to the ACS and Audience URI to the metadata entity ID, and add an `email`
+attribute containing the user's email. Obtain the IdP metadata URL. Entra ID
+enterprise applications and Google Workspace custom SAML applications use the
+same service provider metadata; export their IdP metadata XML if they do not
+provide a publicly fetchable HTTPS metadata URL.
+
+Register the provider through GoTrue's admin API from a trusted administrative
+machine. Replace these placeholders; the bearer token must be an administrative
+`service_role` JWT, never a browser credential:
+
+```bash
+curl --fail-with-body --request POST \
+  'https://auth.example.com/auth/v1/admin/sso/providers' \
+  --header 'Authorization: Bearer <SERVICE_ROLE_JWT>' \
+  --header 'apikey: <SERVICE_ROLE_JWT>' \
+  --header 'Content-Type: application/json' \
+  --data '{
+    "type": "saml",
+    "metadata_url": "https://idp.example.com/app/metadata",
+    "domains": ["example.com"],
+    "attribute_mapping": {"keys": {"email": {"name": "email"}}}
+  }'
+```
+
+Use `metadata_xml` instead of `metadata_url` when importing XML. Match the
+attribute mapping to the IdP's actual attribute name. The `domains` field maps
+an exact domain to this provider; add all domains your users will enter. List
+providers with `GET /auth/v1/admin/sso/providers`; use
+`PUT /auth/v1/admin/sso/providers/<provider-id>` to update an existing provider
+instead of repeating creation. Keep admin access restricted.
+
+### Enable Mike and verify sign-in
+
+Set these in `backend/.env` (or the backend service environment), then restart
+the backend. No frontend rebuild is needed:
+
+```dotenv
+SSO_ENABLED=true
+SSO_DEFAULT_DOMAIN=example.com
+SSO_BUTTON_LABEL=Single sign-on
+SSO_ALLOWED_DOMAINS=example.com
+```
+
+`SSO_ENABLED` defaults to false and enables only with `true` (case-insensitive).
+Omit `SSO_DEFAULT_DOMAIN` to show a domain input. Domains are trimmed and
+normalized to lowercase; use DNS names, or punycode for international domains,
+not email addresses or URLs. `SSO_ALLOWED_DOMAINS` is an optional comma-separated
+list of exact domains; it also applies to the default. Invalid domain settings
+fail closed. Omitting the allowlist permits any domain registered in GoTrue.
+The allowlist controls Mike's sign-in initiation, not account authorization or
+direct access to GoTrue; enforce membership and access policy at the IdP and
+Auth service.
+
+Mike calls GoTrue's `/sso` API using the server-side Supabase SDK, which sends
+`skip_http_redirect: true` and a PKCE challenge. After IdP authentication,
+GoTrue redirects to Mike's existing `/auth/callback`; the backend exchanges
+the code using its HttpOnly verifier cookie and establishes the normal session.
+Start sign-in from Mike in the same browser; IdP-initiated flows are outside
+this integration. The Word add-in's existing authentication remains unchanged.
+
+Before inviting users, verify the metadata contains the public ACS URL, try
+both an assigned and an unassigned IdP user, confirm return to onboarding or
+the app, and confirm logout and an unapproved domain behave as expected. SAML
+identities can be separate accounts from existing email/Google identities; do
+not assume matching emails link accounts or transfer project access.
+
+Cloudflare Access or IAP in front of Mike is complementary perimeter access
+control. It does not establish Mike's Supabase session and is not a substitute
+for this SAML integration. Ensure the IdP/browser can reach the required SAML
+endpoints through any perimeter controls.
+
+References: [Supabase signInWithSSO](https://supabase.com/docs/reference/javascript/auth-signinwithsso),
+[GoTrue SSO API](https://github.com/supabase/auth/blob/v2.189.0/internal/api/sso.go),
+[SAML configuration](https://github.com/supabase/auth/blob/v2.189.0/internal/conf/saml.go),
+and [provider administration](https://github.com/supabase/auth/blob/v2.189.0/internal/api/ssoadmin.go).
+
 ## Install and run
 
 Install dependencies:

--- a/frontend/src/app/components/auth/SsoAuthButton.test.tsx
+++ b/frontend/src/app/components/auth/SsoAuthButton.test.tsx
@@ -1,0 +1,117 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { SsoAuthButton } from "./SsoAuthButton";
+
+const { getAuthConfiguration, startSso } = vi.hoisted(() => ({
+    getAuthConfiguration: vi.fn(),
+    startSso: vi.fn(),
+}));
+vi.mock("@/app/lib/authApi", () => ({ getAuthConfiguration, startSso }));
+
+describe("SsoAuthButton", () => {
+    beforeEach(() => {
+        vi.resetAllMocks();
+        getAuthConfiguration.mockResolvedValue({
+            ssoEnabled: true,
+            ssoButtonLabel: "Single sign-on",
+            ssoDomainRequired: false,
+        });
+        startSso.mockResolvedValue({ url: "https://idp.example/saml" });
+    });
+
+    it("stays hidden while settings load and when disabled", async () => {
+        getAuthConfiguration.mockResolvedValue({ ssoEnabled: false });
+        const { container } = render(<SsoAuthButton onError={vi.fn()} />);
+        expect(container).toBeEmptyDOMElement();
+        await waitFor(() => expect(getAuthConfiguration).toHaveBeenCalled());
+        expect(container).toBeEmptyDOMElement();
+    });
+
+    it("stays hidden if settings cannot load", async () => {
+        getAuthConfiguration.mockRejectedValue(new Error("offline"));
+        const { container } = render(<SsoAuthButton onError={vi.fn()} />);
+        await waitFor(() => expect(getAuthConfiguration).toHaveBeenCalled());
+        expect(container).toBeEmptyDOMElement();
+    });
+
+    it("uses the deployment label and default domain without an input", async () => {
+        getAuthConfiguration.mockResolvedValue({
+            ssoEnabled: true,
+            ssoButtonLabel: "Company login",
+            ssoDomainRequired: false,
+        });
+        const onLoadingChange = vi.fn();
+        render(
+            <SsoAuthButton
+                onError={vi.fn()}
+                onLoadingChange={onLoadingChange}
+            />,
+        );
+        const button = await screen.findByRole("button", {
+            name: "Company login",
+        });
+        expect(button).toHaveAttribute("type", "button");
+        expect(screen.queryByRole("textbox")).not.toBeInTheDocument();
+        await userEvent.click(button);
+        expect(startSso).toHaveBeenCalledWith("/onboarding/profile", undefined);
+        expect(onLoadingChange).toHaveBeenCalledWith(true);
+        expect(
+            screen.getByRole("button", { name: "Continuing…" }),
+        ).toBeDisabled();
+    });
+
+    it("requires a domain and handles Enter without submitting the password form", async () => {
+        getAuthConfiguration.mockResolvedValue({
+            ssoEnabled: true,
+            ssoButtonLabel: "Single sign-on",
+            ssoDomainRequired: true,
+        });
+        const onSubmit = vi.fn((event) => event.preventDefault());
+        render(
+            <form onSubmit={onSubmit}>
+                <SsoAuthButton onError={vi.fn()} />
+            </form>,
+        );
+        const input = await screen.findByRole("textbox", {
+            name: "Organization domain",
+        });
+        expect(screen.getByRole("button")).toBeDisabled();
+        await userEvent.type(input, " example.com {Enter}");
+        expect(startSso).toHaveBeenCalledWith(
+            "/onboarding/profile",
+            "example.com",
+        );
+        expect(onSubmit).not.toHaveBeenCalled();
+    });
+
+    it("respects the parent loading state", async () => {
+        render(<SsoAuthButton onError={vi.fn()} disabled />);
+        expect(await screen.findByRole("button")).toBeDisabled();
+    });
+
+    it.each([
+        [
+            new Error("private diagnostics"),
+            "Unable to start single sign-on. Please try again.",
+        ],
+        [
+            { code: "sso_domain_not_allowed", message: "private diagnostics" },
+            "Single sign-on is not available for this domain.",
+        ],
+    ])("shows intentional errors and permits retry", async (error, message) => {
+        startSso.mockRejectedValue(error);
+        const onError = vi.fn();
+        const onLoadingChange = vi.fn();
+        render(
+            <SsoAuthButton
+                onError={onError}
+                onLoadingChange={onLoadingChange}
+            />,
+        );
+        await userEvent.click(await screen.findByRole("button"));
+        expect(onError).toHaveBeenLastCalledWith(message);
+        expect(onLoadingChange).toHaveBeenLastCalledWith(false);
+        expect(screen.getByRole("button")).toBeEnabled();
+    });
+});

--- a/frontend/src/app/components/auth/SsoAuthButton.tsx
+++ b/frontend/src/app/components/auth/SsoAuthButton.tsx
@@ -1,0 +1,132 @@
+"use client";
+
+import { useEffect, useId, useState } from "react";
+import { Building2, Loader2 } from "lucide-react";
+import { PillButton } from "@/app/components/ui/pill-button";
+import { Input } from "@/app/components/ui/input";
+import { FieldLabel } from "@/app/components/ui/form-field";
+import { authInputClassName } from "./authStyles";
+import {
+    getAuthConfiguration,
+    startSso,
+    type AuthConfiguration,
+} from "@/app/lib/authApi";
+import { knownErrorCodeMessage } from "@/app/lib/userFacingError";
+
+interface SsoAuthButtonProps {
+    onError: (message: string) => void;
+    disabled?: boolean;
+    onLoadingChange?: (loading: boolean) => void;
+}
+
+export function SsoAuthButton({
+    onError,
+    disabled = false,
+    onLoadingChange,
+}: SsoAuthButtonProps) {
+    const domainId = useId();
+    const [config, setConfig] = useState<AuthConfiguration | null>(null);
+    const [domain, setDomain] = useState("");
+    const [loading, setLoading] = useState(false);
+
+    useEffect(() => {
+        let cancelled = false;
+        void getAuthConfiguration()
+            .then((value) => {
+                if (!cancelled) setConfig(value);
+            })
+            .catch(() => {
+                // Optional sign-in method: leave existing login available on failure.
+            });
+        return () => {
+            cancelled = true;
+        };
+    }, []);
+
+    if (!config?.ssoEnabled) return null;
+
+    const handleSso = async () => {
+        setLoading(true);
+        onLoadingChange?.(true);
+        onError("");
+        try {
+            const { url } = await startSso(
+                "/onboarding/profile",
+                config.ssoDomainRequired ? domain.trim() : undefined,
+            );
+            window.location.assign(url);
+        } catch (error) {
+            onError(
+                knownErrorCodeMessage(
+                    error,
+                    {
+                        invalid_request: "Enter a domain such as example.com.",
+                        sso_domain_required:
+                            "Enter your organization's domain.",
+                        sso_domain_not_allowed:
+                            "Single sign-on is not available for this domain.",
+                        sso_disabled: "Single sign-on is not enabled.",
+                        sso_unavailable:
+                            "Unable to start single sign-on for this domain.",
+                    },
+                    "Unable to start single sign-on. Please try again.",
+                ),
+            );
+            setLoading(false);
+            onLoadingChange?.(false);
+        }
+    };
+
+    return (
+        <div className="space-y-3">
+            {config.ssoDomainRequired && (
+                <div>
+                    <FieldLabel htmlFor={domainId}>
+                        Organization domain
+                    </FieldLabel>
+                    <Input
+                        id={domainId}
+                        type="text"
+                        placeholder="example.com"
+                        autoCapitalize="none"
+                        spellCheck={false}
+                        value={domain}
+                        onChange={(event) => setDomain(event.target.value)}
+                        onKeyDown={(event) => {
+                            if (event.key === "Enter") {
+                                event.preventDefault();
+                                if (domain.trim() && !disabled && !loading)
+                                    void handleSso();
+                            }
+                        }}
+                        disabled={disabled || loading}
+                        className={authInputClassName}
+                    />
+                </div>
+            )}
+            <PillButton
+                type="button"
+                tone="white"
+                size="normal"
+                className="w-full"
+                disabled={
+                    disabled ||
+                    loading ||
+                    (config.ssoDomainRequired && !domain.trim())
+                }
+                aria-busy={loading}
+                onClick={() => void handleSso()}
+            >
+                {loading ? (
+                    <Loader2
+                        aria-hidden="true"
+                        className="h-4 w-4 animate-spin"
+                    />
+                ) : (
+                    <Building2 aria-hidden="true" className="h-4 w-4" />
+                )}
+                {loading ? "Continuing…" : config.ssoButtonLabel}
+            </PillButton>
+        </div>
+    );
+}

--- a/frontend/src/app/lib/authApi.test.ts
+++ b/frontend/src/app/lib/authApi.test.ts
@@ -7,6 +7,7 @@ import {
     enrollMfa,
     exchangeAuthCode,
     getAuthSession,
+    getAuthConfiguration,
     getMfaAssurance,
     listMfaFactors,
     login,
@@ -14,6 +15,7 @@ import {
     requestPasswordReset,
     signup,
     startGoogleOAuth,
+    startSso,
     unenrollMfa,
     updateAuthEmail,
     updateAuthPassword,
@@ -136,7 +138,37 @@ describe("cookie auth client", () => {
         await expect(logout()).resolves.toBeUndefined();
     });
 
+    it("loads public auth configuration without caching", async () => {
+        const config = {
+            ssoEnabled: true,
+            ssoButtonLabel: "Company login",
+            ssoDomainRequired: true,
+        };
+        fetchMock.mockResolvedValue(
+            new Response(JSON.stringify(config), { status: 200 }),
+        );
+        await expect(getAuthConfiguration()).resolves.toEqual(config);
+        expect(fetchMock).toHaveBeenCalledWith(
+            "/api/auth/config",
+            expect.objectContaining({ credentials: "include", cache: "no-store" }),
+        );
+    });
+
     it.each([
+        [
+            "SSO with domain",
+            () => startSso("/onboarding", "example.com"),
+            "/api/auth/oauth",
+            "POST",
+            { provider: "sso", next: "/onboarding", domain: "example.com" },
+        ],
+        [
+            "SSO with deployment default",
+            () => startSso("/onboarding"),
+            "/api/auth/oauth",
+            "POST",
+            { provider: "sso", next: "/onboarding" },
+        ],
         [
             "signup",
             () => signup("new@example.test", "long-password", "/onboarding"),

--- a/frontend/src/app/lib/authApi.ts
+++ b/frontend/src/app/lib/authApi.ts
@@ -84,6 +84,23 @@ export async function startGoogleOAuth(next: string) {
     });
 }
 
+export interface AuthConfiguration {
+    ssoEnabled: boolean;
+    ssoButtonLabel: string;
+    ssoDomainRequired: boolean;
+}
+
+export function getAuthConfiguration() {
+    return authRequest<AuthConfiguration>("/config");
+}
+
+export function startSso(next: string, domain?: string) {
+    return authRequest<{ url: string }>("/oauth", {
+        method: "POST",
+        body: JSON.stringify({ provider: "sso", next, domain }),
+    });
+}
+
 export async function exchangeAuthCode(code: string) {
     return authRequest<{ user: AuthUser }>("/exchange", {
         method: "POST",

--- a/frontend/src/app/login/page.test.tsx
+++ b/frontend/src/app/login/page.test.tsx
@@ -20,6 +20,7 @@ vi.mock("next/navigation", () => ({
 vi.mock("@/app/lib/authApi", () => ({
     login,
     startGoogleOAuth,
+    getAuthConfiguration: vi.fn().mockResolvedValue({ ssoEnabled: false }),
 }));
 
 vi.mock("@/app/contexts/AuthContext", () => ({

--- a/frontend/src/app/login/page.tsx
+++ b/frontend/src/app/login/page.tsx
@@ -14,6 +14,7 @@ import {
     authInputClassName,
 } from "@/app/components/auth/authStyles";
 import { AuthDivider } from "@/app/components/auth/AuthDivider";
+import { SsoAuthButton } from "@/app/components/auth/SsoAuthButton";
 import { GoogleAuthButton } from "@/app/components/auth/GoogleAuthButton";
 import { FieldLabel } from "@/app/components/ui/form-field";
 import { knownErrorCodeMessage } from "@/app/lib/userFacingError";
@@ -141,6 +142,11 @@ export default function LoginPage() {
                         </div>
                         <AuthDivider />
                         <GoogleAuthButton
+                            onError={setError}
+                            disabled={loading}
+                            onLoadingChange={setLoading}
+                        />
+                        <SsoAuthButton
                             onError={setError}
                             disabled={loading}
                             onLoadingChange={setLoading}

--- a/frontend/src/app/signup/page.test.tsx
+++ b/frontend/src/app/signup/page.test.tsx
@@ -19,6 +19,7 @@ vi.mock("next/navigation", () => ({
 vi.mock("@/app/lib/authApi", () => ({
     signup,
     startGoogleOAuth,
+    getAuthConfiguration: vi.fn().mockResolvedValue({ ssoEnabled: false }),
 }));
 
 vi.mock("@/app/contexts/AuthContext", () => ({

--- a/frontend/src/app/signup/page.tsx
+++ b/frontend/src/app/signup/page.tsx
@@ -27,6 +27,7 @@ import {
     minimumPasswordMessage,
 } from "@/app/components/auth/passwordPolicy";
 import { AuthDivider } from "@/app/components/auth/AuthDivider";
+import { SsoAuthButton } from "@/app/components/auth/SsoAuthButton";
 import { GoogleAuthButton } from "@/app/components/auth/GoogleAuthButton";
 import { FieldLabel } from "@/app/components/ui/form-field";
 
@@ -231,6 +232,11 @@ function SignupContent() {
                             </PillButton>
                             <AuthDivider />
                             <GoogleAuthButton
+                                onError={setError}
+                                disabled={loading}
+                                onLoadingChange={setLoading}
+                            />
+                            <SsoAuthButton
                                 onError={setError}
                                 disabled={loading}
                                 onLoadingChange={setLoading}


### PR DESCRIPTION
## Summary

Add opt-in enterprise SSO sign-in using SAML providers registered in Supabase Auth (GoTrue). Self-hosted users can choose single sign-on on login/signup and return through Mike's existing PKCE callback and HttpOnly session flow.

PRD: #436

## Changes

- Extend `POST /auth/oauth` with `provider: "sso"`, optional domain/default domain, DNS validation, and an optional exact domain allowlist. Preserve the existing origin checks and auth-flow rate limiter; sanitize SSO provider failures.
- Add `GET /auth/config` with public SSO presentation settings. Add `SsoAuthButton` using existing auth controls, a domain input when needed, loading/keyboard handling, and intentional error messages.
- Document GoTrue configuration, key generation, provider registration, domain mapping, and examples for Okta, Entra ID, and Google Workspace. Add disabled-by-default backend settings and commented Compose configuration.
- Add route/config, real-SDK PKCE cookie, frontend interaction, and auth request tests. No new dependencies, application migrations, or Word add-in changes.

## Why

GoTrue already supports SAML; proxying its SSO API keeps authentication consistent with Mike's existing server-managed session model and avoids IdP-specific code.

Two implementation details adjust the initial design: Google is currently always visible, with no enable/config endpoint, so this adds a minimal SSO configuration endpoint. Auth calls remain in the existing `authApi.ts` wrapper beside Google. GoTrue's pinned version requires PKCS#1 DER RSA key material and `GOTRUE_SAML_EXTERNAL_URL` including `/auth/v1` behind the Compose gateway. The SDK supplies `skip_http_redirect: true` and the PKCE challenge automatically.

SSO-only enforcement, IdP-initiated flows, and account linking are outside this change. The domain allowlist controls initiation through Mike; IdP/GoTrue policy remains responsible for access enforcement.

## Testing

- `npm test --prefix backend`: 112 files passed, 6 skipped; 1,406 tests passed, 39 skipped.
- `npm test --prefix frontend` under Node 22.23.2: all 142 files / 990 tests passed. Invoked with `npm exec --yes --package=node@22 --call 'node --version && npm test --prefix frontend'`.
- `npm run build --prefix frontend`: passed.
- `npm run build --prefix backend`: passed.
- Frontend ESLint on all changed TypeScript/TSX files: passed.
- `git diff --check`: passed.

The initial frontend run under local Node 26.7.0 failed in five files (38 tests) on `localStorage`/`Blob` behavior; the complete suite passed under Node 22 without application or test-environment workarounds. The SDK-boundary test confirms GoTrue request shape and a Secure, HttpOnly, SameSite=Lax PKCE cookie using mocked upstream HTTP.

A live GoTrue/IdP SAML round trip, provider registration, and browser acceptance have not been exercised. Deployment documentation includes those acceptance steps. No remote database or identity provider was modified.
