### PR TITLE
feat: add generic OpenAI-compatible gateway provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -26,3 +26,16 @@ SUPABASE_PUBLISHABLE_KEY=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYm
 # with `openssl rand -hex 32`; do not reuse a Supabase or signing secret.
 WORD_ADDIN_URL=
 AUTH_HANDOFF_ENCRYPTION_SECRET=
+
+# Optional deployment-managed OpenAI-compatible gateway (Chat Completions).
+# Set BOTH base URL (full API base including /v1) and ordered model catalog.
+# Example: legal-chat=Legal chat,vendor/model=Review model
+# Commas and equals signs are reserved. No model discovery is performed.
+GATEWAY_BASE_URL=
+GATEWAY_MODELS=
+# Optional bearer key; leave empty for an unauthenticated local endpoint.
+GATEWAY_API_KEY=
+# Defaults to Gateway when empty.
+GATEWAY_LABEL=
+# Optional raw configured id; empty uses the first catalog entry.
+GATEWAY_DEFAULT_MODEL=

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Website: [mikeoss.com](https://mikeoss.com)
 - Verify citations and research US case law with CourtListener
 - Work from Microsoft Word with the beta task-pane add-in
 - Run supported language models locally through Ollama
+- Configure deployment-managed models through an OpenAI-compatible gateway (LiteLLM, Bifrost, or Portkey); see [gateway setup](docs/deployment.md#openai-compatible-gateway)
 
 ## Quick start
 
@@ -42,7 +43,7 @@ and local email capture without requiring managed infrastructure.
    ```
 
 3. Add an Anthropic, Gemini, or OpenAI API key to `backend/.env`, unless you
-   plan to use Ollama exclusively.
+   plan to use Ollama or an unauthenticated local gateway exclusively.
 
 4. Start the stack:
 

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -159,3 +159,16 @@ ASYNC_TABULAR_EXTRACTION=false
 # The sweep runs every STALE_SWEEP_INTERVAL_MS. Defaults: 30 min / 10 min.
 #STALE_DOC_PROCESSING_MS=1800000
 #STALE_SWEEP_INTERVAL_MS=600000
+
+# Optional deployment-managed OpenAI-compatible gateway (Chat Completions).
+# Set BOTH base URL (full API base including /v1) and ordered model catalog.
+# Example: legal-chat=Legal chat,vendor/model=Review model
+# Commas and equals signs are reserved. No model discovery is performed.
+GATEWAY_BASE_URL=
+GATEWAY_MODELS=
+# Optional bearer key; leave empty for an unauthenticated local endpoint.
+GATEWAY_API_KEY=
+# Defaults to Gateway when empty.
+GATEWAY_LABEL=
+# Optional raw configured id; empty uses the first catalog entry.
+GATEWAY_DEFAULT_MODEL=

--- a/backend/src/__tests__/integration/chat.routes.test.ts
+++ b/backend/src/__tests__/integration/chat.routes.test.ts
@@ -367,6 +367,36 @@ describe("POST /chat — streaming endpoint", () => {
         );
     });
 
+    it("uses the deployment default for stale native preferences without a key", async () => {
+        vi.stubEnv("GATEWAY_BASE_URL", "http://localhost:8080/v1");
+        vi.stubEnv("GATEWAY_MODELS", "legal-chat,review");
+        vi.stubEnv("GATEWAY_DEFAULT_MODEL", "review");
+        try {
+            const settings = await import("../../lib/userSettings");
+            vi.mocked(settings.getUserModelSettings).mockResolvedValueOnce({
+                legal_research_us: false, title_model: null, tabular_model: null,
+                last_selected_chat_model: "gemini-3.7-flash", api_keys: {},
+            });
+            const res = await request(app).post("/chat").set("Authorization", "Bearer test")
+                .send({ messages: VALID_BODY.messages });
+            expect(res.status).toBe(200);
+            expect(runLLMStream).toHaveBeenCalledWith(expect.objectContaining({ model: "gateway/review" }));
+        } finally { vi.unstubAllEnvs(); }
+    });
+
+    it("rejects an explicit gateway model outside the deployment catalog", async () => {
+        vi.stubEnv("GATEWAY_BASE_URL", "http://localhost:8080/v1");
+        vi.stubEnv("GATEWAY_MODELS", "legal-chat");
+        vi.stubEnv("GATEWAY_DEFAULT_MODEL", "");
+        try {
+            const res = await request(app).post("/chat").set("Authorization", "Bearer test")
+                .send({ ...VALID_BODY, model: "gateway/unlisted" });
+            expect(res.status).toBe(400);
+            expect(res.body).toMatchObject({ code: "model_unavailable", detail: expect.stringContaining("not available") });
+            expect(runLLMStream).not.toHaveBeenCalled();
+        } finally { vi.unstubAllEnvs(); }
+    });
+
     it("rejects a chat without an explicit model before streaming", async () => {
         const res = await request(app)
             .post("/chat")

--- a/backend/src/__tests__/integration/tabular.routes.test.ts
+++ b/backend/src/__tests__/integration/tabular.routes.test.ts
@@ -251,6 +251,22 @@ describe("tabular.routes", () => {
 
     // ── POST /tabular-review (create) ─────────────────────────────────────
     describe("POST /tabular-review", () => {
+        it("uses a configured gateway default when creation omits the model", async () => {
+            vi.stubEnv("GATEWAY_BASE_URL", "http://localhost:8080/v1");
+            vi.stubEnv("GATEWAY_MODELS", "legal-chat");
+            vi.stubEnv("GATEWAY_DEFAULT_MODEL", "");
+            try {
+                getUserModelSettings.mockResolvedValue({ tabular_model: null, api_keys: {} });
+                supabaseState.tables.tabular_reviews = { data: { id: "r-gateway", document_ids: [] }, error: null };
+                const res = await request(app).post("/tabular-review").set(...AUTH)
+                    .send({ title: "Gateway review", document_ids: [], columns_config: [] });
+                expect(res.status).toBe(201);
+                expect(supabaseState.inserts).toContainEqual(expect.objectContaining({
+                    table: "tabular_reviews", payload: expect.objectContaining({ model: "gateway/legal-chat" }),
+                }));
+            } finally { vi.unstubAllEnvs(); }
+        });
+
         it("rejects creation without an explicit model", async () => {
             const res = await request(app)
                 .post("/tabular-review")

--- a/backend/src/lib/__tests__/gateway.test.ts
+++ b/backend/src/lib/__tests__/gateway.test.ts
@@ -1,0 +1,163 @@
+import { getUserApiKeyStatus } from "../userApiKeys";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  gatewayConfig,
+  gatewayModelId,
+  parseGatewayModels,
+} from "../llm/gateway";
+import { providerForModel, resolveModel } from "../llm/models";
+import {
+  gatewayAwarePreference,
+  resolveEffectiveChatModel,
+  titleModelForChat,
+} from "../modelSelection";
+import { resolveRequestedModel } from "../routerModels";
+import type { createServerSupabase } from "../supabase";
+
+beforeEach(() => {
+  for (const name of [
+    "BASE_URL",
+    "MODELS",
+    "API_KEY",
+    "LABEL",
+    "DEFAULT_MODEL",
+  ])
+    vi.stubEnv(`GATEWAY_${name}`, "");
+});
+afterEach(() => vi.unstubAllEnvs());
+const db = {} as ReturnType<typeof createServerSupabase>;
+function configure() {
+  vi.stubEnv("GATEWAY_BASE_URL", " http://localhost:8080/v1/// ");
+  vi.stubEnv(
+    "GATEWAY_MODELS",
+    "legal-chat=Legal chat,vendor/model,gateway/nested/model",
+  );
+}
+describe("gateway configuration", () => {
+  it("trims entries and preserves catalog order and names", () => {
+    expect(
+      parseGatewayModels(" a = First , vendor/model , gateway/x=Last "),
+    ).toEqual([
+      { id: "a", label: "First" },
+      { id: "vendor/model", label: "vendor/model" },
+      { id: "gateway/x", label: "Last" },
+    ]);
+  });
+  it.each([
+    "",
+    "a,",
+    ",a",
+    "a,,b",
+    "a,a=Duplicate",
+    "=Name",
+    "a=",
+    "a=b=c",
+    "bad id",
+  ])("rejects invalid catalog %s", (catalog) => {
+    expect(() => parseGatewayModels(catalog)).toThrow("GATEWAY_MODELS");
+  });
+  it("has no public endpoint fallback and validates the default", () => {
+    expect(gatewayConfig()).toBeNull();
+    vi.stubEnv("GATEWAY_MODELS", "a");
+    expect(() => gatewayConfig()).toThrow("GATEWAY_BASE_URL");
+    configure();
+    expect(gatewayConfig()).toMatchObject({
+      baseURL: "http://localhost:8080/v1",
+      defaultModel: "gateway/legal-chat",
+      label: "Gateway",
+    });
+    vi.stubEnv("GATEWAY_DEFAULT_MODEL", "vendor/model");
+    expect(gatewayConfig()?.defaultModel).toBe("gateway/vendor/model");
+    vi.stubEnv("GATEWAY_DEFAULT_MODEL", "unknown");
+    expect(() => gatewayConfig()).toThrow("GATEWAY_DEFAULT_MODEL");
+  });
+  it.each([
+    "ftp://host/v1",
+    "https://user:password@host/v1",
+    "https://host/v1?key=x",
+    "not a URL",
+  ])("rejects unsafe base %s", (base) => {
+    configure();
+    vi.stubEnv("GATEWAY_BASE_URL", base);
+    expect(() => gatewayConfig()).toThrow("GATEWAY_BASE_URL");
+  });
+  it("removes exactly one prefix and checks membership without user selections", async () => {
+    configure();
+    expect(gatewayModelId("gateway/gateway/nested/model")).toBe(
+      "gateway/nested/model",
+    );
+    expect(providerForModel("gateway/legal-chat")).toBe("gateway");
+    expect(resolveModel("gateway/unlisted", "fallback")).toBe("fallback");
+    expect(
+      await resolveRequestedModel("gateway/vendor/model", "", "u", db, "throw"),
+    ).toBe("gateway/vendor/model");
+    await expect(
+      resolveRequestedModel("gateway/unlisted", "", "u", db, "throw"),
+    ).rejects.toThrow("not available");
+  });
+  it("falls back for stale preferences but keeps usable and explicit selections", async () => {
+    configure();
+    const args = {
+      userId: "u",
+      db,
+      apiKeys: {},
+      chatModel: "gemini-3.7-flash",
+    };
+    expect(await resolveEffectiveChatModel(args)).toMatchObject({
+      ok: true,
+      model: "gateway/legal-chat",
+    });
+    expect(
+      await resolveEffectiveChatModel({
+        ...args,
+        requested: "gateway/vendor/model",
+      }),
+    ).toMatchObject({ ok: true, model: "gateway/vendor/model" });
+    expect(
+      await resolveEffectiveChatModel({
+        ...args,
+        requested: "gateway/unlisted",
+      }),
+    ).toMatchObject({ ok: false, status: 400 });
+    expect(
+      await resolveEffectiveChatModel({
+        ...args,
+        requested: "gemini-3.7-flash",
+      }),
+    ).toMatchObject({ ok: false, status: 422 });
+    expect(
+      await resolveEffectiveChatModel({ ...args, apiKeys: { gemini: "key" } }),
+    ).toMatchObject({ ok: true, model: "gemini-3.7-flash" });
+    expect(gatewayAwarePreference("gemini-3.7-flash", () => false)).toBe(
+      "gateway/legal-chat",
+    );
+    expect(titleModelForChat("gateway/vendor/model")).toBe(
+      "gateway/legal-chat",
+    );
+  });
+  it("keeps the original no-selection behavior when unconfigured", async () => {
+    expect(
+      await resolveEffectiveChatModel({ userId: "u", db, apiKeys: {} }),
+    ).toMatchObject({ ok: false, code: "model_required" });
+    expect(gatewayAwarePreference(null, () => false)).toBeNull();
+  });
+});
+
+it("exposes gateway availability without a user key, endpoint or bearer token", async () => {
+  configure();
+  vi.stubEnv("GATEWAY_API_KEY", "deployment-secret");
+  const client = {
+    from: () => ({
+      select: () => ({ eq: async () => ({ data: [], error: null }) }),
+    }),
+  } as unknown as ReturnType<typeof createServerSupabase>;
+  const status = await getUserApiKeyStatus("u", client);
+  expect(status.gateway).toMatchObject({
+    available: true,
+    provider: "gateway",
+    label: "Gateway",
+  });
+  expect(JSON.stringify(status)).not.toMatch(
+    /deployment-secret|localhost|baseURL|apiKey/,
+  );
+});

--- a/backend/src/lib/__tests__/gatewayAdapter.test.ts
+++ b/backend/src/lib/__tests__/gatewayAdapter.test.ts
@@ -1,0 +1,194 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { completeWithProvider, streamWithProvider } from "../llm/providers";
+function streamResponse(chunks: unknown[]): Response {
+  const body = `${chunks
+    .map((chunk) => `data: ${JSON.stringify(chunk)}\n\n`)
+    .join("")}data: [DONE]\n\n`;
+  return new Response(body, {
+    status: 200,
+    headers: { "Content-Type": "text/event-stream" },
+  });
+}
+
+function functionTool(
+  name: string,
+  parameters: Record<string, unknown> = { type: "object" },
+) {
+  return {
+    type: "function" as const,
+    function: { name, description: `${name} test tool`, parameters },
+  };
+}
+
+beforeEach(() => {
+  vi.stubEnv("GATEWAY_MODELS", "legal-chat,openai/gpt-5.4,gateway/v0-1.5-md");
+  vi.stubEnv("GATEWAY_API_KEY", "gateway-user-key");
+  vi.stubEnv("GATEWAY_DEFAULT_MODEL", "");
+});
+afterEach(() => {
+  vi.unstubAllEnvs();
+  vi.unstubAllGlobals();
+});
+describe("gateway transport", () => {
+  it("calls an OpenAI-compatible gateway with Chat Completions and no reasoning field", async () => {
+    vi.stubEnv("GATEWAY_BASE_URL", "https://gateway.example/v1/");
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          choices: [{ message: { content: "A gateway title" } }],
+        }),
+        {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        },
+      ),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await completeWithProvider({
+      model: "gateway/openai/gpt-5.4",
+      user: "Title this",
+    });
+
+    expect(result).toBe("A gateway title");
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe("https://gateway.example/v1/chat/completions");
+    expect(new Headers(init.headers).get("authorization")).toBe(
+      "Bearer gateway-user-key",
+    );
+    const body = JSON.parse(String(init.body));
+    expect(body).toMatchObject({ model: "openai/gpt-5.4" });
+    // Reasoning controls are disabled for this protocol, so the optional
+    // OpenAI extension must not reach a gateway that may reject it.
+    expect(body).not.toHaveProperty("reasoning_effort");
+    expect(body).not.toHaveProperty("reasoning");
+  });
+
+  it("forwards a gateway-native model id that starts with the router slug", async () => {
+    vi.stubEnv("GATEWAY_BASE_URL", "https://gateway.example/v1");
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          choices: [{ message: { content: "A v0 title" } }],
+        }),
+        {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        },
+      ),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    await completeWithProvider({
+      model: "gateway/gateway/v0-1.5-md",
+      user: "Title this",
+    });
+
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(JSON.parse(String(init.body))).toMatchObject({
+      model: "gateway/v0-1.5-md",
+    });
+  });
+
+  it("streams a tool call, its result, and the final text in compatible mode", async () => {
+    vi.stubEnv("GATEWAY_BASE_URL", "https://gateway.example/v1");
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        streamResponse([
+          {
+            choices: [
+              {
+                delta: {
+                  tool_calls: [
+                    {
+                      index: 0,
+                      id: "call-1",
+                      type: "function",
+                      function: {
+                        name: "lookup",
+                        arguments: '{"term":"contract"}',
+                      },
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+          {
+            choices: [{ delta: {}, finish_reason: "tool_calls" }],
+          },
+        ]),
+      )
+      .mockResolvedValueOnce(
+        streamResponse([
+          { choices: [{ delta: { content: "Done" } }] },
+          { choices: [{ delta: {}, finish_reason: "stop" }] },
+        ]),
+      );
+    vi.stubGlobal("fetch", fetchMock);
+    const runTools = vi
+      .fn()
+      .mockResolvedValue([{ tool_use_id: "call-1", content: "result" }]);
+
+    const result = await streamWithProvider({
+      model: "gateway/openai/gpt-5.4",
+      systemPrompt: "Help",
+      messages: [{ role: "user", content: "Review" }],
+      tools: [functionTool("lookup")],
+      reasoning: "high",
+      runTools,
+    });
+
+    expect(result.fullText).toBe("Done");
+    expect(runTools).toHaveBeenCalledOnce();
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(String(fetchMock.mock.calls[0]?.[0])).toBe(
+      "https://gateway.example/v1/chat/completions",
+    );
+    const secondBody = JSON.parse(
+      String((fetchMock.mock.calls[1]?.[1] as RequestInit).body),
+    );
+    expect(secondBody.model).toBe("openai/gpt-5.4");
+    // A requested reasoning level must not reach a gateway whose models
+    // Mike cannot check for support.
+    expect(secondBody).not.toHaveProperty("reasoning_effort");
+    expect(secondBody.messages).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ role: "assistant" }),
+        expect.objectContaining({
+          role: "tool",
+          tool_call_id: "call-1",
+          content: "result",
+        }),
+      ]),
+    );
+  });
+
+  it("sends aliases without Authorization when the deployment key is omitted", async () => {
+    vi.stubEnv("GATEWAY_BASE_URL", "http://localhost:8080/v1");
+    vi.stubEnv("GATEWAY_API_KEY", "");
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          choices: [{ message: { content: "Title" } }],
+        }),
+        { headers: { "Content-Type": "application/json" } },
+      ),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    await completeWithProvider({ model: "gateway/legal-chat", user: "Title" });
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(new Headers(init.headers).has("authorization")).toBe(false);
+    expect(JSON.parse(String(init.body)).model).toBe("legal-chat");
+  });
+  it("rejects unlisted models before any HTTP request", async () => {
+    vi.stubEnv("GATEWAY_BASE_URL", "http://localhost:8080/v1");
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+    await expect(
+      completeWithProvider({ model: "gateway/unlisted", user: "Title" }),
+    ).rejects.toThrow("not available");
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});

--- a/backend/src/lib/__tests__/gatewayTabular.test.ts
+++ b/backend/src/lib/__tests__/gatewayTabular.test.ts
@@ -1,0 +1,46 @@
+import { afterEach, beforeEach, expect, it, vi } from "vitest";
+import type { createServerSupabase } from "../supabase";
+const { getUserModelSettings } = vi.hoisted(() => ({
+  getUserModelSettings: vi.fn(),
+}));
+vi.mock("../userSettings", () => ({ getUserModelSettings }));
+import { validateSelectedModel } from "../tabular/tabular.shared";
+const db = {} as ReturnType<typeof createServerSupabase>;
+beforeEach(() => {
+  vi.stubEnv("GATEWAY_BASE_URL", "http://localhost:8080/v1");
+  vi.stubEnv("GATEWAY_MODELS", "chat,review");
+  vi.stubEnv("GATEWAY_DEFAULT_MODEL", "review");
+  getUserModelSettings.mockResolvedValue({ api_keys: {}, tabular_model: null });
+});
+afterEach(() => vi.unstubAllEnvs());
+it("uses the gateway default for a stored native model without a key", async () => {
+  expect(
+    await validateSelectedModel("claude-sonnet-5", "u", db, true),
+  ).toMatchObject({ ok: true, model: "gateway/review" });
+});
+it("preserves a usable stored model and a saved preference for new reviews", async () => {
+  getUserModelSettings.mockResolvedValue({
+    api_keys: { claude: "key" },
+    tabular_model: "claude-sonnet-5",
+  });
+  expect(
+    await validateSelectedModel("claude-sonnet-5", "u", db, true),
+  ).toMatchObject({ ok: true, model: "claude-sonnet-5" });
+  expect(await validateSelectedModel(undefined, "u", db)).toMatchObject({
+    ok: true,
+    model: "claude-sonnet-5",
+  });
+});
+it("does not silently replace an explicit unavailable native request", async () => {
+  expect(await validateSelectedModel("claude-sonnet-5", "u", db)).toMatchObject(
+    { ok: false, status: 422 },
+  );
+});
+it("rejects an unlisted explicit gateway model but recovers a stale stored one", async () => {
+  expect(await validateSelectedModel("gateway/removed", "u", db)).toMatchObject(
+    { ok: false, status: 400 },
+  );
+  expect(
+    await validateSelectedModel("gateway/removed", "u", db, true),
+  ).toMatchObject({ ok: true, model: "gateway/review" });
+});

--- a/backend/src/lib/__tests__/userSettings.test.ts
+++ b/backend/src/lib/__tests__/userSettings.test.ts
@@ -193,3 +193,19 @@ describe("getUserModelSettings on an un-migrated database", () => {
         expect(settings.tabular_model).toBeNull();
     });
 });
+
+
+it("uses gateway defaults for unavailable saved title and tabular preferences", async () => {
+    vi.stubEnv("GATEWAY_BASE_URL", "http://localhost:8080/v1");
+    vi.stubEnv("GATEWAY_MODELS", "legal-chat,review");
+    vi.stubEnv("GATEWAY_DEFAULT_MODEL", "review");
+    getUserApiKeys.mockResolvedValue({});
+    try {
+        const settings = await getUserModelSettings("user-1", profileDb({
+            title_model: "claude-haiku-4-5", tabular_model: "gemini-3.7-flash",
+        }));
+        expect(settings.title_model).toBe("gateway/review");
+        expect(settings.tabular_model).toBe("gateway/review");
+        expect(settings.last_selected_chat_model).toBe("gateway/review");
+    } finally { vi.unstubAllEnvs(); }
+});

--- a/backend/src/lib/llm/gateway.ts
+++ b/backend/src/lib/llm/gateway.ts
@@ -1,0 +1,116 @@
+import { UserFacingError } from "../userFacingError";
+
+export function parseGatewayModels(
+  value: string,
+): { id: string; label: string }[] {
+  const seen = new Set<string>();
+  return value.split(",").map((entry) => {
+    const parts = entry.trim().split("=");
+    const id = parts[0]?.trim() ?? "";
+    const label = parts.length === 1 ? id : parts[1]?.trim();
+    if (
+      !id ||
+      /[\s,=]/.test(id) ||
+      parts.length > 2 ||
+      !label ||
+      seen.has(id)
+    ) {
+      throw new Error(
+        "GATEWAY_MODELS requires unique non-empty ids and optional display names; commas and equals signs are reserved.",
+      );
+    }
+    seen.add(id);
+    return { id, label };
+  });
+}
+
+/** Read per call, normalize once, and never infer a public endpoint. */
+export function gatewayConfig() {
+  const baseURL = process.env.GATEWAY_BASE_URL?.trim().replace(/\/+$/, "");
+  const catalog = process.env.GATEWAY_MODELS?.trim();
+  if (
+    !baseURL &&
+    !catalog &&
+    !process.env.GATEWAY_API_KEY?.trim() &&
+    !process.env.GATEWAY_DEFAULT_MODEL?.trim() &&
+    !process.env.GATEWAY_LABEL?.trim()
+  )
+    return null;
+  if (!baseURL || !catalog)
+    throw new Error("Gateway requires GATEWAY_BASE_URL and GATEWAY_MODELS.");
+  let url: URL;
+  try {
+    url = new URL(baseURL);
+  } catch {
+    throw new Error("GATEWAY_BASE_URL must be an HTTP(S) API base URL.");
+  }
+  if (
+    !["http:", "https:"].includes(url.protocol) ||
+    url.username ||
+    url.password ||
+    url.search ||
+    url.hash
+  ) {
+    throw new Error(
+      "GATEWAY_BASE_URL must be an HTTP(S) API base URL without credentials, query or fragment.",
+    );
+  }
+  const models = parseGatewayModels(catalog);
+  const defaultId = process.env.GATEWAY_DEFAULT_MODEL?.trim() || models[0]!.id;
+  if (!models.some((model) => model.id === defaultId))
+    throw new Error(
+      "GATEWAY_DEFAULT_MODEL must name a configured raw model id.",
+    );
+  return {
+    baseURL,
+    models,
+    defaultModel: `gateway/${defaultId}`,
+    label: process.env.GATEWAY_LABEL?.trim() || "Gateway",
+    apiKey: process.env.GATEWAY_API_KEY?.trim() || undefined,
+  };
+}
+
+export function gatewayModelId(model: string): string {
+  return model.replace(/^gateway\//, "");
+}
+
+export function isGatewayModelAvailable(model: string): boolean {
+  return (
+    model.startsWith("gateway/") &&
+    !!gatewayConfig()?.models.some((item) => item.id === gatewayModelId(model))
+  );
+}
+
+export function requireGatewayModel(model: string) {
+  const config = gatewayConfig();
+  if (
+    !config ||
+    !model.startsWith("gateway/") ||
+    !config.models.some((item) => item.id === gatewayModelId(model))
+  ) {
+    throw new UserFacingError(
+      `${config?.label ?? "Gateway"} model is not available. Select a configured model.`,
+    );
+  }
+  return config;
+}
+
+/** Explicit safe projection: endpoint and credentials never enter API responses. */
+export function gatewayCatalog() {
+  const config = gatewayConfig();
+  return {
+    provider: "gateway" as const,
+    label: config?.label ?? "Gateway",
+    available: !!config,
+    defaultModel: config?.defaultModel ?? null,
+    models:
+      config?.models.map((model) => ({
+        id: `gateway/${model.id}`,
+        label: model.label,
+        group: config.label,
+        source: config.label,
+        provider: "gateway" as const,
+        available: true,
+      })) ?? [],
+  };
+}

--- a/backend/src/lib/llm/models.ts
+++ b/backend/src/lib/llm/models.ts
@@ -1,3 +1,4 @@
+import { isGatewayModelAvailable } from "./gateway";
 import { REASONING_LEVELS, type Provider, type ReasoningLevel } from "./types";
 
 // ---------------------------------------------------------------------------
@@ -138,6 +139,7 @@ const ALL_MODELS = new Set<string>([
 // ---------------------------------------------------------------------------
 
 export function providerForModel(model: string): Provider {
+    if (model.startsWith("gateway/")) return "gateway";
     if (model.startsWith("ollama")) return "ollama";
     if (model.startsWith("openrouter/")) return "openrouter";
     if (model.startsWith("vercel/")) return "vercel";
@@ -164,6 +166,7 @@ export function resolveModel(
     if (
         canonical &&
         (ALL_MODELS.has(canonical) ||
+            isGatewayModelAvailable(canonical) ||
             canonical.startsWith("ollama/") ||
             /^(?:openrouter|vercel)\/[^\s/]+\/[^\s]+$/.test(canonical) ||
             // OpenCode Go's catalog ids are single-segment ("glm-5"), not the

--- a/backend/src/lib/llm/providers.ts
+++ b/backend/src/lib/llm/providers.ts
@@ -1,3 +1,4 @@
+import { gatewayModelId, requireGatewayModel } from "./gateway";
 import {
   aiSdkFetch,
   completeAiSdkText,
@@ -212,6 +213,28 @@ async function createProviderAdapter(
   apiKeys?: UserApiKeys,
 ): Promise<AiSdkAdapterConfig> {
   const provider = providerForModel(model);
+
+  if (provider === "gateway") {
+    const config = requireGatewayModel(model);
+    const { createOpenAICompatible } = await import("@ai-sdk/openai-compatible");
+    const gateway = createOpenAICompatible({
+      name: "gateway",
+      baseURL: config.baseURL,
+      apiKey: config.apiKey,
+      fetch: aiSdkFetch,
+    });
+    return {
+      provider,
+      label: config.label,
+      model: gateway(gatewayModelId(model)),
+      modelId: model,
+      // Reasoning controls stay off until Mike can tell which models behind
+      // an arbitrary gateway accept them: the field is an optional OpenAI
+      // extension that stricter gateways reject outright, and levels are
+      // forwarded verbatim without Vercel's provider-specific translation.
+      supportsReasoning: false,
+    };
+  }
 
   if (provider === "claude") {
     return createAnthropicAdapter({

--- a/backend/src/lib/llm/types.ts
+++ b/backend/src/lib/llm/types.ts
@@ -9,6 +9,7 @@ export type Provider =
     | "openrouter"
     | "vercel"
     | "opencode-go"
+    | "gateway"
     | "ollama";
 
 export const REASONING_LEVELS = [

--- a/backend/src/lib/modelSelection.ts
+++ b/backend/src/lib/modelSelection.ts
@@ -1,3 +1,4 @@
+import { gatewayConfig, isGatewayModelAvailable } from "./llm/gateway";
 import {
     CLAUDE_LOW_MODELS,
     GEMINI_LOW_MODELS,
@@ -76,6 +77,7 @@ export function hasApiKeyForModel(
     apiKeys: UserApiKeys,
 ): boolean {
     const provider = providerForModel(model);
+    if (provider === "gateway") return isGatewayModelAvailable(model);
     return provider === "ollama" || !!apiKeys[provider]?.trim();
 }
 
@@ -83,7 +85,7 @@ type EffectiveChatModelResult =
     | {
           ok: true;
           model: string;
-          source: "request" | "chat" | "last_selected";
+          source: "request" | "chat" | "last_selected" | "gateway";
       }
     | {
           ok: false;
@@ -93,9 +95,9 @@ type EffectiveChatModelResult =
       };
 
 /**
- * Resolve a chat turn without inventing a product default. An explicit
+ * Resolve a chat turn, using a configured deployment gateway as the final fallback. An explicit
  * request is authoritative. Otherwise the chat's saved model wins, with the
- * one profile-level last-selected model as the only fallback.
+ * one profile-level last-selected model before the deployment fallback.
  */
 export async function resolveEffectiveChatModel(args: {
     requested?: string | null;
@@ -113,7 +115,9 @@ export async function resolveEffectiveChatModel(args: {
                 ok: false,
                 status: 400,
                 code: "model_unavailable",
-                detail: `Model "${requestedText}" is not available. Select another model.`,
+                detail: requestedText.startsWith("gateway/")
+                    ? `${gatewayConfig()?.label ?? "Gateway"} model is not available. Select a configured model.`
+                    : `Model "${requestedText}" is not available. Select another model.`,
             };
         }
         try {
@@ -165,6 +169,9 @@ export async function resolveEffectiveChatModel(args: {
         }
     }
 
+    const gateway = gatewayConfig();
+    if (gateway) return { ok: true, model: gateway.defaultModel, source: "gateway" };
+
     return {
         ok: false,
         status: 400,
@@ -178,7 +185,8 @@ export async function resolveEffectiveChatModel(args: {
  *
  * A saved title preference is an explicit override. Otherwise first-party
  * chat models map to that provider's cheapest title-tier model. Routers and
- * local models reuse the exact chat model because Mike cannot safely infer a
+ * local models reuse the exact chat model; deployment gateways use their configured
+ * default. Mike cannot safely infer a
  * cheaper equivalent within an external/dynamic catalog.
  */
 export function titleModelForChat(
@@ -200,10 +208,22 @@ export function titleModelForChat(
             return GEMINI_LOW_MODELS[0];
         case "openai":
             return OPENAI_LOW_MODELS[0];
+        case "gateway":
+            return gatewayConfig()!.defaultModel;
         case "openrouter":
         case "vercel":
         case "opencode-go":
         case "ollama":
             return resolvedChatModel;
     }
+}
+
+/** Only configured deployments introduce a fallback for absent/unusable preferences. */
+export function gatewayAwarePreference(
+    model: string | null,
+    usable: (model: string) => boolean,
+): string | null {
+    const gateway = gatewayConfig();
+    if (!gateway || (model && usable(model))) return model;
+    return gateway.defaultModel;
 }

--- a/backend/src/lib/routerModels.ts
+++ b/backend/src/lib/routerModels.ts
@@ -1,3 +1,4 @@
+import { requireGatewayModel } from "./llm/gateway";
 import { createServerSupabase } from "./supabase";
 import { UserFacingError } from "./userFacingError";
 import { resolveModel } from "./llm/models";
@@ -69,6 +70,17 @@ export async function resolveRequestedModel(
     db: Db = createServerSupabase(),
     onOutsideSelection: "throw" | "fallback" = "fallback",
 ): Promise<string> {
+    if (requested?.startsWith("gateway/")) {
+        try {
+            requireGatewayModel(requested);
+            return requested;
+        } catch (error) {
+            if (onOutsideSelection === "throw" || !(error instanceof UserFacingError)) {
+                throw error;
+            }
+            return fallback;
+        }
+    }
     const resolved = resolveModel(requested, fallback);
     const router = routerForModelId(resolved);
     if (!router) return resolved;

--- a/backend/src/lib/tabular/tabular.generate.ts
+++ b/backend/src/lib/tabular/tabular.generate.ts
@@ -66,7 +66,7 @@ export async function prepareTabularGenerate(
     // of the user's global defaults, and it must still resolve + be keyed for
     // this user. Failures are carried out verbatim so both the sync and the
     // async endpoint answer with the same status/body.
-    const selected = await validateSelectedModel(review.model, userId, db);
+    const selected = await validateSelectedModel(review.model, userId, db, true);
     if (!selected.ok)
         return {
             ok: false,

--- a/backend/src/lib/tabular/tabular.shared.ts
+++ b/backend/src/lib/tabular/tabular.shared.ts
@@ -4,6 +4,7 @@
 // (tabular.prompt.ts, tabular.extract.ts, …) and routes/tabular.ts can
 // import them.
 
+import { gatewayConfig } from "../llm/gateway";
 import { createServerSupabase } from "../supabase";
 import {
     providerForModel,
@@ -13,7 +14,11 @@ import {
 } from "../llm";
 import { getUserModelSettings } from "../userSettings";
 import { resolveRequestedModel } from "../routerModels";
-import { TABULAR_MODEL_REQUIRED_DETAIL } from "../modelSelection";
+import {
+    gatewayAwarePreference,
+    hasApiKeyForModel,
+    TABULAR_MODEL_REQUIRED_DETAIL,
+} from "../modelSelection";
 import { UserFacingError } from "../userFacingError";
 
 export type Db = ReturnType<typeof createServerSupabase>;
@@ -26,6 +31,7 @@ export type Log = Pick<Console, "error">;
 // ---------------------------------------------------------------------------
 
 function providerLabel(provider: Provider): string {
+    if (provider === "gateway") return gatewayConfig()?.label ?? "Gateway";
     if (provider === "claude") return "Anthropic";
     if (provider === "openai") return "OpenAI";
     if (provider === "openrouter") return "OpenRouter";
@@ -46,7 +52,7 @@ export function missingModelApiKey(
     apiKeys: UserApiKeys,
 ): MissingApiKey | null {
     const provider = providerForModel(model);
-    if (provider === "ollama") return null; // local, no key
+    if (provider === "ollama" || provider === "gateway") return null; // deployment-managed
     if (apiKeys[provider]?.trim()) return null;
     return {
         provider,
@@ -80,7 +86,20 @@ export async function validateSelectedModel(
     model: unknown,
     userId: string,
     db: Db,
+    stored = false,
 ): Promise<ValidatedModel | ModelValidationFailure> {
+    let settings: Awaited<ReturnType<typeof getUserModelSettings>> | undefined;
+    const text = typeof model === "string" ? model.trim() : "";
+    if (gatewayConfig() && (stored || !text)) {
+        settings = await getUserModelSettings(userId, db);
+        const candidate = stored
+            ? await resolveRequestedModel(text, "", userId, db, "fallback")
+            : settings.tabular_model;
+        model = gatewayAwarePreference(
+            candidate || null,
+            (candidateModel) => hasApiKeyForModel(candidateModel, settings!.api_keys),
+        );
+    }
     const requested = resolveModel(
         typeof model === "string" ? model.trim() : "",
         "",
@@ -122,7 +141,7 @@ export async function validateSelectedModel(
         throw error;
     }
 
-    const { api_keys: apiKeys } = await getUserModelSettings(userId, db);
+    const { api_keys: apiKeys } = settings ?? await getUserModelSettings(userId, db);
     const missingKey = missingModelApiKey(selected, apiKeys);
     if (missingKey) {
         return {

--- a/backend/src/lib/userApiKeys.ts
+++ b/backend/src/lib/userApiKeys.ts
@@ -1,3 +1,4 @@
+import { gatewayCatalog } from "./llm/gateway";
 import crypto from "crypto";
 import { createServerSupabase } from "./supabase";
 import type { UserApiKeys } from "./llm";
@@ -13,6 +14,7 @@ export type ApiKeyProvider =
     | "courtlistener";
 export type ApiKeySource = "user" | "env" | null;
 export type ApiKeyStatus = Record<ApiKeyProvider, boolean> & {
+    gateway?: ReturnType<typeof gatewayCatalog>;
     sources: Record<ApiKeyProvider, ApiKeySource>;
 };
 
@@ -162,6 +164,8 @@ export async function getUserApiKeyStatus(
         }
     }
 
+    const gateway = gatewayCatalog();
+    if (gateway.available) status.gateway = gateway;
     return status;
 }
 

--- a/backend/src/lib/userSettings.ts
+++ b/backend/src/lib/userSettings.ts
@@ -7,6 +7,8 @@ import {
 } from "./routerModels";
 import {
     normalizeOptionalModelPreference,
+    gatewayAwarePreference,
+    hasApiKeyForModel,
     normalizeReasoningLevel,
 } from "./modelSelection";
 
@@ -87,19 +89,14 @@ export async function getUserModelSettings(
         }
     }
 
+    const preference = (value: string | null | undefined) => gatewayAwarePreference(
+        normalizeOptionalModelPreference(value, routerModels),
+        (model) => hasApiKeyForModel(model, api_keys),
+    );
     return {
-        title_model: normalizeOptionalModelPreference(
-            data?.title_model,
-            routerModels,
-        ),
-        tabular_model: normalizeOptionalModelPreference(
-            data?.tabular_model,
-            routerModels,
-        ),
-        last_selected_chat_model: normalizeOptionalModelPreference(
-            data?.last_selected_chat_model,
-            routerModels,
-        ),
+        title_model: preference(data?.title_model),
+        tabular_model: preference(data?.tabular_model),
+        last_selected_chat_model: preference(data?.last_selected_chat_model),
         last_selected_reasoning_level: normalizeReasoningLevel(
             data?.last_selected_reasoning_level,
         ),

--- a/backend/src/routes/__tests__/models.test.ts
+++ b/backend/src/routes/__tests__/models.test.ts
@@ -346,3 +346,30 @@ describe("GET /models/opencode-go", () => {
         consoleError.mockRestore();
     });
 });
+
+
+describe("GET /models/gateway", () => {
+    afterEach(() => { vi.unstubAllEnvs(); vi.unstubAllGlobals(); });
+    it("exposes only the configured catalog without discovery or secrets", async () => {
+        vi.stubEnv("GATEWAY_BASE_URL", "https://gateway.example/v1");
+        vi.stubEnv("GATEWAY_MODELS", "legal-chat=Legal chat,vendor/model=Review");
+        vi.stubEnv("GATEWAY_LABEL", "Legal models");
+        vi.stubEnv("GATEWAY_API_KEY", "deployment-secret");
+        vi.stubEnv("GATEWAY_DEFAULT_MODEL", "vendor/model");
+        const fetchMock = vi.fn(); vi.stubGlobal("fetch", fetchMock);
+        const res = await request(app).get("/models/gateway");
+        expect(res.status).toBe(200);
+        expect(res.body).toEqual({ provider: "gateway", label: "Legal models", available: true,
+            defaultModel: "gateway/vendor/model", models: [
+                { id: "gateway/legal-chat", label: "Legal chat", group: "Legal models", source: "Legal models", provider: "gateway", available: true },
+                { id: "gateway/vendor/model", label: "Review", group: "Legal models", source: "Legal models", provider: "gateway", available: true },
+            ] });
+        expect(JSON.stringify(res.body)).not.toMatch(/deployment-secret|gateway.example|Authorization/);
+        expect(fetchMock).not.toHaveBeenCalled();
+    });
+    it("returns an empty catalog when unconfigured", async () => {
+        for (const name of ["BASE_URL", "MODELS", "API_KEY", "LABEL", "DEFAULT_MODEL"]) vi.stubEnv(`GATEWAY_${name}`, "");
+        const res = await request(app).get("/models/gateway");
+        expect(res.body).toEqual({ provider: "gateway", label: "Gateway", available: false, defaultModel: null, models: [] });
+    });
+});

--- a/backend/src/routes/__tests__/userRouterModels.test.ts
+++ b/backend/src/routes/__tests__/userRouterModels.test.ts
@@ -300,3 +300,17 @@ describe("normalizeRouterModels", () => {
         ).toEqual(["glm-5.3", "qwen3.8-max", "minimax-m3"]);
     });
 });
+
+
+describe("gateway profile defaults", () => {
+    it("replaces stale native preferences without requiring router selections", async () => {
+        vi.stubEnv("GATEWAY_BASE_URL", "http://localhost:8080/v1");
+        vi.stubEnv("GATEWAY_MODELS", "legal-chat=Legal chat");
+        vi.stubEnv("GATEWAY_DEFAULT_MODEL", "");
+        try {
+            const res = await request(app).get("/user/profile");
+            expect(res.status).toBe(200);
+            expect(res.body).toMatchObject({ titleModel: "gateway/legal-chat", tabularModel: "gateway/legal-chat", lastSelectedChatModel: "gateway/legal-chat" });
+        } finally { vi.unstubAllEnvs(); }
+    });
+});

--- a/backend/src/routes/models.ts
+++ b/backend/src/routes/models.ts
@@ -1,3 +1,4 @@
+import { gatewayCatalog } from "../lib/llm/gateway";
 import { Router } from "express";
 import { requireAuth } from "../middleware/auth";
 import { ollamaAuthHeaders as authHeaders } from "../lib/llm/providers";
@@ -7,6 +8,13 @@ import { getUserApiKeys } from "../lib/userApiKeys";
 import { sendInternalError } from "../lib/httpError";
 
 export const modelsRouter = Router();
+modelsRouter.get("/gateway", requireAuth, (_req, res) => {
+    try {
+        res.json(gatewayCatalog());
+    } catch (error) {
+        sendInternalError(res, error);
+    }
+});
 
 function catalogPrice(value: unknown): string | undefined {
     if (typeof value !== "string" && typeof value !== "number") {

--- a/backend/src/routes/tabular.ts
+++ b/backend/src/routes/tabular.ts
@@ -1,3 +1,4 @@
+import { gatewayConfig } from "../lib/llm/gateway";
 import { Router } from "express";
 import { randomUUID } from "node:crypto";
 import { requireAuth } from "../middleware/auth";
@@ -487,7 +488,7 @@ tabularRouter.post("/", requireAuth, async (req, res) => {
         model?: string;
     };
 
-    if (typeof model !== "string" || !model.trim()) {
+    if ((typeof model !== "string" || !model.trim()) && !gatewayConfig()) {
         return void res.status(400).json({
             code: "model_required",
             detail: TABULAR_MODEL_REQUIRED_DETAIL,
@@ -1305,6 +1306,7 @@ tabularRouter.post(
             review.model,
             userId,
             db,
+            true,
         );
         if (!selectedModel.ok) {
             return void res

--- a/backend/src/routes/user.ts
+++ b/backend/src/routes/user.ts
@@ -1,3 +1,6 @@
+import { gatewayAwarePreference } from "../lib/modelSelection";
+import { providerForModel } from "../lib/llm/models";
+import { isGatewayModelAvailable } from "../lib/llm/gateway";
 import crypto from "crypto";
 import { Router } from "express";
 import { requireAuth, requireMfaIfEnrolled } from "../middleware/auth";
@@ -581,6 +584,14 @@ function serializeProfile(
     apiKeyStatus?: ApiKeyStatus,
 ) {
     const creditsUsed = row.message_credits_used ?? 0;
+    const preference = (value: string | null | undefined) => gatewayAwarePreference(
+        normalizeOptionalModelPreference(value, routerModels),
+        (model) => {
+            const provider = providerForModel(model);
+            return provider === "gateway" ? isGatewayModelAvailable(model)
+                : provider === "ollama" || !apiKeyStatus || !!apiKeyStatus[provider];
+        },
+    );
     return {
         displayName: row.display_name,
         organisation: row.organisation,
@@ -605,18 +616,9 @@ function serializeProfile(
         creditsResetDate: row.credits_reset_date,
         creditsRemaining: Math.max(MONTHLY_CREDIT_LIMIT - creditsUsed, 0),
         tier: row.tier || "Free",
-        titleModel: normalizeOptionalModelPreference(
-            row.title_model,
-            routerModels,
-        ),
-        tabularModel: normalizeOptionalModelPreference(
-            row.tabular_model,
-            routerModels,
-        ),
-        lastSelectedChatModel: normalizeOptionalModelPreference(
-            row.last_selected_chat_model,
-            routerModels,
-        ),
+        titleModel: preference(row.title_model),
+        tabularModel: preference(row.tabular_model),
+        lastSelectedChatModel: preference(row.last_selected_chat_model),
         lastSelectedReasoningLevel:
             normalizeReasoningLevel(row.last_selected_reasoning_level) ??
             "high",

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -9,7 +9,7 @@ storage instead of the infrastructure bundled with Docker Compose.
 - npm and Git
 - A Supabase project
 - A Cloudflare R2, MinIO, or other S3-compatible bucket
-- At least one supported model-provider API key, or an accessible Ollama server
+- At least one supported model-provider API key, an accessible Ollama server, or a configured OpenAI-compatible gateway
 - Optional: a CourtListener API token for case-law tools
 - LibreOffice when DOC/DOCX-to-PDF conversion is required
 
@@ -302,3 +302,61 @@ commented `worker` service demonstrating this.
 
 See [Safe local testing](safe-local-testing.md), the [security policy](../SECURITY.md),
 and [Troubleshooting](troubleshooting.md) for related guidance.
+
+
+## OpenAI-compatible gateway
+
+Mike supports one deployment-managed `gateway` provider using OpenAI Chat
+Completions, alongside the existing native providers, routers and Ollama.
+Examples include LiteLLM, Bifrost and Portkey. Vercel configuration and its
+transport are unchanged.
+
+Set these server-only variables in `backend/.env` for a direct backend install,
+or the root `.env` for Docker Compose. Compose already passes both env files to
+the backend; root values take precedence. No frontend environment values or
+schema migration are needed.
+
+```dotenv
+GATEWAY_BASE_URL=http://host.docker.internal:8080/v1
+GATEWAY_MODELS=legal-chat=Legal chat,vendor/model=Review model
+GATEWAY_LABEL=Gateway
+GATEWAY_DEFAULT_MODEL=legal-chat
+GATEWAY_API_KEY=
+```
+
+`GATEWAY_BASE_URL` and `GATEWAY_MODELS` are required together. Supply the full
+HTTP(S) API base, including `/v1` when required by your endpoint. Mike removes
+trailing slashes but does not append `/v1` or fall back to a public endpoint.
+URLs must not contain embedded credentials, query strings or fragments.
+`GATEWAY_API_KEY` is optional and, when present, is sent as a bearer token.
+Leave it empty only when the endpoint does not require authentication.
+
+The ordered catalog accepts comma-separated `id` or `id=Display name` entries.
+Whitespace around entries and names is trimmed; IDs must be non-empty, unique
+and contain no whitespace. Empty names/entries and extra equals signs are
+rejected. Commas and equals signs are reserved and cannot occur inside IDs or
+names. `GATEWAY_DEFAULT_MODEL` is a raw configured ID; omission selects the
+first entry. `GATEWAY_LABEL` defaults to “Gateway”. Restart the backend after
+changing deployment configuration.
+
+Authenticated users receive these models automatically in the web and Word
+pickers and model preferences, grouped and sourced under the configured label.
+The machine provider remains `gateway`. Stored IDs are `gateway/<raw-id>`;
+Mike removes exactly one prefix before forwarding, preserving aliases and
+nested IDs (including raw IDs beginning with `gateway/`). The server checks
+catalog membership for every invocation, independently of user router selections.
+Endpoint credentials are never exposed through catalog or profile responses.
+
+Usable saved preferences and explicit choices take precedence. When none are
+usable, configured gateway defaults cover chat, automatic titles/lightweight
+extractions, and tabular review, including stale native preferences without a
+usable key. Explicit unavailable requests return an error. An installation with
+no gateway configuration retains its existing model-selection behavior. Personal
+native keys remain supported; this feature does not enforce gateway-only use.
+
+There is no `/models` discovery or `GATEWAY_HEADERS` support in this version.
+Gateway models do not advertise reasoning or vision capabilities, and Mike does
+not send reasoning controls. Operators must configure models that support Mike's
+required tools. Validate streaming and a tool-call/result round trip against your
+actual endpoint before rollout; presence in the catalog does not prove tool
+support. Automated transport tests exercise an OpenAI-compatible HTTP fixture.

--- a/frontend/src/app/(pages)/settings/models/page.tsx
+++ b/frontend/src/app/(pages)/settings/models/page.tsx
@@ -96,8 +96,10 @@ export default function ModelPreferencesPage() {
                     <div className="px-4 py-5">
                         <FieldLabel>Title generation model</FieldLabel>
                         <p className="text-xs text-gray-400 mb-2">
-                            By default, titles use the cheapest model from the
-                            chat provider. Choose a model here to override that.
+                            {profile?.apiKeys.gateway?.available
+                                ? `By default, titles use the ${profile.apiKeys.gateway.label} deployment default.`
+                                : "By default, titles use the cheapest model from the chat provider."}
+                            {" "}Choose a model here to override that.
                         </p>
                         <ModelPreferenceDropdown
                             value={canonicalModelId(
@@ -107,6 +109,7 @@ export default function ModelPreferencesPage() {
                             )}
                             options={[
                                 ...SETTINGS_MODELS,
+                                ...(profile?.apiKeys.gateway?.models ?? []),
                                 ...selectedOpenRouterOptions,
                                 ...selectedVercelOptions,
                                 ...selectedOpenCodeGoOptions,
@@ -115,7 +118,9 @@ export default function ModelPreferencesPage() {
                             apiKeys={profile?.apiKeys}
                             isSaving={savingField === "titleModel"}
                             isSaved={savedField === "titleModel"}
-                            emptyOptionLabel="Automatic — same provider as chat"
+                            emptyOptionLabel={profile?.apiKeys.gateway?.available
+                                ? "Automatic — deployment default"
+                                : "Automatic — same provider as chat"}
                             onChange={(id) =>
                                 handleModelChange("titleModel", id)
                             }
@@ -135,6 +140,7 @@ export default function ModelPreferencesPage() {
                             )}
                             options={[
                                 ...MODELS,
+                                ...(profile?.apiKeys.gateway?.models ?? []),
                                 ...selectedOpenRouterOptions,
                                 ...selectedVercelOptions,
                                 ...selectedOpenCodeGoOptions,

--- a/frontend/src/app/components/assistant/ChatInput.tsx
+++ b/frontend/src/app/components/assistant/ChatInput.tsx
@@ -823,6 +823,7 @@ export const ChatInput = forwardRef<ChatInputHandle, Props>(function ChatInput(
             <ApiKeyMissingPopup
                 open={apiKeyModalProvider !== null}
                 provider={apiKeyModalProvider}
+                gatewayLabel={profile?.apiKeys.gateway?.label}
                 onClose={() => setApiKeyModalProvider(null)}
             />
             <NoModelsWarningPopup

--- a/frontend/src/app/components/assistant/ModelToggle.render.test.tsx
+++ b/frontend/src/app/components/assistant/ModelToggle.render.test.tsx
@@ -26,7 +26,7 @@ function keys(configured: Partial<Record<keyof ApiKeyState, boolean>>) {
                 source: configured[provider] ? "user" : null,
             },
         ]),
-    ) as ApiKeyState;
+    ) as unknown as ApiKeyState;
 }
 
 describe("ModelToggle responsive trigger", () => {
@@ -331,5 +331,24 @@ describe("ModelToggle provider grouping", () => {
 
         expect(screen.getByText("Direct")).toBeInTheDocument();
         expect(screen.getByText("OpenRouter")).toBeInTheDocument();
+    });
+});
+
+
+describe("deployment gateway models", () => {
+    it("shows configured names and group/source without router selections or reasoning", async () => {
+        const apiKeys = keys({});
+        apiKeys.gateway = { provider: "gateway", label: "Legal models", available: true, defaultModel: "gateway/legal-chat", models: [
+            { id: "gateway/legal-chat", label: "Legal chat", group: "Legal models", source: "Legal models", provider: "gateway", available: true },
+            { id: "gateway/offline", label: "Unavailable model", group: "Legal models", source: "Legal models", provider: "gateway", available: false },
+        ] };
+        const onChange = vi.fn();
+        render(<ModelToggle value="gateway/legal-chat" onChange={onChange} apiKeys={apiKeys} reasoningLevel="high" onReasoningChange={vi.fn()} />);
+        await userEvent.click(screen.getByRole("button", { name: "Choose model" }));
+        expect(screen.getAllByText("Legal models").length).toBeGreaterThan(0);
+        expect(screen.getAllByText("Legal chat").length).toBeGreaterThan(0);
+        expect(screen.queryByText("Unavailable model")).not.toBeInTheDocument();
+        expect(screen.queryByRole("slider")).not.toBeInTheDocument();
+        expect(screen.queryByText("Gemini 3.7 Flash")).not.toBeInTheDocument();
     });
 });

--- a/frontend/src/app/components/assistant/ModelToggle.tsx
+++ b/frontend/src/app/components/assistant/ModelToggle.tsx
@@ -246,6 +246,7 @@ export function ModelToggle({
   const ollamaModels = useOllamaModels();
   const models = [
     ...MODELS,
+    ...(apiKeys?.gateway?.models ?? []),
     ...openRouterModelOptions(openRouterModels),
     ...vercelModelOptions(vercelModels),
     ...openCodeGoModelOptions(openCodeGoModels),
@@ -299,7 +300,7 @@ export function ModelToggle({
       onEmptyClick={
         onNoModelsClick ? () => onNoModelsClick(emptyReason) : undefined
       }
-      reasoningLevel={normalizedReasoningLevel}
+      reasoningLevel={value.startsWith("gateway/") ? undefined : normalizedReasoningLevel}
       onReasoningChange={onReasoningChange}
       reasoningLevels={supportedReasoningLevels}
     />

--- a/frontend/src/app/components/popups/ApiKeyMissingPopup.tsx
+++ b/frontend/src/app/components/popups/ApiKeyMissingPopup.tsx
@@ -11,27 +11,30 @@ interface Props {
     provider: ModelProvider | null;
     /** Optional override for the body sentence. */
     message?: string;
+    gatewayLabel?: string;
 }
 
-export function ApiKeyMissingPopup({ open, onClose, provider, message }: Props) {
+export function ApiKeyMissingPopup({ open, onClose, provider, message, gatewayLabel }: Props) {
     const router = useRouter();
     if (!open) return null;
 
-    const providerName = provider ? providerLabel(provider) : "this provider";
+    const providerName = provider ? providerLabel(provider, gatewayLabel) : "this provider";
     const body =
         message ??
-        `You haven't added a ${providerName} API key yet. Add one in Settings to use this model.`;
+        (provider === "gateway"
+            ? `${providerName} model is unavailable. Select a configured model or contact your deployment administrator.`
+            : `You haven't added a ${providerName} API key yet. Add one in Settings to use this model.`);
 
     const handleGoToSettings = () => {
         onClose();
-        router.push("/settings/byok");
+        router.push(provider === "gateway" ? "/settings/models" : "/settings/byok");
     };
 
     return (
         <WarningPopup
             open={open}
             onClose={onClose}
-            title="API key required"
+            title={provider === "gateway" ? "Model unavailable" : "API key required"}
             message={body}
             icon={
                 <AlertTriangle className="mt-0.5 h-3.5 w-3.5 shrink-0 text-red-600" />

--- a/frontend/src/app/contexts/UserProfileContext.tsx
+++ b/frontend/src/app/contexts/UserProfileContext.tsx
@@ -140,6 +140,7 @@ function emptyApiKeys(): ApiKeyState {
 function toProfile(data: ApiUserProfile): UserProfile {
     const { apiKeyStatus, ...profile } = data;
     const apiKeys = emptyApiKeys();
+    apiKeys.gateway = apiKeyStatus.gateway;
     for (const provider of API_KEY_PROVIDERS) {
         apiKeys[provider] = {
             configured: !!apiKeyStatus[provider],

--- a/frontend/src/app/hooks/useSelectedModel.ts
+++ b/frontend/src/app/hooks/useSelectedModel.ts
@@ -20,6 +20,7 @@ export function isAllowedModelId(id: string): boolean {
     return (
         ALLOWED_MODEL_IDS.has(id) ||
         id.startsWith("ollama/") ||
+        id.startsWith("gateway/") ||
         ROUTER_SLUGS.some((slug) => id.startsWith(`${slug}/`))
     );
 }

--- a/frontend/src/app/lib/mikeApi.test.ts
+++ b/frontend/src/app/lib/mikeApi.test.ts
@@ -55,6 +55,7 @@ import {
     getLibraryFolderPath,
     getMcpConnector,
     getOllamaModels,
+    getGatewayModels,
     getOpenCodeGoModels,
     getOpenRouterModels,
     getVercelModels,
@@ -2662,6 +2663,13 @@ describe("unwrapping and blob wrappers", () => {
         expect(workflowAddonAssetDisplayUrl("workflow/1", "asset 1")).toBe(
             "/api/workflow-addons/workflow%2F1/assets/asset%201/display",
         );
+    });
+
+    it("loads the deployment-managed gateway catalog", async () => {
+        const catalog = { provider: "gateway", label: "Legal models", available: true, defaultModel: "gateway/legal-chat", models: [] };
+        fetchMock.mockResolvedValue(jsonResponse(catalog));
+        await expect(getGatewayModels()).resolves.toEqual(catalog);
+        expect(lastFetchCall().url).toBe("/api/models/gateway");
     });
 
     it("getOllamaModels unwraps the models envelope", async () => {

--- a/frontend/src/app/lib/mikeApi.ts
+++ b/frontend/src/app/lib/mikeApi.ts
@@ -693,15 +693,28 @@ export type ApiKeyProvider =
     | "opencode-go"
     | "courtlistener";
 export type ApiKeySource = "user" | "env" | null;
+export interface GatewayCatalog {
+    provider: "gateway";
+    label: string;
+    available: boolean;
+    defaultModel: string | null;
+    models: { id: string; label: string; group: string; source: string; provider: "gateway"; available: boolean }[];
+}
+
+export async function getGatewayModels(): Promise<GatewayCatalog> {
+    return apiRequest<GatewayCatalog>("/models/gateway");
+}
+
 export type ApiKeyState = Record<
     ApiKeyProvider,
     {
         configured: boolean;
         source: ApiKeySource;
     }
->;
+> & { gateway?: GatewayCatalog };
 
 export type ApiKeyStatus = Record<ApiKeyProvider, boolean> & {
+    gateway?: GatewayCatalog;
     sources?: Partial<Record<ApiKeyProvider, ApiKeySource>>;
 };
 

--- a/frontend/src/app/lib/modelAvailability.ts
+++ b/frontend/src/app/lib/modelAvailability.ts
@@ -11,9 +11,11 @@ export type ModelProvider =
     | "openrouter"
     | "vercel"
     | "opencode-go"
+    | "gateway"
     | "ollama";
 
 export function getModelProvider(modelId: string): ModelProvider | null {
+    if (modelId.startsWith("gateway/")) return "gateway";
     if (modelId.startsWith("ollama/")) return "ollama"; // dynamic, not in the static list
     if (modelId.startsWith("openrouter/")) return "openrouter";
     if (modelId.startsWith("vercel/")) return "vercel";
@@ -27,6 +29,7 @@ export function isModelAvailable(
     modelId: string,
     apiKeys: ApiKeyState,
 ): boolean {
+    if (modelId.startsWith("gateway/")) return !!apiKeys.gateway?.models.some((model) => model.id === modelId && model.available);
     const provider = getModelProvider(modelId);
     if (!provider) return false;
     return isProviderAvailable(provider, apiKeys);
@@ -36,11 +39,13 @@ export function isProviderAvailable(
     provider: ModelProvider,
     apiKeys: ApiKeyState,
 ): boolean {
+    if (provider === "gateway") return !!apiKeys.gateway?.available;
     if (provider === "ollama") return true; // local, no key needed
     return !!apiKeys[provider]?.configured;
 }
 
-export function providerLabel(provider: ModelProvider): string {
+export function providerLabel(provider: ModelProvider, gatewayLabel = "Gateway"): string {
+    if (provider === "gateway") return gatewayLabel;
     if (provider === "claude") return "Anthropic (Claude)";
     if (provider === "openai") return "OpenAI";
     if (provider === "openrouter") return "OpenRouter";

--- a/frontend/src/wordAddin/catalogParity.test.ts
+++ b/frontend/src/wordAddin/catalogParity.test.ts
@@ -176,7 +176,7 @@ describe("word add-in catalog parity", () => {
                         source: provider === configured ? "user" : null,
                     },
                 ]),
-            ) as ApiKeyState;
+            ) as unknown as ApiKeyState;
             for (const id of sharedIds) {
                 expect
                     .soft(
@@ -187,4 +187,18 @@ describe("word add-in catalog parity", () => {
             }
         }
     });
+});
+
+
+it("keeps gateway membership and availability identical across clients", () => {
+    const gateway = { provider: "gateway" as const, label: "Legal models", available: true, defaultModel: "gateway/legal-chat", models: [
+        { id: "gateway/legal-chat", label: "Legal chat", group: "Legal models", source: "Legal models", provider: "gateway" as const, available: true },
+        { id: "gateway/offline", label: "Offline", group: "Legal models", source: "Legal models", provider: "gateway" as const, available: false },
+    ] };
+    const web = { gateway } as ApiKeyState;
+    const addin = { gateway } as unknown as ApiKeyStatus;
+    for (const id of ["gateway/legal-chat", "gateway/offline", "gateway/unlisted"]) {
+        expect(addinIsModelAvailable(id, addin)).toBe(webIsModelAvailable(id, web));
+        expect(webIsModelAvailable(id, web)).toBe(id === "gateway/legal-chat");
+    }
 });

--- a/word-addin/src/taskpane/api/client.ts
+++ b/word-addin/src/taskpane/api/client.ts
@@ -260,7 +260,20 @@ export async function updateLastSelectedReasoningLevel(
   });
 }
 
+export interface GatewayCatalog {
+  provider: "gateway";
+  label: string;
+  available: boolean;
+  defaultModel: string | null;
+  models: { id: string; label: string; group: string; source: string; available: boolean }[];
+}
+
+export async function getGatewayModels(): Promise<GatewayCatalog> {
+  return apiRequest<GatewayCatalog>("/models/gateway");
+}
+
 export interface ApiKeyStatus {
+  gateway?: GatewayCatalog;
   claude: boolean;
   gemini: boolean;
   openai: boolean;

--- a/word-addin/src/taskpane/components/assistant/ChatInput.tsx
+++ b/word-addin/src/taskpane/components/assistant/ChatInput.tsx
@@ -405,7 +405,9 @@ export const ChatInput = forwardRef<ChatInputHandle, ChatInputProps>(
       }
       if (!isModelAvailable(model, keyStatus)) {
         setModelError(
-          `Add a ${missingModelProvider(model)} API key before using this model.`,
+          model.startsWith("gateway/")
+            ? `${keyStatus?.gateway?.label ?? "Gateway"} model is unavailable. Select another model.`
+            : `Add a ${missingModelProvider(model)} API key before using this model.`,
         );
         return;
       }

--- a/word-addin/src/taskpane/components/assistant/ModelToggle.tsx
+++ b/word-addin/src/taskpane/components/assistant/ModelToggle.tsx
@@ -68,6 +68,7 @@ export function ModelToggle({
     }));
     return [
       ...STATIC_MODELS,
+      ...(keyStatus?.gateway?.models ?? []),
       ...openRouterOptions,
       ...vercelOptions,
       ...openCodeGoOptions,
@@ -116,7 +117,7 @@ export function ModelToggle({
       compact={compact}
       emptyLabel="No Models"
       onEmptyClick={onNoModelsClick}
-      reasoningLevel={normalizedReasoningLevel}
+      reasoningLevel={value.startsWith("gateway/") ? undefined : normalizedReasoningLevel}
       onReasoningChange={onReasoningChange}
       reasoningLevels={supportedReasoningLevels}
     />

--- a/word-addin/src/taskpane/components/shell/ApiKeyBanner.tsx
+++ b/word-addin/src/taskpane/components/shell/ApiKeyBanner.tsx
@@ -55,7 +55,7 @@ export function ApiKeyBanner(): React.ReactElement | null {
     getApiKeyStatus()
       .then((status: ApiKeyStatus) => {
         if (cancelled) return;
-        const anyConfigured = status.claude || status.gemini || status.openai;
+        const anyConfigured = status.claude || status.gemini || status.openai || status.gateway?.available;
         setMissingKey(!anyConfigured);
       })
       .catch(() => {

--- a/word-addin/src/taskpane/lib/modelCatalog.ts
+++ b/word-addin/src/taskpane/lib/modelCatalog.ts
@@ -182,6 +182,7 @@ export function isAllowedModelId(id: string): boolean {
   return (
     ALLOWED_MODEL_IDS.has(id) ||
     id.startsWith("ollama/") ||
+    id.startsWith("gateway/") ||
     ROUTER_SLUGS.some((slug) => id.startsWith(`${slug}/`))
   );
 }
@@ -196,6 +197,7 @@ export function isModelAvailable(
   // blocking sends here on a flaky WKWebView request would brick the composer
   // for requests the backend would happily accept.
   if (!status) return true;
+  if (modelId.startsWith("gateway/")) return !!status.gateway?.models.some((model) => model.id === modelId && model.available);
   if (modelId.startsWith("openrouter/")) return !!status.openrouter;
   if (modelId.startsWith("vercel/")) return !!status.vercel;
   if (modelId.startsWith("opencode-go/")) return !!status["opencode-go"];
@@ -206,7 +208,8 @@ export function isModelAvailable(
   return !!status.openai;
 }
 
-export function missingModelProvider(modelId: string): string {
+export function missingModelProvider(modelId: string, gatewayLabel = "Gateway"): string {
+  if (modelId.startsWith("gateway/")) return gatewayLabel;
   const group = STATIC_MODELS.find((item) => item.id === modelId)?.group;
   if (modelId.startsWith("openrouter/") || group === "OpenRouter") {
     return "OpenRouter";


### PR DESCRIPTION
Implements #437.

## Summary

Self-hosted deployments can configure a first-class `gateway` provider for OpenAI-compatible Chat Completions endpoints, such as LiteLLM, Bifrost and Portkey. Users receive the deployment's configured models automatically in web and Word pickers without saving personal router selections.

## Changes

Add a shared server configuration parser for `GATEWAY_BASE_URL`, `GATEWAY_MODELS`, optional `GATEWAY_API_KEY`, `GATEWAY_LABEL` and `GATEWAY_DEFAULT_MODEL`. Validate URL shape, catalog delimiters, unique non-empty IDs and default membership. Use the existing compatible SDK and shared completion/streaming paths. Strip exactly one `gateway/` prefix, preserve aliases and nested IDs, and enforce configuration-backed membership before inference.

Expose a safe authenticated catalog at `/models/gateway` and include gateway availability in profile/key-status responses. Endpoint credentials remain server-only. Web and Word pickers use configured display names and the deployment label as group/source, retain `gateway` as the machine provider, and omit unsupported reasoning controls. Model preferences and unavailable-model diagnostics recognize the deployment provider.

Resolve missing or unusable preferences to the configured default for chat, titles/lightweight generation and tabular review, including stored native selections without a usable key. Keep usable preferences and explicit model choices; reject explicit unavailable models. Vercel's adapter/catalog and unconfigured installations retain their existing behavior.

Document direct-backend and Compose configuration in both environment examples, deployment documentation and README. No migration is needed: existing model preference/review columns are unconstrained text, and gateway configuration is not stored in per-user key or router-selection tables. Compose already loads the documented environment files.

`GATEWAY_HEADERS`, discovery and advertised vision/reasoning capabilities remain outside this change. Personal native keys remain usable.

## Why

A distinct provider lets deployment operators use their own endpoint and model aliases without inheriting another provider's catalog or protocol assumptions. Server membership checks prevent crafted requests from spending deployment credentials on unlisted models.

## Testing

Final verification used Node 22.23.2:

- `npm run build --prefix backend`: passed.
- `npm test --prefix backend`, final run 1: 114 files passed, 6 skipped; 1,418 tests passed, 39 skipped.
- `npm test --prefix backend`, final run 2: identical passing results.
- `npm run build --prefix frontend`: passed.
- `npm run lint --prefix frontend`: passed with 0 errors and 34 warnings.
- `npm test --prefix frontend`: 141 files and 983 tests passed.
- `npm run typecheck --prefix word-addin`: passed after installing locked dependencies.
- `git diff --check`: passed.

Regression coverage includes parser failures, exact prefix removal, optional bearer authentication, request bodies without reasoning fields, streamed tool call/result/final text, catalog/profile exposure, server membership rejection, chat/title/tabular defaults and web/Word availability parity.

An initial backend run caught a title-switch fall-through introduced during implementation; it was corrected before the two final passing runs. The initial frontend run under the host's Node 26.7.0 failed on localStorage/Blob behavior; the complete suite passed under Node 22 without changes to unrelated tests.

Transport tests use an OpenAI-compatible HTTP response fixture.

## Live validation

This branch, merged unchanged onto current `main` (8b3466f), runs in a self-hosted pilot deployment with Bifrost as the gateway. Verified on 2026-09-08:

- Web picker shows the configured gateway group with five models and the deployment label; personal router selections were not required.
- Streamed chat completion and the follow-up title generation both reached the gateway on the configured default model (an Anthropic model routed through Bifrost). A second configured model (Gemini via Vertex) also returned 200 through the same virtual key.
- Bearer authentication with `GATEWAY_API_KEY` works; `/models/gateway` and `/user` responses do not expose the key.
- Unset configuration leaves existing provider behaviour unchanged.

Not yet exercised in the deployment: the Word add-in picker and tabular review against the gateway. Both are covered by the test suite.
