### PR TITLE
fix: keep Unicode titles in generated document filenames

### DIFF
--- a/backend/src/lib/chat/tools/__tests__/documentOps.generatedFilename.test.ts
+++ b/backend/src/lib/chat/tools/__tests__/documentOps.generatedFilename.test.ts
@@ -1,0 +1,248 @@
+import { describe, it, expect, vi, beforeEach, afterAll } from "vitest";
+import JSZip from "jszip";
+
+// The title a user asks for is the only human-readable part of a generated
+// document's name, and it travels through three surfaces that have to agree:
+// the tool result the model reports, the persisted version row, and the signed
+// download token the browser follows. These tests use the real storage-key
+// helper and the real token signer, because a mocked key or a mocked download
+// URL cannot show whether the title survived either of them.
+
+const uploadFile = vi.fn(async () => {});
+
+vi.mock("../../../storage", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../../storage")>()),
+  uploadFile: (...a: unknown[]) => uploadFile(...a),
+  downloadFile: vi.fn(async () => null),
+}));
+
+const docxToPdf = vi.fn(async () => Buffer.from("pdf-bytes"));
+vi.mock("../../../convert", () => ({
+  docxToPdf: (...a: unknown[]) => docxToPdf(...a),
+  convertedPdfKey: (userId: string, docId: string) =>
+    `converted-pdfs/${userId}/${docId}.pdf`,
+}));
+
+vi.mock("../../../queue/conversionQueue", () => ({
+  enqueueConversion: vi.fn(async () => ({})),
+}));
+
+vi.mock("../../../supabase", () => ({
+  createServerSupabase: vi.fn(),
+}));
+
+import { buildContentDisposition } from "../../../storage";
+import { verifyDownload } from "../../../downloadTokens";
+import {
+  generateDocx,
+  generateExcel,
+  generatePpt,
+  safeGeneratedFilename,
+} from "../documentOps";
+
+process.env.DOWNLOAD_SIGNING_SECRET = "test-secret-32-bytes-long-enough!!";
+
+afterAll(() => {
+  delete process.env.DOWNLOAD_SIGNING_SECRET;
+});
+
+type Insert = { table: string; payload: Record<string, unknown> };
+
+// Chainable Supabase double: records inserts, returns fixed ids.
+function makeDb() {
+  const inserts: Insert[] = [];
+  function from(table: string) {
+    const b: Record<string, unknown> = {
+      insert(payload: Record<string, unknown>) {
+        inserts.push({ table, payload });
+        return b;
+      },
+      update: () => b,
+      select: () => b,
+      eq: () => b,
+      single: () =>
+        Promise.resolve({
+          data: { id: table === "documents" ? "doc-db-1" : "ver-db-1" },
+          error: null,
+        }),
+      then: (onF: (v: unknown) => unknown) =>
+        Promise.resolve({ data: null, error: null }).then(onF),
+    };
+    return b;
+  }
+  return { inserts, from };
+}
+
+const SECTIONS = [{ heading: "Clause 1", content: "Body." }];
+const SHEETS = [{ name: "Sheet1", columns: ["Value"], rows: [["a"]] }];
+const SLIDES = [{ title: "One", bullets: ["a"] }];
+
+const JAPANESE_TITLE = "秘密保持契約書";
+
+type Generated = {
+  filename: string;
+  download_url: string;
+};
+
+async function generate(extension: "docx" | "xlsx" | "pptx", title: string) {
+  const db = makeDb();
+  const result =
+    extension === "docx"
+      ? await generateDocx(title, SECTIONS, "user-1", db as never)
+      : extension === "xlsx"
+        ? await generateExcel(title, SHEETS, "user-1", db as never)
+        : await generatePpt(title, SLIDES, "user-1", db as never);
+
+  expect(result).not.toHaveProperty("error");
+  const generated = result as Generated;
+  const version = db.inserts.find((i) => i.table === "document_versions");
+  const upload = uploadFile.mock.calls.find(
+    (call) => typeof call[0] === "string" && call[0].endsWith(`.${extension}`),
+  ) as unknown as [string, ArrayBuffer, string] | undefined;
+  expect(upload).toBeDefined();
+
+  return {
+    filename: generated.filename,
+    versionFilename: version?.payload.filename,
+    versionStoragePath: version?.payload.storage_path,
+    uploadedKey: upload![0],
+    uploadedBytes: upload![1],
+    tokenFilename: verifyDownload(
+      generated.download_url.replace("/download/", ""),
+    )?.filename,
+  };
+}
+
+beforeEach(() => {
+  uploadFile.mockClear();
+  docxToPdf.mockClear();
+});
+
+describe("safeGeneratedFilename", () => {
+  it.each([
+    ["秘密保持契約書", "秘密保持契約書.docx"],
+    ["資料使用協議", "資料使用協議.docx"],
+    ["비밀유지계약서", "비밀유지계약서.docx"],
+    ["Договор", "Договор.docx"],
+    ["Σύμβαση", "Σύμβαση.docx"],
+    ["عقد", "عقد.docx"],
+    ["अनुबंध", "अनुबंध.docx"],
+    ["Résumé", "Résumé.docx"],
+    // Decomposed input composes to the same name as the precomposed one.
+    ["Re\u0301sume\u0301", "Résumé.docx"],
+    // Compatibility characters are kept as themselves rather than folded to
+    // ASCII: the normalization is NFC, not NFKC.
+    ["①", "①.docx"],
+    ["１２３", "１２３.docx"],
+  ])("keeps the letters and numbers of %s", (title, expected) => {
+    expect(safeGeneratedFilename(title, "docx")).toBe(expected);
+  });
+
+  it.each([
+    ["NDA 2026 - Draft", "NDA 2026 - Draft.docx"],
+    ["---", "---.docx"],
+    ["", "document.docx"],
+    ['.../\\:*?"<>|', "document.docx"],
+  ])("leaves the existing behaviour for %s unchanged", (title, expected) => {
+    expect(safeGeneratedFilename(title, "docx")).toBe(expected);
+  });
+
+  it("drops separators, controls and other non-name characters", () => {
+    // Slash, backslash, CR, LF, non-breaking space, minus sign, zero-width
+    // joiner, right-to-left override.
+    const title = "a/b\\c\r\nd\u00a0e\u2212f\u200dg\u202eh";
+    expect(safeGeneratedFilename(title, "docx")).toBe("abcdefgh.docx");
+  });
+
+  it("uses the caller's extension, never one implied by the title", () => {
+    expect(safeGeneratedFilename("report.exe", "docx")).toBe("reportexe.docx");
+  });
+
+  it("falls back when nothing readable survives", () => {
+    // Combining marks with no base letter are not a name anyone can read.
+    expect(safeGeneratedFilename("\u0301\u0301", "docx")).toBe("document.docx");
+    expect(safeGeneratedFilename("   ", "docx")).toBe("document.docx");
+    expect(safeGeneratedFilename(undefined as never, "docx")).toBe(
+      "document.docx",
+    );
+  });
+
+  it("bounds the stem on whole characters", () => {
+    expect(safeGeneratedFilename("a".repeat(70), "docx")).toBe(
+      `${"a".repeat(64)}.docx`,
+    );
+
+    // A supplementary-plane letter costs two UTF-16 units, so it does not fit
+    // after 63 of them. Splitting it would leave an unpaired surrogate that
+    // the download header's percent-encoding cannot represent.
+    const straddling = safeGeneratedFilename(
+      `${"a".repeat(63)}\u{20000}`,
+      "docx",
+    );
+    expect(straddling).toBe(`${"a".repeat(63)}.docx`);
+    expect(() => encodeURIComponent(straddling)).not.toThrow();
+
+    // Combining marks belong to the letter they sit on.
+    expect(
+      safeGeneratedFilename(`${"a".repeat(63)}e\u0301\u0302`, "docx"),
+    ).toBe(`${"a".repeat(63)}.docx`);
+
+    // A single character longer than the whole budget leaves nothing. The
+    // first mark composes onto the "a", so this is 70 UTF-16 units in one
+    // cluster.
+    expect(safeGeneratedFilename(`a${"\u0301".repeat(70)}`, "docx")).toBe(
+      "document.docx",
+    );
+  });
+});
+
+describe("generated document naming", () => {
+  it.each(["docx", "xlsx", "pptx"] as const)(
+    "%s: one Unicode name reaches the result, the version row and the download token",
+    async (extension) => {
+      const out = await generate(extension, JAPANESE_TITLE);
+      const expected = `${JAPANESE_TITLE}.${extension}`;
+
+      expect(out.filename).toBe(expected);
+      expect(out.versionFilename).toBe(expected);
+      expect(out.tokenFilename).toBe(expected);
+      expect(out.versionStoragePath).toBe(out.uploadedKey);
+    },
+  );
+
+  it("does not put the title in the storage key", async () => {
+    const ascii = await generate("docx", "Mutual NDA");
+    const japanese = await generate("docx", JAPANESE_TITLE);
+    const withoutDocId = (key: string) =>
+      key.replace(/^generated\/user-1\/[0-9a-f]+\//, "generated/user-1/*/");
+
+    expect(withoutDocId(ascii.uploadedKey)).toBe(
+      "generated/user-1/*/generated.docx",
+    );
+    expect(withoutDocId(japanese.uploadedKey)).toBe(
+      withoutDocId(ascii.uploadedKey),
+    );
+  });
+
+  it("serves the Unicode name in the download header with an ASCII fallback", async () => {
+    const out = await generate("docx", JAPANESE_TITLE);
+    const header = buildContentDisposition("attachment", out.filename);
+
+    const extended = header.match(/filename\*=UTF-8''([^;]+)$/);
+    expect(extended).not.toBeNull();
+    expect(decodeURIComponent(extended![1])).toBe(`${JAPANESE_TITLE}.docx`);
+
+    const ascii = header.match(/filename="([^"]+)"/);
+    expect(ascii).not.toBeNull();
+    expect(ascii![1]).toMatch(/^[\x20-\x7e]+\.docx$/);
+  });
+
+  it.each(["docx", "xlsx", "pptx"] as const)(
+    "%s: a Unicode name still produces a valid package",
+    async (extension) => {
+      const out = await generate(extension, JAPANESE_TITLE);
+      const archive = await JSZip.loadAsync(out.uploadedBytes);
+      expect(archive.file("[Content_Types].xml")).not.toBeNull();
+    },
+  );
+});

--- a/backend/src/lib/chat/tools/documentOps.ts
+++ b/backend/src/lib/chat/tools/documentOps.ts
@@ -553,12 +553,7 @@ export async function generateDocx(
       }
     }
     const docId = crypto.randomUUID().replace(/-/g, "");
-    const safeTitle =
-      title
-        .replace(/[^a-zA-Z0-9 -]/g, "")
-        .trim()
-        .slice(0, 64) || "document";
-    const filename = `${safeTitle}.docx`;
+    const filename = safeGeneratedFilename(title, "docx");
     const key = generatedDocKey(userId, docId, filename);
 
     await uploadFile(
@@ -632,14 +627,48 @@ export async function generateDocx(
   }
 }
 
+const GENERATED_FILENAME_MAX_UNITS = 64;
+
+const graphemeSegmenter = new Intl.Segmenter(undefined, {
+  granularity: "grapheme",
+});
+
+/**
+ * Filename stem for a generated document.
+ *
+ * The title is prose the user asked for, so the stem keeps letters, marks and
+ * numbers in any script alongside the spaces and hyphens the ASCII-only
+ * version already allowed, and still drops path separators, control and
+ * formatting characters, and punctuation. Normalization is NFC rather than
+ * NFKC: "e" + U+0301 becomes "é", but fullwidth and circled characters stay
+ * themselves instead of being folded into ASCII.
+ *
+ * The length bound walks whole grapheme clusters, so a truncated stem can
+ * never end in half a character — half of a supplementary-plane letter is an
+ * unpaired surrogate, which the download header's percent-encoding cannot
+ * represent.
+ */
+function generatedFilenameStem(title: string): string {
+  const allowed = title
+    .normalize("NFC")
+    .replace(/[^\p{L}\p{M}\p{N} -]/gu, "")
+    // Filtering can leave a mark next to a base it was not adjacent to.
+    .normalize("NFC")
+    .trim();
+
+  let stem = "";
+  for (const { segment } of graphemeSegmenter.segment(allowed)) {
+    if (stem.length + segment.length > GENERATED_FILENAME_MAX_UNITS) break;
+    stem += segment;
+  }
+
+  // Marks and spaces alone are not a name anyone can read.
+  return /^[\p{M}\s]*$/u.test(stem) ? "" : stem;
+}
+
 export function safeGeneratedFilename(title: string, extension: string) {
   const rawTitle = typeof title === "string" ? title : "document";
-  const safeTitle =
-    rawTitle
-      .replace(/[^a-zA-Z0-9 -]/g, "")
-      .trim()
-      .slice(0, 64) || "document";
-  return `${safeTitle}.${extension}`;
+  return `${generatedFilenameStem(rawTitle) || "document"}.${extension}`;
 }
 
 function xmlEscape(value: unknown) {


### PR DESCRIPTION
## Summary

Generated DOCX, XLSX and PPTX files are named by stripping every character
outside `[a-zA-Z0-9 -]` from the title, so a title in any script but unaccented
Latin loses its name. This gives all three generators one naming policy that
keeps Unicode letters, marks and numbers, and adds a regression suite for it.

Fixes #448. Two files, +289/-12 at `c737c7c`.

## Why / Motivation

Both naming sites — the inline one in `generateDocx` and `safeGeneratedFilename`,
which `persistGeneratedFile` uses for XLSX and PPTX — apply the same character
class, so on `main` today:

| Title | Before | After |
| --- | --- | --- |
| `秘密保持契約書` | `document.docx` | `秘密保持契約書.docx` |
| `비밀유지계약서` | `document.docx` | `비밀유지계약서.docx` |
| `Договор` | `document.docx` | `Договор.docx` |
| `Σύμβαση` | `document.docx` | `Σύμβαση.docx` |
| `عقد` | `document.docx` | `عقد.docx` |
| `अनुबंध` | `document.docx` | `अनुबंध.docx` |
| `Résumé` | `Rsum.docx` | `Résumé.docx` |

That one string is the tool result the model reports, the
`document_versions.filename` row, and the filename inside the signed
`/download/:token` payload, so for those users the name is `document.docx` in
the chat message the tool returns, in the document list, and in the file the
browser saves.

Nothing downstream required an ASCII name. `buildContentDisposition` already
emits a UTF-8 `filename*` with an ASCII fallback; `generatedDocKey` derives the
object key from a random id and the extension, so the key never held the title;
the download token is base64url over UTF-8 JSON. And an *uploaded*
`秘密保持契約書.docx` already keeps its name — `uploadProcessing.ts` writes
`file.filename` into `document_versions.filename` verbatim. Only the generated
half was lossy.

## Changes

- `safeGeneratedFilename` keeps Unicode letters, marks and numbers alongside the
  space and hyphen it already allowed. Everything the old class rejected —
  path separators, control and formatting characters, punctuation — is still
  rejected, and an empty result still falls back to `document`.
- Normalization is NFC, not NFKC, so `e` + `U+0301` composes to `é` while
  fullwidth digits and `①` stay themselves instead of folding into ASCII.
- The 64-unit length bound now walks whole grapheme clusters. This only starts
  to matter here: the old class deleted every non-ASCII character before
  truncating, so `.slice(0, 64)` had nothing multi-unit left to cut. Once the
  stem can hold supplementary-plane letters and combining sequences, a
  code-unit cut can leave an unpaired surrogate — which `encodeURIComponent`,
  and so the `Content-Disposition` `filename*` value, cannot encode — or
  detach a mark from its base.
- `generateDocx` calls `safeGeneratedFilename` instead of repeating it inline,
  so there is one policy rather than two copies of one.
- New `backend/src/lib/chat/tools/__tests__/documentOps.generatedFilename.test.ts`
  drives the three real generators and asserts the tool result, the persisted
  version row and the decoded download token carry the same name; that the
  storage key is still independent of the title; that the response header
  carries the UTF-8 name with an ASCII fallback; and that the packages remain
  valid. It uses the real `generatedDocKey` and the real token signer, because
  a mocked key or URL cannot show whether the name survived them.

## Tradeoffs & risks

- ASCII behaviour is unchanged, including `---`, the empty-title and
  punctuation-only fallbacks, the fixed caller-supplied extension, and 64-unit
  truncation of a long ASCII title. Those cases are pinned by tests that pass on
  `main` as well.
- Format characters (`Cf`), including ZWJ and ZWNJ, remain excluded. Some
  scripts use them orthographically; preserving them safely needs its own
  design, so this patch does not claim universal orthographic fidelity.
- The ASCII fallback in `Content-Disposition` becomes a row of underscores for a
  fully non-Latin name. That is what the existing `sanitizeDispositionFilename`
  already does for uploaded files with the same names, and `filename*` is what
  browsers use.
- Out of scope, same assumption, different behaviour: `normalizeHeadingText` in
  the same file also reduces to `[a-zA-Z0-9]`, so the "first heading repeats the
  title" suppression in `generateDocx` never fires for a non-Latin title. Worth
  a separate change; it is not a filename question.
- Coordination: #356 also removes the inline DOCX naming block as part of a
  wider refactor. It does not change the character class. Whichever lands
  second needs a small conflict resolution in that hunk; I am happy to rebase.

## How verified

Node 22, from `backend/`, against base `8b3466fc04bf8cad623238a71fca1fda3fc89fde`.

Regression arm — the new tests applied alone to unmodified `main`:

```
npx vitest run src/lib/chat/tools/__tests__/documentOps.generatedFilename.test.ts
  Tests  16 failed | 11 passed (27)
  → expected 'document.docx' to be '秘密保持契約書.docx'
```

The 11 that already pass there are the control: the ASCII/fallback
compatibility cases, the title-independent storage key, and package validity.

One assertion cannot be proved that way. The straddling-surrogate case passes
on `main` for the wrong reason — the old class deletes `U+20000` before
truncating, so nothing multi-unit was ever left to cut. It guards the new code
instead, and a mutant proves it does: replacing the grapheme walk with
`allowed.slice(0, 64)` yields a 64-unit stem ending in an unpaired surrogate,
`encodeURIComponent` on the resulting filename throws `URI malformed`, and that
assertion fails.
The combining-mark case next to it does fail on unmodified `main`.

With this patch:

```
npx vitest run src/lib/chat/tools/__tests__/documentOps.generatedFilename.test.ts
  Tests  27 passed (27)

npm test
  Test Files  112 passed | 6 skipped (118)
       Tests  1410 passed | 39 skipped (1449)

npm run build      # tsc, clean
```

`npm test` on unmodified `main` is `111 passed | 6 skipped` files and
`1383 passed | 39 skipped` tests, so the difference is exactly the 27 added
tests and nothing else. `npx prettier --check` is clean on the new test file;
`documentOps.ts` is not Prettier-clean on `main` and this patch does not change
that either way.

Not run: the Playwright suite (`npm run test:e2e`) and the gated
`npm run test:stack`, neither of which covers this path. No LLM calls, live
Supabase or real documents were needed; the test uses synthetic content.

## Checklist

- [x] Ran the relevant build/test command for the area changed.
- [x] Reviewed `git diff` and removed unrelated changes.
- [x] Updated docs / env examples if setup, config, or behavior changed — no
      doc or env example describes generated filenames, so there was nothing to
      update.
- [x] No secrets, API keys, real documents, or `.env` files committed.
